### PR TITLE
Prevent checking redundant objects like <link1,link2> and <link2,link…

### DIFF
--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -294,9 +294,11 @@ inline btScalar addDiscreteSingleResult(btManifoldPoint& cp,
   const CollisionObjectWrapper* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());
   const CollisionObjectWrapper* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());
 
-  ObjectPairKey pc = getObjectPairKey(cd0->getName(), cd1->getName());
+  ObjectPairKey pk;
+  if( !getObjectPairKey(cd0->getName(), cd1->getName(), pk) )
+    return 0;
 
-  const auto& it = collisions.res->find(pc);
+  const auto& it = collisions.res->find(pk);
   bool found = (it != collisions.res->end());
 
   //    size_t l = 0;
@@ -318,7 +320,7 @@ inline btScalar addDiscreteSingleResult(btManifoldPoint& cp,
   contact.distance = cp.m_distance1;
   contact.normal = convertBtToEigen(-1 * cp.m_normalWorldOnB);
 
-  if (!processResult(collisions, contact, pc, found))
+  if (!processResult(collisions, contact, pk, found))
   {
     return 0;
   }

--- a/tesseract_collision/include/tesseract_collision/contact_checker_common.h
+++ b/tesseract_collision/include/tesseract_collision/contact_checker_common.h
@@ -37,11 +37,19 @@ typedef std::pair<std::string, std::string> ObjectPairKey;
  * @brief Get a key for two object to search the collision matrix
  * @param obj1 First collision object name
  * @param obj2 Second collision object name
- * @return The collision pair key
+ * @param pair A collision pair key. Will be updated if the obj's are valid.
+ * @return True if the collision pair key was updated successfully.
  */
-inline ObjectPairKey getObjectPairKey(const std::string& obj1, const std::string& obj2)
+inline bool getObjectPairKey(const std::string& obj1, const std::string& obj2, ObjectPairKey &pair)
 {
-  return obj1 < obj2 ? std::make_pair(obj1, obj2) : std::make_pair(obj2, obj1);
+  if (obj1 < obj2)
+  {
+    pair = std::make_pair(obj1, obj2);
+    return true;
+  }
+  // Avoid redundant entries like <link1,link2> and <link2,link1>
+  else
+    return false;
 }
 
 /**


### PR DESCRIPTION
…1>. Possible fix for #24

I think it will help the code run a bit faster, too, because it's checking fewer pairs.