### PR TITLE
Update contact monitor to use the latest version

### DIFF
--- a/tesseract_collision/src/bullet/bullet_utils.cpp
+++ b/tesseract_collision/src/bullet/bullet_utils.cpp
@@ -259,10 +259,10 @@ CollisionObjectWrapper::CollisionObjectWrapper(const std::string& name,
   , m_shape_poses(shape_poses)
   , m_collision_object_types(collision_object_types)
 {
-  assert(shapes.empty());
-  assert(shape_poses.empty());
-  assert(collision_object_types.empty());
-  assert(name.empty());
+  assert(!shapes.empty());
+  assert(!shape_poses.empty());
+  assert(!collision_object_types.empty());
+  assert(!name.empty());
   assert(shapes.size() == shape_poses.size());
   assert(shapes.size() == collision_object_types.size());
 

--- a/tesseract_collision/src/fcl/fcl_utils.cpp
+++ b/tesseract_collision/src/fcl/fcl_utils.cpp
@@ -323,10 +323,10 @@ FCLCollisionObjectWrapper::FCLCollisionObjectWrapper(const std::string& name,
   , shape_poses_(shape_poses)
   , collision_object_types_(collision_object_types)
 {
-  assert(shapes.empty());
-  assert(shape_poses.empty());
-  assert(collision_object_types.empty());
-  assert(name.empty());
+  assert(!shapes.empty());
+  assert(!shape_poses.empty());
+  assert(!collision_object_types.empty());
+  assert(!name.empty());
   assert(shapes.size() == shape_poses.size());
   assert(shapes.size() == collision_object_types.size());
 

--- a/tesseract_core/include/tesseract_core/basic_types.h
+++ b/tesseract_core/include/tesseract_core/basic_types.h
@@ -148,10 +148,10 @@ namespace ContactRequestTypes
 {
 enum ContactRequestType
 {
-  FIRST,   /**< Return at first contact for any pair of objects */
-  CLOSEST, /**< Return the global minimum for a pair of objects */
-  ALL,     /**< Return all contacts for a pair of objects */
-  LIMITED  /**< Return limited set of contacts for a pair of objects */
+  FIRST = 0,   /**< Return at first contact for any pair of objects */
+  CLOSEST = 1, /**< Return the global minimum for a pair of objects */
+  ALL = 2,     /**< Return all contacts for a pair of objects */
+  LIMITED = 3  /**< Return limited set of contacts for a pair of objects */
 };
 }
 typedef ContactRequestTypes::ContactRequestType ContactRequestType;

--- a/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_monitoring/CMakeLists.txt
@@ -33,8 +33,8 @@ include_directories(
 )
 
 # Tesseract ROS Nodes
-#add_executable(${PROJECT_NAME}_contacts_node src/contact_monitor.cpp)
-#target_link_libraries(${PROJECT_NAME}_contacts_node ${catkin_LIBRARIES})
+add_executable(${PROJECT_NAME}_contacts_node src/contact_monitor.cpp)
+target_link_libraries(${PROJECT_NAME}_contacts_node ${catkin_LIBRARIES})
 
 add_library(${PROJECT_NAME}_environment
   src/environment_monitor.cpp

--- a/tesseract_monitoring/launch/contact_monitor.launch
+++ b/tesseract_monitoring/launch/contact_monitor.launch
@@ -3,10 +3,18 @@
   <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
   <!-- The name of the parameter under which the URDF is loaded -->
   <arg name="robot_description" default="robot_description"/>
-  <arg name="plugin" default="tesseract_collision/BulletContactChecker"/>
+  <arg name="plugin" default="tesseract_collision/BulletDiscreteBVHManager"/>
   <arg name="monitor_links" default=""/>
-  <arg name="debug" default="false"/>
+
+  <!--
+  FIRST = 0,   /**< Return at first contact for any pair of objects */
+  CLOSEST = 1, /**< Return the global minimum for a pair of objects */
+  ALL = 2,     /**< Return all contacts for a pair of objects */
+  LIMITED = 3  /**< Return limited set of contacts for a pair of objects */
+  -->
+  <arg name="request_type" default="2"/>
   <arg name="contact_distance"/>
+  <arg name="debug" default="false"/>
 
   <arg name="rate" default="200"/>
 
@@ -26,6 +34,7 @@
     <param name="plugin" type="string" value="$(arg plugin)"/>
     <param name="contact_distance" value="$(arg contact_distance)"/>
     <param name="monitor_links" value="$(arg monitor_links)"/>
+    <param name="request_type" value="$(arg request_type)"/>
     <param name="publish_environment" value="$(arg debug)"/>
   </node>
 

--- a/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_monitoring/src/contact_monitor.cpp
@@ -2,7 +2,7 @@
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
 #include <srdfdom/model.h>
-#include <tesseract_collision/contact_checker_base.h>
+#include <tesseract_core/discrete_contact_manager_base.h>
 #include <tesseract_msgs/ContactResultVector.h>
 #include <tesseract_msgs/ModifyTesseractEnv.h>
 #include <tesseract_ros/kdl/kdl_env.h>
@@ -17,6 +17,7 @@ const std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default RO
 const double DEFAULT_CONTACT_DISTANCE = 0.1;
 
 KDLEnvPtr env;
+DiscreteContactManagerBasePtr manager;
 ros::Subscriber joint_states_sub;
 ros::Publisher contact_results_pub;
 ros::Publisher environment_pub;
@@ -33,7 +34,10 @@ void callbackJointState(const sensor_msgs::JointState::ConstPtr& msg)
   contacts_msg.constacts.clear();
 
   env->setState(msg->name, msg->position);
-  env->calcDistancesDiscrete(contacts);
+  EnvStateConstPtr state = env->getState();
+
+  manager->setCollisionObjectsTransform(state->transforms);
+  manager->contactTest(contacts);
 
   if (publish_environment)
   {
@@ -47,9 +51,9 @@ void callbackJointState(const sensor_msgs::JointState::ConstPtr& msg)
   contacts_msg.constacts.reserve(contacts_vector.size());
   for (const auto& contact : contacts_vector)
   {
-    tesseract_msgs::ContactResult msg;
-    tesseractContactResultToContactResultMsg(msg, contact);
-    contacts_msg.constacts.push_back(msg);
+    tesseract_msgs::ContactResult contact_msg;
+    tesseractContactResultToContactResultMsg(contact_msg, contact, msg->header.stamp);
+    contacts_msg.constacts.push_back(contact_msg);
   }
   contact_results_pub.publish(contacts_msg);
 }
@@ -59,6 +63,12 @@ bool callbackModifyTesseractEnv(tesseract_msgs::ModifyTesseractEnvRequest& reque
 {
   boost::mutex::scoped_lock(modify_mutex);
   response.success = processTesseractStateMsg(*env, request.state);
+
+  // Create a new manager
+  ContactRequest req = manager->getContactRequest();
+  manager = env->getDiscreteContactManager();
+  manager->setContactRequest(req);
+
   return true;
 }
 
@@ -79,11 +89,23 @@ int main(int argc, char** argv)
   if (pnh.hasParam("plugin"))
   {
     pnh.getParam("plugin", plugin);
-    env->loadContactCheckerPlugin(plugin);
+    env->loadDiscreteContactManagerPlugin(plugin);
   }
 
   // Initial setup
   std::string urdf_xml_string, srdf_xml_string;
+  if (!nh.hasParam(robot_description))
+  {
+    ROS_ERROR("Failed to find parameter: %s", robot_description.c_str());
+    return -1;
+  }
+
+  if (!nh.hasParam(robot_description + "_semantic"))
+  {
+    ROS_ERROR("Failed to find parameter: %s", (robot_description + "_semantic").c_str());
+    return -1;
+  }
+
   nh.getParam(robot_description, urdf_xml_string);
   nh.getParam(robot_description + "_semantic", srdf_xml_string);
 
@@ -93,25 +115,40 @@ int main(int argc, char** argv)
   if (urdf_model == nullptr)
   {
     ROS_ERROR("Failed to parse URDF.");
-    return 0;
+    return -1;
   }
 
   if (!env->init(urdf_model, srdf_model))
   {
     ROS_ERROR("Failed to initialize environment.");
-    return 0;
+    return -1;
   }
 
   // Setup request information
   ContactRequest req;
   req.isContactAllowed = env->getIsContactAllowedFn();
   pnh.param<double>("contact_distance", req.contact_distance, DEFAULT_CONTACT_DISTANCE);
-  pnh.getParam("monitor_links", req.link_names);
+
+  req.link_names = env->getLinkNames();
+  if (pnh.hasParam("monitor_links"))
+    pnh.getParam("monitor_links", req.link_names);
+
   if (req.link_names.empty())
     req.link_names = env->getLinkNames();
 
-  req.type = ContactRequestTypes::ALL;
-  env->setContactRequest(req);
+  int type = 2;
+  if (pnh.hasParam("request_type"))
+    pnh.getParam("request_type", type);
+
+  if (type < 0 || type > 3)
+  {
+    ROS_WARN("Request type must be 0, 1, 2 or 3. Setting to 2(ALL)!");
+    type = 2;
+  }
+
+  req.type = (tesseract::ContactRequestType)type;
+  manager = env->getDiscreteContactManager();
+  manager->setContactRequest(req);
 
   joint_states_sub = nh.subscribe("joint_states", 1, &callbackJointState);
   contact_results_pub = pnh.advertise<tesseract_msgs::ContactResultVector>("contact_results", 1, true);
@@ -121,6 +158,8 @@ int main(int argc, char** argv)
 
   if (publish_environment)
     environment_pub = pnh.advertise<tesseract_msgs::TesseractState>("tesseract", 100, false);
+
+  ROS_INFO("Contact Monitor Running!");
 
   ros::spin();
 

--- a/tesseract_msgs/msg/ContactResult.msg
+++ b/tesseract_msgs/msg/ContactResult.msg
@@ -1,3 +1,4 @@
+time stamp
 float64 distance
 byte[2] type_id # ROBOT_LINK = 0, ROBOT_ATTACHED = 1
 string[2] link_names

--- a/tesseract_ros/include/tesseract_ros/ros_tesseract_utils.h
+++ b/tesseract_ros/include/tesseract_ros/ros_tesseract_utils.h
@@ -741,8 +741,10 @@ static inline bool processTesseractStateMsg(tesseract_ros::ROSBasicEnvPtr env,
 }
 
 static inline void tesseractContactResultToContactResultMsg(tesseract_msgs::ContactResult& contact_result_msg,
-                                                            const tesseract::ContactResult& contact_result)
+                                                            const tesseract::ContactResult& contact_result,
+                                                            const ros::Time& stamp = ros::Time::now())
 {
+  contact_result_msg.stamp = stamp;
   contact_result_msg.distance = contact_result.distance;
   contact_result_msg.link_names[0] = contact_result.link_names[0];
   contact_result_msg.link_names[1] = contact_result.link_names[1];
@@ -777,9 +779,10 @@ static inline void tesseractContactResultToContactResultMsg(tesseract_msgs::Cont
 }
 
 static inline void tesseractContactResultToContactResultMsg(tesseract_msgs::ContactResultPtr contact_result_msg,
-                                                            const tesseract::ContactResult& contact_result)
+                                                            const tesseract::ContactResult& contact_result,
+                                                            const ros::Time& stamp = ros::Time::now())
 {
-  tesseractContactResultToContactResultMsg(*contact_result_msg, contact_result);
+  tesseractContactResultToContactResultMsg(*contact_result_msg, contact_result, stamp);
 }
 
 static inline void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,


### PR DESCRIPTION
Also fixes failing asserts which should have been not equals.
This also adds a timestamp to the contact results message.