### PR TITLE
OMPL Planner Fixups

### DIFF
--- a/tesseract_planning/CMakeLists.txt
+++ b/tesseract_planning/CMakeLists.txt
@@ -16,7 +16,8 @@ catkin_package(
     include
     ${OMPL_INCLUDE_DIRS}
   LIBRARIES
-    tesseract_ros_trajopt_planner
+    ${PROJECT_NAME}_ompl
+    ${PROJECT_NAME}_trajopt
   CATKIN_DEPENDS
     roscpp
     tesseract_ros

--- a/tesseract_planning/src/ompl/chain_ompl_interface.cpp
+++ b/tesseract_planning/src/ompl/chain_ompl_interface.cpp
@@ -86,11 +86,10 @@ bool ChainOmplInterface::isStateValid(const ompl::base::State* state) const
   const ompl::base::RealVectorStateSpace::StateType* s = state->as<ompl::base::RealVectorStateSpace::StateType>();
   const auto dof = joint_names_.size();
 
-  Eigen::Map<Eigen::VectorXd> joint_angles(s->values, dof);
-  tesseract::EnvStatePtr env_state = env_->getState(joint_names_, joint_angles);
+  Eigen::Map<Eigen::VectorXd> joint_angles(s->values, long(dof));
+  tesseract::EnvStateConstPtr env_state = env_->getState(joint_names_, joint_angles);
 
-  for (const auto& link_name : link_names_)
-    contact_manager_->setCollisionObjectsTransform(link_name, env_state->transforms[link_name]);
+  contact_manager_->setCollisionObjectsTransform(env_state->transforms);
 
   tesseract::ContactResultMap contact_map;
   contact_manager_->contactTest(contact_map);


### PR DESCRIPTION
Fixups required to use the OMPL planner effectively with other ROS systems. This includes
* a change to compute the transforms and set the transforms of the whole scene, and  
 * a fix to the CMakeLists to export the right libraries.