### PR TITLE
Refractor out ContactRequest type

### DIFF
--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
@@ -90,11 +90,19 @@ public:
 
   void setCollisionObjectsTransform(const TransformMap& pose1, const TransformMap& pose2) override;
 
-  void setContactRequest(const ContactRequest& req) override;
+  void setActiveCollisionObjects(const std::vector<std::string>& names) override;
 
-  const ContactRequest& getContactRequest() const override;
+  const std::vector<std::string>& getActiveCollisionObjects() const override;
 
-  void contactTest(ContactResultMap& collisions) override;
+  void setContactDistanceThreshold(double contact_distance) override;
+
+  double getContactDistanceThreshold() const override;
+
+  void setIsContactAllowedFn(IsContactAllowedFn fn) override;
+
+  IsContactAllowedFn getIsContactAllowedFn() const override;
+
+  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
 
   /**
    * @brief A a bullet collision object to the manager
@@ -103,11 +111,14 @@ public:
   void addCollisionObject(const COWPtr& cow);
 
 private:
-  ContactRequest request_;                            /**< @brief The active contact request message */
+  std::vector<std::string> active_;                   /**< @brief A list of the active collision objects */
+  double contact_distance_;                           /**< @brief The contact distance threshold */
+  IsContactAllowedFn fn_;                             /**< @brief The is allowed collision function */
+
   std::unique_ptr<btCollisionDispatcher> dispatcher_; /**< @brief The bullet collision dispatcher used for getting
                                                          object to object collison algorithm */
-  btDispatcherInfo dispatch_info_;              /**< @brief The bullet collision dispatcher configuration information */
-  btDefaultCollisionConfiguration coll_config_; /**< @brief The bullet collision configuration */
+  btDispatcherInfo dispatch_info_;                    /**< @brief The bullet collision dispatcher configuration information */
+  btDefaultCollisionConfiguration coll_config_;       /**< @brief The bullet collision configuration */
   std::unique_ptr<btBroadphaseInterface> broadphase_; /**< @brief The bullet broadphase interface */
   Link2Cow link2cow_;                                 /**< @brief A map of collision objects being managed */
   Link2Cow link2castcow_;                             /**< @brief A map of cast collision objects being managed. */
@@ -117,7 +128,7 @@ private:
    * @param cow The Collision object
    * @param collisions The collision results
    */
-  void contactTest(const COWPtr& cow, ContactDistanceData& collisions);
+  void contactTest(const COWPtr& cow, ContactTestData& collisions);
 };
 typedef std::shared_ptr<BulletCastBVHManager> BulletCastBVHManagerPtr;
 

--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
@@ -89,11 +89,19 @@ public:
 
   void setCollisionObjectsTransform(const TransformMap& pose1, const TransformMap& pose2) override;
 
-  void setContactRequest(const ContactRequest& req) override;
+  void setActiveCollisionObjects(const std::vector<std::string>& names) override;
 
-  const ContactRequest& getContactRequest() const override;
+  const std::vector<std::string>& getActiveCollisionObjects() const override;
 
-  void contactTest(ContactResultMap& collisions) override;
+  void setContactDistanceThreshold(double contact_distance) override;
+
+  double getContactDistanceThreshold() const override;
+
+  void setIsContactAllowedFn(IsContactAllowedFn fn) override;
+
+  IsContactAllowedFn getIsContactAllowedFn() const override;
+
+  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
 
   /**
    * @brief A a bullet collision object to the manager
@@ -102,7 +110,10 @@ public:
   void addCollisionObject(const COWPtr& cow);
 
 private:
-  ContactRequest request_;                            /**< @brief The active contact request message */
+  std::vector<std::string> active_;                   /**< @brief A list of the active collision objects */
+  double contact_distance_;                           /**< @brief The contact distance threshold */
+  IsContactAllowedFn fn_;                             /**< @brief The is allowed collision function */
+
   std::unique_ptr<btCollisionDispatcher> dispatcher_; /**< @brief The bullet collision dispatcher used for getting
                                                          object to object collison algorithm */
   btDispatcherInfo dispatch_info_;              /**< @brief The bullet collision dispatcher configuration information */

--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
@@ -78,11 +78,19 @@ public:
 
   void setCollisionObjectsTransform(const TransformMap& transforms) override;
 
-  void contactTest(ContactResultMap& collisions) override;
+  void setActiveCollisionObjects(const std::vector<std::string>& names) override;
 
-  void setContactRequest(const ContactRequest& req) override;
+  const std::vector<std::string>& getActiveCollisionObjects() const override;
 
-  const ContactRequest& getContactRequest() const override;
+  void setContactDistanceThreshold(double contact_distance) override;
+
+  double getContactDistanceThreshold() const override;
+
+  void setIsContactAllowedFn(IsContactAllowedFn fn) override;
+
+  IsContactAllowedFn getIsContactAllowedFn() const override;
+
+  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
 
   /**
    * @brief A a bullet collision object to the manager
@@ -97,7 +105,10 @@ public:
   const Link2Cow& getCollisionObjects() const;
 
 private:
-  ContactRequest request_;                            /**< @brief The active contact request message */
+  std::vector<std::string> active_;                   /**< @brief A list of the active collision objects */
+  double contact_distance_;                           /**< @brief The contact distance threshold */
+  IsContactAllowedFn fn_;                             /**< @brief The is allowed collision function */
+
   std::unique_ptr<btCollisionDispatcher> dispatcher_; /**< @brief The bullet collision dispatcher used for getting
                                                          object to object collison algorithm */
   btDispatcherInfo dispatch_info_;              /**< @brief The bullet collision dispatcher configuration information */
@@ -110,7 +121,7 @@ private:
    * @param cow The Collision object
    * @param collisions The collision results
    */
-  void contactTest(const COWPtr& cow, ContactDistanceData& collisions);
+  void contactTest(const COWPtr& cow, ContactTestData& collisions);
 };
 typedef std::shared_ptr<BulletDiscreteBVHManager> BulletDiscreteBVHManagerPtr;
 

--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
@@ -77,11 +77,19 @@ public:
 
   void setCollisionObjectsTransform(const TransformMap& transforms) override;
 
-  void contactTest(ContactResultMap& collisions) override;
+  void setActiveCollisionObjects(const std::vector<std::string>& names) override;
 
-  void setContactRequest(const ContactRequest& req) override;
+  const std::vector<std::string>& getActiveCollisionObjects() const override;
 
-  const ContactRequest& getContactRequest() const override;
+  void setContactDistanceThreshold(double contact_distance) override;
+
+  double getContactDistanceThreshold() const override;
+
+  void setIsContactAllowedFn(IsContactAllowedFn fn) override;
+
+  IsContactAllowedFn getIsContactAllowedFn() const override;
+
+  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
 
   /**
    * @brief A a bullet collision object to the manager
@@ -96,7 +104,10 @@ public:
   const Link2Cow& getCollisionObjects() const;
 
 private:
-  ContactRequest request_;                            /**< @brief The active contact request message */
+  std::vector<std::string> active_;                   /**< @brief A list of the active collision objects */
+  double contact_distance_;                           /**< @brief The contact distance threshold */
+  IsContactAllowedFn fn_;                             /**< @brief The is allowed collision function */
+
   std::unique_ptr<btCollisionDispatcher> dispatcher_; /**< @brief The bullet collision dispatcher used for getting
                                                          object to object collison algorithm */
   btDispatcherInfo dispatch_info_;              /**< @brief The bullet collision dispatcher configuration information */

--- a/tesseract_collision/include/tesseract_collision/contact_checker_common.h
+++ b/tesseract_collision/include/tesseract_collision/contact_checker_common.h
@@ -91,7 +91,7 @@ isContactAllowed(const std::string& name1, const std::string& name2, const IsCon
   return false;
 }
 
-inline ContactResult* processResult(ContactDistanceData& cdata,
+inline ContactResult* processResult(ContactTestData& cdata,
                                     ContactResult& contact,
                                     const std::pair<std::string, std::string>& key,
                                     bool found)
@@ -99,7 +99,7 @@ inline ContactResult* processResult(ContactDistanceData& cdata,
   if (!found)
   {
     ContactResultVector data;
-    if (cdata.req->type == ContactRequestType::FIRST)
+    if (cdata.type == ContactTestType::FIRST)
     {
       data.emplace_back(contact);
       cdata.done = true;
@@ -110,18 +110,18 @@ inline ContactResult* processResult(ContactDistanceData& cdata,
       data.emplace_back(contact);
     }
 
-    return &(cdata.res->insert(std::make_pair(key, data)).first->second.back());
+    return &(cdata.res.insert(std::make_pair(key, data)).first->second.back());
   }
   else
   {
-    assert(cdata.req->type != ContactRequestType::FIRST);
-    ContactResultVector& dr = cdata.res->at(key);
-    if (cdata.req->type == ContactRequestType::ALL)
+    assert(cdata.type != ContactTestType::FIRST);
+    ContactResultVector& dr = cdata.res[key];
+    if (cdata.type == ContactTestType::ALL)
     {
       dr.emplace_back(contact);
       return &(dr.back());
     }
-    else if (cdata.req->type == ContactRequestType::CLOSEST)
+    else if (cdata.type == ContactTestType::CLOSEST)
     {
       if (contact.distance < dr[0].distance)
       {
@@ -129,7 +129,7 @@ inline ContactResult* processResult(ContactDistanceData& cdata,
         return &(dr[0]);
       }
     }
-    //    else if (cdata.req->type == DistanceRequestType::LIMITED)
+    //    else if (cdata.cdata.condition == DistanceRequestType::LIMITED)
     //    {
     //      assert(dr.size() < cdata.req->max_contacts_per_body);
     //      dr.emplace_back(contact);

--- a/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -78,11 +78,19 @@ public:
 
   void setCollisionObjectsTransform(const TransformMap& transforms) override;
 
-  void contactTest(ContactResultMap& collisions) override;
+  void setActiveCollisionObjects(const std::vector<std::string>& names) override;
 
-  void setContactRequest(const ContactRequest& req) override;
+  const std::vector<std::string>& getActiveCollisionObjects() const override;
 
-  const ContactRequest& getContactRequest() const override;
+  void setContactDistanceThreshold(double contact_distance) override;
+
+  double getContactDistanceThreshold() const override;
+
+  void setIsContactAllowedFn(IsContactAllowedFn fn) override;
+
+  IsContactAllowedFn getIsContactAllowedFn() const override;
+
+  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
 
   /**
    * @brief Add a fcl collision object to the manager
@@ -99,7 +107,10 @@ public:
 private:
   std::unique_ptr<fcl::BroadPhaseCollisionManagerd> manager_; /**< @brief FCL Broad Phase Collision Manager */
   Link2COW link2cow_;      /**< @brief A map of all (static and active) collision objects being managed */
-  ContactRequest request_; /**< @brief Active request to be used for methods that don't require a request */
+
+  std::vector<std::string> active_;                   /**< @brief A list of the active collision objects */
+  double contact_distance_;                           /**< @brief The contact distance threshold */
+  IsContactAllowedFn fn_;                             /**< @brief The is allowed collision function */
 };
 typedef std::shared_ptr<FCLDiscreteBVHManager> FCLDiscreteBVHManagerPtr;
 }

--- a/tesseract_collision/include/tesseract_collision/fcl/fcl_utils.h
+++ b/tesseract_collision/include/tesseract_collision/fcl/fcl_utils.h
@@ -170,16 +170,16 @@ inline COWPtr createFCLCollisionObject(const std::string& name,
 }
 
 /**
- * @brief updateCollisionObjectsWithRequest
- * @param req
- * @param cow
+ * @brief Update collision objects filters
+ * @param active The active collision objects
+ * @param cow The collision object to update
  */
-inline void updateCollisionObjectWithRequest(const ContactRequest& req, COW& cow)
+inline void updateCollisionObjectFilters(const std::vector<std::string>& active, COW& cow)
 {
   // For descrete checks we can check static to kinematic and kinematic to
   // kinematic
   cow.m_collisionFilterGroup = CollisionFilterGroups::KinematicFilter;
-  if (!isLinkActive(req.link_names, cow.getName()))
+  if (!isLinkActive(active, cow.getName()))
   {
     cow.m_collisionFilterGroup = CollisionFilterGroups::StaticFilter;
   }

--- a/tesseract_collision/src/bullet/bullet_cast_simple_manager.cpp
+++ b/tesseract_collision/src/bullet/bullet_cast_simple_manager.cpp
@@ -57,6 +57,7 @@ BulletCastSimpleManager::BulletCastSimpleManager()
 
   dispatcher_->setDispatcherFlags(dispatcher_->getDispatcherFlags() &
                                   ~btCollisionDispatcher::CD_USE_RELATIVE_CONTACT_BREAKING_THRESHOLD);
+  contact_distance_ = 0;
 }
 
 ContinuousContactManagerBasePtr BulletCastSimpleManager::clone() const
@@ -72,10 +73,14 @@ ContinuousContactManagerBasePtr BulletCastSimpleManager::clone() const
 
     new_cow->setWorldTransform(cow.second->getWorldTransform());
 
-    new_cow->setContactProcessingThreshold(request_.contact_distance);
+    new_cow->setContactProcessingThreshold(contact_distance_);
     manager->addCollisionObject(new_cow);
   }
-  manager->setContactRequest(request_);
+
+  manager->setActiveCollisionObjects(active_);
+  manager->setContactDistanceThreshold(contact_distance_);
+  manager->setIsContactAllowedFn(fn_);
+
   return manager;
 }
 
@@ -240,9 +245,60 @@ void BulletCastSimpleManager::setCollisionObjectsTransform(const TransformMap& p
   }
 }
 
-void BulletCastSimpleManager::contactTest(ContactResultMap& collisions)
+void BulletCastSimpleManager::setActiveCollisionObjects(const std::vector<std::string>& names)
 {
-  ContactDistanceData cdata(&request_, &collisions);
+  active_ = names;
+  cows_.clear();
+  cows_.reserve(link2cow_.size());
+
+  // Now need to update the broadphase with correct aabb
+  for (auto& co : link2cow_)
+  {
+    COWPtr& cow = co.second;
+
+    // Update with request
+    updateCollisionObjectFilters(active_, *cow, false);
+
+    // Get the cast collision object
+    COWPtr cast_cow = link2castcow_[cow->getName()];
+
+    // Update with request
+    updateCollisionObjectFilters(active_, *cast_cow, true);
+
+    // Add to collision object vector
+    if (cow->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
+    {
+      cows_.insert(cows_.begin(), cast_cow);
+    }
+    else
+    {
+      cows_.push_back(cow);
+    }
+  }
+}
+
+const std::vector<std::string>& BulletCastSimpleManager::getActiveCollisionObjects() const { return active_; }
+
+void BulletCastSimpleManager::setContactDistanceThreshold(double contact_distance)
+{
+  contact_distance_ = contact_distance;
+
+  for (auto& co : link2cow_)
+    co.second->setContactProcessingThreshold(contact_distance);
+
+  for (auto& co : link2castcow_)
+    co.second->setContactProcessingThreshold(contact_distance);
+}
+
+double BulletCastSimpleManager::getContactDistanceThreshold() const { return contact_distance_; }
+
+void BulletCastSimpleManager::setIsContactAllowedFn(IsContactAllowedFn fn) { fn_ = fn; }
+
+IsContactAllowedFn BulletCastSimpleManager::getIsContactAllowedFn() const { return fn_; }
+
+void BulletCastSimpleManager::contactTest(ContactResultMap& collisions, const ContactTestType& type)
+{
+  ContactTestData cdata(active_, contact_distance_, fn_, type, collisions);
 
   for (auto cow1_iter = cows_.begin(); cow1_iter != (cows_.end() - 1); cow1_iter++)
   {
@@ -273,7 +329,7 @@ void BulletCastSimpleManager::contactTest(ContactResultMap& collisions)
 
       if (aabb_check)
       {
-        bool needs_collision = needsCollisionCheck(*cow1, *cow2, request_.isContactAllowed, false);
+        bool needs_collision = needsCollisionCheck(*cow1, *cow2, fn_, false);
 
         if (needs_collision)
         {
@@ -304,39 +360,6 @@ void BulletCastSimpleManager::contactTest(ContactResultMap& collisions)
   }
 }
 
-void BulletCastSimpleManager::setContactRequest(const ContactRequest& req)
-{
-  request_ = req;
-  cows_.clear();
-  cows_.reserve(link2cow_.size());
-
-  // Now need to update the broadphase with correct aabb
-  for (auto& co : link2cow_)
-  {
-    COWPtr& cow = co.second;
-
-    // Update with request
-    updateCollisionObjectWithRequest(request_, *cow, false);
-
-    // Get the cast collision object
-    COWPtr cast_cow = link2castcow_[cow->getName()];
-
-    // Update with request
-    updateCollisionObjectWithRequest(request_, *cast_cow, true);
-
-    // Add to collision object vector
-    if (cow->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
-    {
-      cows_.insert(cows_.begin(), cast_cow);
-    }
-    else
-    {
-      cows_.push_back(cow);
-    }
-  }
-}
-
-const ContactRequest& BulletCastSimpleManager::getContactRequest() const { return request_; }
 void BulletCastSimpleManager::addCollisionObject(const COWPtr& cow)
 {
   link2cow_[cow->getName()] = cow;

--- a/tesseract_collision/test/collision_box_box_cast_unit.cpp
+++ b/tesseract_collision/test/collision_box_box_cast_unit.cpp
@@ -45,11 +45,8 @@ void runTest(tesseract::ContinuousContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is inside another
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("moving_box_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"moving_box_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   checker.setCollisionObjectsTransform("static_box_link", Eigen::Isometry3d::Identity());
@@ -65,7 +62,7 @@ void runTest(tesseract::ContinuousContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);

--- a/tesseract_collision/test/collision_box_box_unit.cpp
+++ b/tesseract_collision/test/collision_box_box_unit.cpp
@@ -70,12 +70,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is inside another
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("box_link");
-  req.link_names.push_back("second_box_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"box_link", "second_box_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   tesseract::TransformMap location;
@@ -88,7 +84,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -116,7 +112,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
 
   checker.setCollisionObjectsTransform(location);
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -126,10 +122,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.25;
 
-  checker.setContactRequest(req);
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.25);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract_collision/test/collision_box_cone_unit.cpp
+++ b/tesseract_collision/test/collision_box_cone_unit.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 #include <ros/ros.h>
 
-void addCollisionObjects(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mesh = false)
+void addCollisionObjects(tesseract::DiscreteContactManagerBase& checker)
 {
   //////////////////////
   // Add box to checker
@@ -62,12 +62,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("box_link");
-  req.link_names.push_back("cone_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"box_link", "cone_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   tesseract::TransformMap location;
@@ -78,7 +74,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -106,9 +102,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   location["cone_link"].translation() = Eigen::Vector3d(1, 0, 0);
   result.clear();
   result_vector.clear();
-  checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.setCollisionObjectsTransform(location);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -118,10 +114,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.251;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.251);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract_collision/test/collision_box_cylinder_unit.cpp
+++ b/tesseract_collision/test/collision_box_cylinder_unit.cpp
@@ -62,12 +62,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("box_link");
-  req.link_names.push_back("cylinder_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"box_link", "cylinder_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   tesseract::TransformMap location;
@@ -78,7 +74,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -107,7 +103,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -117,10 +113,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.251;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.251);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract_collision/test/collision_box_sphere_unit.cpp
+++ b/tesseract_collision/test/collision_box_sphere_unit.cpp
@@ -71,12 +71,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("box_link");
-  req.link_names.push_back("sphere_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"box_link", "sphere_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   tesseract::TransformMap location;
@@ -87,7 +83,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -117,7 +113,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -127,10 +123,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.251;  // 0.251;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.251);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -156,12 +151,8 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("box_link");
-  req.link_names.push_back("sphere_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"box_link", "sphere_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   tesseract::TransformMap location;
@@ -172,7 +163,7 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -199,7 +190,7 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -209,10 +200,9 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.27;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.27);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract_collision/test/collision_clone_unit.cpp
+++ b/tesseract_collision/test/collision_clone_unit.cpp
@@ -66,12 +66,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, double dist_tol, do
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("sphere_link");
-  req.link_names.push_back("sphere1_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"sphere_link", "sphere1_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Test when object is inside another
   tesseract::TransformMap location;
@@ -82,7 +78,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, double dist_tol, do
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -95,7 +91,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, double dist_tol, do
   tesseract::ContactResultMap cloned_result;
   tesseract::DiscreteContactManagerBasePtr cloned_checker = checker.clone();
 
-  cloned_checker->contactTest(cloned_result);
+  cloned_checker->contactTest(cloned_result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector cloned_result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(cloned_result, cloned_result_vector);

--- a/tesseract_collision/test/collision_large_dataset_unit.cpp
+++ b/tesseract_collision/test/collision_large_dataset_unit.cpp
@@ -49,11 +49,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
   }
 
   // Check if they are in collision
-  tesseract::ContactRequest req;
-  req.link_names = link_names;
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::ALL;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects(link_names);
+  checker.setContactDistanceThreshold(0.1);
   checker.setCollisionObjectsTransform(location);
 
   tesseract::ContactResultVector result_vector;
@@ -63,7 +60,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
   {
     tesseract::ContactResultMap result;
     result_vector.clear();
-    checker.contactTest(result);
+    checker.contactTest(result, tesseract::ContactTestType::ALL);
     tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
   }
   ros::WallTime end_time = ros::WallTime::now();

--- a/tesseract_collision/test/collision_mesh_mesh_unit.cpp
+++ b/tesseract_collision/test/collision_mesh_mesh_unit.cpp
@@ -66,12 +66,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   ///////////////////////////////////////////////////////////////////
   // Test when object is in collision (Closest Feature Edge to Edge)
   ///////////////////////////////////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("sphere_link");
-  req.link_names.push_back("sphere1_link");
-  req.contact_distance = 0;
-  req.type = tesseract::ContactRequestType::ALL;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"sphere_link", "sphere1_link"});
+  checker.setContactDistanceThreshold(0);
 
   // Test when object is inside another
   tesseract::TransformMap location;
@@ -82,7 +78,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::ALL);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -97,7 +93,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::ALL);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -107,11 +103,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.55;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.55);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -134,13 +128,11 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   location["sphere1_link"].translation() = Eigen::Vector3d(0, 1, 0);
   result.clear();
   result_vector.clear();
-  checker.setCollisionObjectsTransform(location);
-
-  req.contact_distance = 0.55;
-  checker.setContactRequest(req);
 
   // The closest feature of the mesh should be edge to edge
-  checker.contactTest(result);
+  checker.setCollisionObjectsTransform(location);
+  checker.setContactDistanceThreshold(0.55);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract_collision/test/collision_multi_threaded_unit.cpp
+++ b/tesseract_collision/test/collision_multi_threaded_unit.cpp
@@ -49,11 +49,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
   }
 
   // Check if they are in collision
-  tesseract::ContactRequest req;
-  req.link_names = link_names;
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::ALL;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects(link_names);
+  checker.setContactDistanceThreshold(0.1);
   checker.setCollisionObjectsTransform(location);
 
   unsigned num_threads = 4;
@@ -101,7 +98,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
     }
 
     tesseract::ContactResultMap result;
-    manager->contactTest(result);
+    manager->contactTest(result, tesseract::ContactTestType::ALL);
     tesseract::moveContactResultsMapToContactResultsVector(result, result_vector[tn]);
   }
   ros::WallTime end_time = ros::WallTime::now();

--- a/tesseract_collision/test/collision_octomap_sphere_unit.cpp
+++ b/tesseract_collision/test/collision_octomap_sphere_unit.cpp
@@ -58,12 +58,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, double tol)
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("octomap_link");
-  req.link_names.push_back("sphere_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"octomap_link", "sphere_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Set the collision object transforms
   tesseract::TransformMap location;
@@ -78,7 +74,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, double tol)
   for (auto i = 0; i < 10; ++i)
   {
     result.clear();
-    checker.contactTest(result);
+    checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   }
   ros::WallTime end_time = ros::WallTime::now();
   ROS_INFO_STREAM("DT: " << (end_time - start_time).toSec());

--- a/tesseract_collision/test/collision_sphere_sphere_unit.cpp
+++ b/tesseract_collision/test/collision_sphere_sphere_unit.cpp
@@ -80,12 +80,8 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   //////////////////////////////////////
   // Test when object is in collision
   //////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("sphere_link");
-  req.link_names.push_back("sphere1_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"sphere_link", "sphere1_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Test when object is inside another
   tesseract::TransformMap location;
@@ -96,7 +92,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -126,7 +122,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -136,10 +132,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.52;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.52);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -165,12 +160,8 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   ///////////////////////////////////////////////////////////////////
   // Test when object is in collision (Closest Feature Edge to Edge)
   ///////////////////////////////////////////////////////////////////
-  tesseract::ContactRequest req;
-  req.link_names.push_back("sphere_link");
-  req.link_names.push_back("sphere1_link");
-  req.contact_distance = 0.1;
-  req.type = tesseract::ContactRequestType::CLOSEST;
-  checker.setContactRequest(req);
+  checker.setActiveCollisionObjects({"sphere_link", "sphere1_link"});
+  checker.setContactDistanceThreshold(0.1);
 
   // Test when object is inside another
   tesseract::TransformMap location;
@@ -181,7 +172,7 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
 
   // Perform collision check
   tesseract::ContactResultMap result;
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
 
   tesseract::ContactResultVector result_vector;
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
@@ -208,7 +199,7 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -218,10 +209,9 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   /////////////////////////////////////////////////////////////////////////
   result.clear();
   result_vector.clear();
-  req.contact_distance = 0.55;
-  checker.setContactRequest(req);
 
-  checker.contactTest(result);
+  checker.setContactDistanceThreshold(0.55);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -249,7 +239,7 @@ void runConvexTest(tesseract::DiscreteContactManagerBase& checker)
   result.clear();
   result_vector.clear();
 
-  checker.contactTest(result);
+  checker.contactTest(result, tesseract::ContactTestType::CLOSEST);
   tesseract::moveContactResultsMapToContactResultsVector(result, result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract_core/include/tesseract_core/basic_env.h
+++ b/tesseract_core/include/tesseract_core/basic_env.h
@@ -281,7 +281,7 @@ inline bool continuousCollisionCheckTrajectory(ContinuousContactManagerBase& man
     for (const auto& link_name : link_names)
       manager.setCollisionObjectsTransform(link_name, state0->transforms[link_name], state1->transforms[link_name]);
 
-    manager.contactTest(collisions);
+    manager.contactTest(collisions, ContactTestTypes::FIRST);
 
     if (collisions.size() > 0)
       found = true;

--- a/tesseract_core/include/tesseract_core/basic_types.h
+++ b/tesseract_core/include/tesseract_core/basic_types.h
@@ -142,9 +142,9 @@ enum ContinouseCollisionType
 }
 typedef ContinouseCollisionTypes::ContinouseCollisionType ContinouseCollisionType;
 
-namespace ContactRequestTypes
+namespace ContactTestTypes
 {
-enum ContactRequestType
+enum ContactTestType
 {
   FIRST = 0,   /**< Return at first contact for any pair of objects */
   CLOSEST = 1, /**< Return the global minimum for a pair of objects */
@@ -152,18 +152,7 @@ enum ContactRequestType
   LIMITED = 3  /**< Return limited set of contacts for a pair of objects */
 };
 }
-typedef ContactRequestTypes::ContactRequestType ContactRequestType;
-
-/** @brief The ContactRequest struct */
-struct ContactRequest
-{
-  ContactRequestType type; /**< The type of request */
-  double contact_distance; /**< The maximum distance between two objects for which distance data should be calculated */
-  std::vector<std::string> link_names; /**< Name of the links to calculate distance data for. */
-  IsContactAllowedFn isContactAllowed; /**< The allowed collision matrix */
-
-  ContactRequest() : type(ContactRequestType::CLOSEST), contact_distance(0.0) {}
-};
+typedef ContactTestTypes::ContactTestType ContactTestType;
 
 struct ContactResult
 {
@@ -197,15 +186,28 @@ struct ContactResult
 typedef std::vector<ContactResult> ContactResultVector;
 typedef std::map<std::pair<std::string, std::string>, ContactResultVector> ContactResultMap;
 
-/// Destance query results information
-struct ContactDistanceData
+/// Contact test data and query results information
+struct ContactTestData
 {
-  ContactDistanceData(const ContactRequest* req, ContactResultMap* res) : req(req), res(res), done(false) {}
-  /// Distance query request information
-  const ContactRequest* req;
+  ContactTestData(const std::vector<std::string>& active,
+                  const double& contact_distance,
+                  const IsContactAllowedFn& fn,
+                  const ContactTestType& type,
+                  ContactResultMap& res) :
+    active(active),
+    contact_distance(contact_distance),
+    fn(fn),
+    type(type),
+    res(res),
+    done(false) {}
+
+  const std::vector<std::string>& active;
+  const double& contact_distance;
+  const IsContactAllowedFn& fn;
+  const ContactTestType& type;
 
   /// Destance query results information
-  ContactResultMap* res;
+  ContactResultMap& res;
 
   /// Indicate if search is finished
   bool done;

--- a/tesseract_core/include/tesseract_core/continuous_contact_manager_base.h
+++ b/tesseract_core/include/tesseract_core/continuous_contact_manager_base.h
@@ -158,22 +158,41 @@ public:
   virtual void setCollisionObjectsTransform(const TransformMap& pose1, const TransformMap& pose2) = 0;
 
   /**
-   * @brief Set the active contact request information
-   * @param req ContactRequest information
+   * @brief Set which collision objects can move
+   * @param names A vector of collision object names
    */
-  virtual void setContactRequest(const ContactRequest& req) = 0;
+  virtual void setActiveCollisionObjects(const std::vector<std::string>& names) = 0;
 
   /**
-   * @brief Get the active contact request information
-   * @return Active contact request information
+   * @brief Get which collision objects can move
+   * @return A list of collision object names
    */
-  virtual const ContactRequest& getContactRequest() const = 0;
+  virtual const std::vector<std::string>& getActiveCollisionObjects() const = 0;
+
+  /**
+   * @brief Set the contact distance threshold for which collision should be considered.
+   * @param contact_distance The contact distance
+   */
+  virtual void setContactDistanceThreshold(double contact_distance) = 0;
+
+  /**
+   * @brief Get the contact distance threshold
+   * @return The contact distance
+   */
+  virtual double getContactDistanceThreshold() const = 0;
+
+  /** @brief Set the active function for determining if two links are allowed to be in collision */
+  virtual void setIsContactAllowedFn(IsContactAllowedFn fn) = 0;
+
+  /** @brief Get the active function for determining if two links are allowed to be in collision */
+  virtual IsContactAllowedFn getIsContactAllowedFn() const = 0;
 
   /**
    * @brief Perform a contact test for all objects based
    * @param collisions The Contact results data
+   * @param type The type of contact test
    */
-  virtual void contactTest(ContactResultMap& collisions) = 0;
+  virtual void contactTest(ContactResultMap& collisions, const ContactTestType& type) = 0;
 };
 typedef std::shared_ptr<ContinuousContactManagerBase> ContinuousContactManagerBasePtr;
 typedef std::shared_ptr<const ContinuousContactManagerBase> ContinuousContactManagerBaseConstPtr;

--- a/tesseract_core/include/tesseract_core/discrete_contact_manager_base.h
+++ b/tesseract_core/include/tesseract_core/discrete_contact_manager_base.h
@@ -114,22 +114,40 @@ public:
   virtual void setCollisionObjectsTransform(const TransformMap& transforms) = 0;
 
   /**
-   * @brief Set the active contact request information
-   * @param req ContactRequest information
+   * @brief Set which collision objects can move
+   * @param names A vector of collision object names
    */
-  virtual void setContactRequest(const ContactRequest& req) = 0;
+  virtual void setActiveCollisionObjects(const std::vector<std::string>& names) = 0;
 
   /**
-   * @brief Get the active contact request information
-   * @return Active contact request information
+   * @brief Get which collision objects can move
+   * @return A list of collision object names
    */
-  virtual const ContactRequest& getContactRequest() const = 0;
+  virtual const std::vector<std::string>& getActiveCollisionObjects() const = 0;
+
+  /**
+   * @brief Set the contact distance threshold for which collision should be considered.
+   * @param contact_distance The contact distance
+   */
+  virtual void setContactDistanceThreshold(double contact_distance) = 0;
+
+  /**
+   * @brief Get the contact distance threshold
+   * @return The contact distance
+   */
+  virtual double getContactDistanceThreshold() const = 0;
+
+  /** @brief Set the active function for determining if two links are allowed to be in collision */
+  virtual void setIsContactAllowedFn(IsContactAllowedFn fn) = 0;
+
+  /** @brief Get the active function for determining if two links are allowed to be in collision */
+  virtual IsContactAllowedFn getIsContactAllowedFn() const = 0;
 
   /**
    * @brief Perform a contact test for all objects based
    * @param collisions The Contact results data
    */
-  virtual void contactTest(ContactResultMap& collisions) = 0;
+  virtual void contactTest(ContactResultMap& collisions, const ContactTestType& type) = 0;
 };
 typedef std::shared_ptr<DiscreteContactManagerBase> DiscreteContactManagerBasePtr;
 typedef std::shared_ptr<const DiscreteContactManagerBase> DiscreteContactManagerBaseConstPtr;

--- a/tesseract_monitoring/launch/contact_monitor.launch
+++ b/tesseract_monitoring/launch/contact_monitor.launch
@@ -12,7 +12,7 @@
   ALL = 2,     /**< Return all contacts for a pair of objects */
   LIMITED = 3  /**< Return limited set of contacts for a pair of objects */
   -->
-  <arg name="request_type" default="2"/>
+  <arg name="contact_test_type" default="2"/>
   <arg name="contact_distance"/>
   <arg name="debug" default="false"/>
 
@@ -34,7 +34,7 @@
     <param name="plugin" type="string" value="$(arg plugin)"/>
     <param name="contact_distance" value="$(arg contact_distance)"/>
     <param name="monitor_links" value="$(arg monitor_links)"/>
-    <param name="request_type" value="$(arg request_type)"/>
+    <param name="contact_test_type" value="$(arg contact_test_type)"/>
     <param name="publish_environment" value="$(arg debug)"/>
   </node>
 

--- a/tesseract_planning/src/ompl/chain_ompl_interface.cpp
+++ b/tesseract_planning/src/ompl/chain_ompl_interface.cpp
@@ -32,13 +32,10 @@ ChainOmplInterface::ChainOmplInterface(tesseract::BasicEnvConstPtr environment, 
   ss_->setStateValidityChecker(std::bind(&ChainOmplInterface::isStateValid, this, std::placeholders::_1));
   contact_fn_ = std::bind(&ChainOmplInterface::isContactAllowed, this, std::placeholders::_1, std::placeholders::_2);
 
-  tesseract::ContactRequest req;
-  req.link_names = link_names_;
-  req.isContactAllowed = contact_fn_;
-  req.type = tesseract::ContactRequestTypes::FIRST;
-
   contact_manager_ = env_->getDiscreteContactManager();
-  contact_manager_->setContactRequest(req);
+  contact_manager_->setActiveCollisionObjects(link_names_);
+  contact_manager_->setContactDistanceThreshold(0);
+  contact_manager_->setIsContactAllowedFn(contact_fn_);
 
   // We need to set the planner and call setup before it can run
 }
@@ -92,7 +89,7 @@ bool ChainOmplInterface::isStateValid(const ompl::base::State* state) const
   contact_manager_->setCollisionObjectsTransform(env_state->transforms);
 
   tesseract::ContactResultMap contact_map;
-  contact_manager_->contactTest(contact_map);
+  contact_manager_->contactTest(contact_map, tesseract::ContactTestTypes::FIRST);
 
   return contact_map.empty();
 }

--- a/tesseract_planning/src/ompl/continuous_motion_validator.cpp
+++ b/tesseract_planning/src/ompl/continuous_motion_validator.cpp
@@ -15,13 +15,10 @@ ContinuousMotionValidator::ContinuousMotionValidator(ompl::base::SpaceInformatio
   is_allowed_cb_ =
       std::bind(&ContinuousMotionValidator::isContactAllowed, this, std::placeholders::_1, std::placeholders::_2);
 
-  tesseract::ContactRequest req;
-  req.link_names = links_;
-  req.isContactAllowed = is_allowed_cb_;
-  req.type = tesseract::ContactRequestTypes::FIRST;
-
   contact_manager_ = env_->getContinuousContactManager();
-  contact_manager_->setContactRequest(req);
+  contact_manager_->setActiveCollisionObjects(links_);
+  contact_manager_->setContactDistanceThreshold(0);
+  contact_manager_->setIsContactAllowedFn(is_allowed_cb_);
 }
 
 bool ContinuousMotionValidator::checkMotion(const ompl::base::State* s1, const ompl::base::State* s2) const
@@ -84,7 +81,7 @@ bool ContinuousMotionValidator::continuousCollisionCheck(const ompl::base::State
         link_name, state0->transforms[link_name], state1->transforms[link_name]);
 
   tesseract::ContactResultMap contact_map;
-  contact_manager_->contactTest(contact_map);
+  contact_manager_->contactTest(contact_map, tesseract::ContactTestTypes::FIRST);
 
   return contact_map.empty();
 }

--- a/tesseract_ros/src/kdl/kdl_env.cpp
+++ b/tesseract_ros/src/kdl/kdl_env.cpp
@@ -625,6 +625,7 @@ void KDLEnv::loadDiscreteContactManagerPlugin(const std::string& plugin)
     return;
   }
 
+  discrete_manager_->setIsContactAllowedFn(is_contact_allowed_fn_);
   if (initialized_)
   {
     for (const auto& link : urdf_model_->links_)
@@ -691,6 +692,7 @@ void KDLEnv::loadContinuousContactManagerPlugin(const std::string& plugin)
     return;
   }
 
+  continuous_manager_->setIsContactAllowedFn(is_contact_allowed_fn_);
   if (initialized_)
   {
     for (const auto& link : urdf_model_->links_)


### PR DESCRIPTION
The type ContactRequest was left over from MoveIt and no longer make sense with the new implementation of contact managers.