### PR TITLE
Fix trajopt planner collision check

### DIFF
--- a/tesseract_planning/src/trajopt/trajopt_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_planner.cpp
@@ -134,6 +134,8 @@ bool TrajoptPlanner::solve(PlannerResponse& response,
   // Check and report collisions
   std::vector<tesseract::ContactResultMap> collisions;
   ContinuousContactManagerBasePtr manager = prob->GetEnv()->getContinuousContactManager();
+  manager->setActiveCollisionObjects(prob->GetKin()->getLinkNames());
+  manager->setContactDistanceThreshold(0);
   collisions.clear();
   bool found = tesseract::continuousCollisionCheckTrajectory(
       *manager, *prob->GetEnv(), *prob->GetKin(), getTraj(opt.x(), prob->GetVars()), collisions);


### PR DESCRIPTION
Adds in the two lines so that the final collision check actually works