### PR TITLE
Cleanup and Simplify a few things

### DIFF
--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -46,6 +46,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <btBulletCollisionCommon.h>
 #pragma GCC diagnostic pop
 

--- a/tesseract_collision/src/bullet/bullet_utils.cpp
+++ b/tesseract_collision/src/bullet/bullet_utils.cpp
@@ -43,6 +43,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.h>
 #include <BulletCollision/CollisionShapes/btShapeHull.h>
 #include <BulletCollision/Gimpact/btGImpactShape.h>

--- a/tesseract_core/include/tesseract_core/basic_types.h
+++ b/tesseract_core/include/tesseract_core/basic_types.h
@@ -46,7 +46,7 @@ using AlignedMap = std::map<Key, Value, std::less<Key>, Eigen::aligned_allocator
 
 using VectorIsometry3d = AlignedVector<Eigen::Isometry3d>;
 using VectorVector4d = AlignedVector<Eigen::Vector4d>;
-using VectorVector3d = AlignedVector<Eigen::Vector3d>;
+using VectorVector3d = std::vector<Eigen::Vector3d>;
 using TransformMap = AlignedMap<std::string, Eigen::Isometry3d>;
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> TrajArray;

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
@@ -42,7 +42,7 @@ struct TrajOptPlannerConfig
   /** @brief Trajopt problem to be solved (Required) */
   trajopt::TrajOptProbPtr prob;
 
-  /** @brief Optimization parameters to be used (Required) */
+  /** @brief Optimization parameters to be used (Optional) */
   trajopt::BasicTrustRegionSQPParameters params;
 
   /** @brief Callback functions called on each iteration of the optimization (Optional) */

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
@@ -34,11 +34,26 @@ namespace tesseract
 {
 namespace tesseract_planning
 {
-class TrajoptPlanner : public BasicPlanner
+struct TrajOptPlannerConfig
+{
+  TrajOptPlannerConfig(trajopt::TrajOptProbPtr prob) : prob(prob) {}
+  virtual ~TrajOptPlannerConfig() {}
+
+  /** @brief Trajopt problem to be solved (Required) */
+  trajopt::TrajOptProbPtr prob;
+
+  /** @brief Optimization parameters to be used (Required) */
+  trajopt::BasicTrustRegionSQPParameters params;
+
+  /** @brief Callback functions called on each iteration of the optimization (Optional) */
+  std::vector<trajopt::Optimizer::Callback> callbacks;
+};
+
+class TrajOptPlanner : public BasicPlanner
 {
 public:
   /** @brief Construct a basic planner */
-  TrajoptPlanner()
+  TrajOptPlanner()
   {
     name_ = "TRAJOPT";
 
@@ -59,74 +74,14 @@ public:
 
   /**
    * @brief Sets up the optimizer and solves the SQP problem with no callbacks and default parameters
+   *
+   * Note: This does not use the request information because everything is provided by config parameter
+   *
    * @param response The results of the optimization. Primary output is the optimized joint trajectory
-   * @param prob Trajopt problem to be solved
+   * @param config Trajopt planner config
    * @return true if optimization complete
    */
-  bool solve(PlannerResponse& response, const trajopt::TrajOptProbPtr& prob);
-
-  /**
-   * @brief Sets up the optimizer and solves the SQP problem with no callbacks and parameters passed in
-   * @param response The results of the optimization. Primary output is the optimized joint trajectory
-   * @param prob Trajopt problem to be solved
-   * @param params Optimization parameters to be used
-   * @return true if optimization complete
-   */
-  bool solve(PlannerResponse& response,
-             const trajopt::TrajOptProbPtr& prob,
-             const trajopt::BasicTrustRegionSQPParameters& params);
-
-  /**
-   * @brief Sets up the optimizer and solves the SQP problem with a single callback and parameters passed in
-   * @param response The results of the optimization. Primary output is the optimized joint trajectory
-   * @param prob Trajopt problem to be solved
-   * @param params Optimization parameters to be used
-   * @param callback A callback function to be called on each iteration of the optimization, e.g. plotting, write to
-   * file, etc.
-   * @return true if optimization complete
-   */
-  bool solve(PlannerResponse& response,
-             const trajopt::TrajOptProbPtr& prob,
-             const trajopt::BasicTrustRegionSQPParameters& params,
-             const trajopt::Optimizer::Callback& callback);
-
-  /**
-   * @brief Sets up the optimizer and solves the SQP problem with a single callback and default parameters
-   * @param response The results of the optimization. Primary output is the optimized joint trajectory
-   * @param prob Trajopt problem to be solved
-   * @param callback A callback function to be called on each iteration of the optimization, e.g. plotting, write to
-   * file, etc.
-   * @return true if optimization complete
-   */
-  bool solve(PlannerResponse& response,
-             const trajopt::TrajOptProbPtr& prob,
-             const trajopt::Optimizer::Callback& callback);
-
-  /**
-   * @brief Sets up the optimizer and solves the SQP problem with a vector of callbacks and default parameters
-   * @param response The results of the optimization. Primary output is the optimized joint trajectory
-   * @param prob Trajopt problem to be solved
-   * @param callbacks A callback function to be called on each iteration of the optimization, e.g. plotting, write to
-   * file, etc.
-   * @return true if optimization complete
-   */
-  bool solve(PlannerResponse& response,
-             const trajopt::TrajOptProbPtr& prob,
-             const std::vector<trajopt::Optimizer::Callback>& callbacks);
-
-  /**
-   * @brief Sets up optimizer and solves a SQP problem
-   * @param response The results of the optimization. Primary output is the optimized joint trajectory
-   * @param prob Trajopt problem to be solved
-   * @param params SQP parameters for the optimization. If not given, defaults will be used
-   * @param callbacks A callback function to be called on each iteration of the optimization, e.g. plotting, write to
-   * file, etc.
-   * @return true if optimization complete
-   */
-  bool solve(PlannerResponse& response,
-             const trajopt::TrajOptProbPtr& prob,
-             const trajopt::BasicTrustRegionSQPParameters& params,
-             const std::vector<trajopt::Optimizer::Callback>& callbacks);
+  bool solve(PlannerResponse& response, const TrajOptPlannerConfig& config);
 
   bool terminate() override;
 

--- a/tesseract_planning/src/trajopt/trajopt_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_planner.cpp
@@ -39,7 +39,7 @@ namespace tesseract
 {
 namespace tesseract_planning
 {
-bool TrajoptPlanner::solve(PlannerResponse& response)
+bool TrajOptPlanner::solve(PlannerResponse& response)
 {
   Json::Value root;
   Json::Reader reader;
@@ -68,60 +68,15 @@ bool TrajoptPlanner::solve(PlannerResponse& response)
   return solve(response, prob);
 }
 
-bool TrajoptPlanner::solve(PlannerResponse& response, const trajopt::TrajOptProbPtr& prob)
-{
-  BasicTrustRegionSQPParameters params;
-  return solve(response, prob, params);
-}
-
-bool TrajoptPlanner::solve(PlannerResponse& response,
-                           const trajopt::TrajOptProbPtr& prob,
-                           const BasicTrustRegionSQPParameters& params)
-{
-  std::vector<trajopt::Optimizer::Callback> callbacks;
-  return solve(response, prob, params, callbacks);
-}
-
-bool TrajoptPlanner::solve(PlannerResponse& response,
-                           const trajopt::TrajOptProbPtr& prob,
-                           const BasicTrustRegionSQPParameters& params,
-                           const trajopt::Optimizer::Callback& callback)
-{
-  std::vector<trajopt::Optimizer::Callback> callbacks;
-  callbacks.push_back(callback);
-  return solve(response, prob, params, callbacks);
-}
-
-bool TrajoptPlanner::solve(PlannerResponse& response,
-                           const trajopt::TrajOptProbPtr& prob,
-                           const trajopt::Optimizer::Callback& callback)
-{
-  BasicTrustRegionSQPParameters params;
-  std::vector<trajopt::Optimizer::Callback> callbacks;
-  callbacks.push_back(callback);
-  return solve(response, prob, params, callbacks);
-}
-
-bool TrajoptPlanner::solve(PlannerResponse& response,
-                           const trajopt::TrajOptProbPtr& prob,
-                           const std::vector<trajopt::Optimizer::Callback>& callbacks)
-{
-  BasicTrustRegionSQPParameters params;
-  return solve(response, prob, params, callbacks);
-}
-
-bool TrajoptPlanner::solve(PlannerResponse& response,
-                           const trajopt::TrajOptProbPtr& prob,
-                           const BasicTrustRegionSQPParameters& params,
-                           const std::vector<trajopt::Optimizer::Callback>& callbacks)
+bool TrajOptPlanner::solve(PlannerResponse& response, const TrajOptPlannerConfig& config)
 {
   // Create optimizer
-  BasicTrustRegionSQP opt(prob);
-  opt.setParameters(params);
-  opt.initialize(trajToDblVec(prob->GetInitTraj()));
+  BasicTrustRegionSQP opt(config.prob);
+  opt.setParameters(config.params);
+  opt.initialize(trajToDblVec(config.prob->GetInitTraj()));
 
   // Add all callbacks
-  for (const trajopt::Optimizer::Callback& callback : callbacks)
+  for (const trajopt::Optimizer::Callback& callback : config.callbacks)
   {
     opt.addCallback(callback);
   }
@@ -133,12 +88,12 @@ bool TrajoptPlanner::solve(PlannerResponse& response,
 
   // Check and report collisions
   std::vector<tesseract::ContactResultMap> collisions;
-  ContinuousContactManagerBasePtr manager = prob->GetEnv()->getContinuousContactManager();
-  manager->setActiveCollisionObjects(prob->GetKin()->getLinkNames());
+  ContinuousContactManagerBasePtr manager = config.prob->GetEnv()->getContinuousContactManager();
+  manager->setActiveCollisionObjects(config.prob->GetKin()->getLinkNames());
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   bool found = tesseract::continuousCollisionCheckTrajectory(
-      *manager, *prob->GetEnv(), *prob->GetKin(), getTraj(opt.x(), prob->GetVars()), collisions);
+      *manager, *config.prob->GetEnv(), *config.prob->GetKin(), getTraj(opt.x(), config.prob->GetVars()), collisions);
 
   if (found)
   {
@@ -150,15 +105,15 @@ bool TrajoptPlanner::solve(PlannerResponse& response,
   }
 
   // Send response
-  response.trajectory = getTraj(opt.x(), prob->GetVars());
+  response.trajectory = getTraj(opt.x(), config.prob->GetVars());
   response.status_code = opt.results().status;
-  response.joint_names = prob->GetEnv()->getJointNames();
+  response.joint_names = config.prob->GetKin()->getJointNames();
   response.status_description = sco::statusToString(opt.results().status);
   return true;
 }
 
-bool TrajoptPlanner::terminate() { return false; }
-void TrajoptPlanner::clear() { request_ = PlannerRequest(); }
+bool TrajOptPlanner::terminate() { return false; }
+void TrajOptPlanner::clear() { request_ = PlannerRequest(); }
 
 }  // namespace tesseract_planning
 }  // namespace tesseract

--- a/tesseract_rviz/include/tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h
+++ b/tesseract_rviz/include/tesseract_rviz/tesseract_state_plugin/tesseract_state_display.h
@@ -90,6 +90,7 @@ private Q_SLOTS:
   void changedURDFSceneAlpha();
   void changedAttachedBodyColor();
   void changedTesseractStateTopic();
+  void changedJointStateTopic();
   void changedEnableLinkHighlight();
   void changedEnableVisualVisible();
   void changedEnableCollisionVisible();
@@ -107,7 +108,8 @@ protected:
   void setLinkColor(Robot* robot, const std::string& link_name, const QColor& color);
   void unsetLinkColor(Robot* robot, const std::string& link_name);
 
-  void newTesseractStateCallback(const tesseract_msgs::TesseractStateConstPtr state);
+  void newTesseractStateCallback(const tesseract_msgs::TesseractStateConstPtr& state);
+  void newJointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
 
   void setHighlightedLinks(const tesseract_msgs::TesseractState::_highlight_links_type& highlight_links);
   void setHighlightedLink(const std::string& link_name, const std_msgs::ColorRGBA& color);
@@ -122,6 +124,7 @@ protected:
   // render the robot
   ros::NodeHandle nh_;
   ros::Subscriber tesseract_state_subscriber_;
+  ros::Subscriber joint_state_subscriber_;
 
   tesseract::tesseract_ros::ROSBasicEnvPtr env_;
   StateVisualizationPtr state_;
@@ -132,6 +135,7 @@ protected:
   rviz::StringProperty* urdf_description_property_;
   rviz::StringProperty* root_link_name_property_;
   rviz::RosTopicProperty* tesseract_state_topic_property_;
+  rviz::RosTopicProperty* joint_state_topic_property_;
   rviz::FloatProperty* alpha_property_;
   rviz::ColorProperty* attached_body_color_property_;
   rviz::BoolProperty* enable_link_highlight_;


### PR DESCRIPTION
* The first commit ignore warning messages in bullet
* The second commit simplifies the trajopt planner by introducing a TrajOptPlannerConfig structure which reduces the number of overload methods.
* The third adds joint_state monitoring to the state display so the state in rviz gets updated if joint_states changes.
* The forth commit fixes an error in the axis plotting and also add utils for converting tesseract informtiaon to JointStateMsg's