### PR TITLE
Being forgiving to SRDF joint <group> which contain fixed joints

### DIFF
--- a/tesseract_ros/src/kdl/kdl_joint_kin.cpp
+++ b/tesseract_ros/src/kdl/kdl_joint_kin.cpp
@@ -305,11 +305,11 @@ bool KDLJointKin::init(urdf::ModelInterfaceConstSharedPtr model,
 
     if (jnt.getType() != KDL::Joint::None)
       joint_to_qnr_[jnt.getName()] = tree_element.second.q_nr;
+    else
+      continue;
 
     if (joint_it == joint_names.end())
       continue;
-
-    assert(jnt.getType() != KDL::Joint::None);
 
     // Add affected link names to list
     std::vector<std::string>::const_iterator link_it = std::find(link_list_.begin(), link_list_.end(), seg.getName());


### PR DESCRIPTION
At the moment, in `kdl_joint_kin`, loading a robots whose SRDF file has fixed joints in a given `<group>` will cause an assert to trigger.
On the other side, it looks like tools like the MoveIt! Setup Assistant don't punish users when adding fixed joints in groups, even though ti goes against the purpose of defining the group in the first place (i.e., defining a set of joints for planning).
Being this the case, we should be forgiving and just skip joints that are `fixed` upon loading, so that we don't take them into account when planning.
This small fix allows to do that.

What do you think @Levi-Armstrong ?