### PR TITLE
Build file updates

### DIFF
--- a/tesseract_ext/bullet3_ros/CMakeLists.txt
+++ b/tesseract_ext/bullet3_ros/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS)
 #set(BUILD_PYBULLET_NUMPY OFF CACHE BOOL "Disable Bullet Python Numpy")
 #set(USE_DOUBLE_PRECISION ON CACHE BOOL "Enable Bullet Double Precision")
 
+set(BUILD_UNIT_TESTS OFF CACHE BOOL "Disable Bullet Unit Tests" FORCE)
+
 file(MAKE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/include/bullet")
 catkin_package(
   INCLUDE_DIRS bullet3/src bullet3/Extras ${CMAKE_INSTALL_PREFIX}/include/bullet

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -162,3 +162,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
 )
+
+# Mark plugin XML files for installation
+install(FILES tesseract_rviz_state_plugin_description.xml tesseract_rviz_trajectory_plugin_description.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION
This PR implements the following changes:
- Turns off `bullet` unit test build
  - `bullet` will build an included version of `gtest` if unit tests are built. This can conflict with system installs of `gtest`. Building unit tests for `bullet` is also unnecessary since this repository does not maintain it
- Installs XML files for plugins in the `tesseract_rviz` package
