### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/tesseract_collision/CMakeLists.txt
+++ b/tesseract_collision/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tesseract_collision)
 
-add_compile_options(
-  -std=c++11
-  -Wall
-  -Wextra
-  -Wsuggest-override
-  -Wconversion
-  -Wsign-conversion)
+add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
   bullet3_ros
@@ -72,9 +66,11 @@ add_library(${PROJECT_NAME}_bullet
 )
 
 target_link_libraries(${PROJECT_NAME}_bullet ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_bullet PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_library(${PROJECT_NAME}_bullet_plugin src/bullet/bullet_plugin.cpp)
 target_link_libraries(${PROJECT_NAME}_bullet_plugin ${PROJECT_NAME}_bullet ${catkin_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_bullet_plugin PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_library(${PROJECT_NAME}_fcl
   src/fcl/fcl_discrete_managers.cpp
@@ -82,12 +78,15 @@ add_library(${PROJECT_NAME}_fcl
 )
 
 target_link_libraries(${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_fcl PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_library(${PROJECT_NAME}_fcl_plugin src/fcl/fcl_plugin.cpp)
 target_link_libraries(${PROJECT_NAME}_fcl_plugin ${PROJECT_NAME}_fcl ${catkin_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_fcl_plugin PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_executable(create_convex_hull src/create_convex_hull.cpp)
 target_link_libraries(create_convex_hull ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES})
+target_compile_options(create_convex_hull PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${PROJECT_NAME}_bullet_plugin ${PROJECT_NAME}_fcl_plugin create_convex_hull
@@ -124,40 +123,50 @@ if (CATKIN_ENABLE_TESTING)
   )
 
   catkin_add_gtest(${PROJECT_NAME}_box_sphere_unit test/collision_box_sphere_unit.cpp)
-  target_link_libraries(${PROJECT_NAME}_box_sphere_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
-
+  target_link_libraries(${PROJECT_NAME}_box_sphere_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${GTEST_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_box_sphere_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
   catkin_add_gtest(${PROJECT_NAME}_box_cylinder_unit test/collision_box_cylinder_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_box_cylinder_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
 
   catkin_add_gtest(${PROJECT_NAME}_box_cone_unit test/collision_box_cone_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_box_cone_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_box_cone_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_box_box_unit test/collision_box_box_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_box_box_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_box_box_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_large_dataset_unit test/collision_large_dataset_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_large_dataset_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_large_dataset_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_sphere_sphere_unit test/collision_sphere_sphere_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_sphere_sphere_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_sphere_sphere_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_mesh_mesh_unit test/collision_mesh_mesh_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_mesh_mesh_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_mesh_mesh_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_multi_threaded_unit test/collision_multi_threaded_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_multi_threaded_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_multi_threaded_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_octomap_sphere_unit test/collision_octomap_sphere_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_octomap_sphere_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_octomap_sphere_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_clone_unit test/collision_clone_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_clone_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_clone_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_box_box_cast_unit test/collision_box_box_cast_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_box_box_cast_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_box_box_cast_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
   catkin_add_gtest(${PROJECT_NAME}_compound_compound_unit test/collision_compound_compound_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_compound_compound_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})
+  target_compile_options(${PROJECT_NAME}_compound_compound_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 #  catkin_add_gtest(${PROJECT_NAME}_convex_concave_unit test/convex_concave_unit.cpp)
 #  target_link_libraries(${PROJECT_NAME}_convex_concave_unit ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${LIBFCL_INCLUDE_DIRS})

--- a/tesseract_collision/test/collision_large_dataset_unit.cpp
+++ b/tesseract_collision/test/collision_large_dataset_unit.cpp
@@ -45,7 +45,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
         link_names.push_back("sphere_link_" + std::to_string(x) + std::to_string(y) + std::to_string(z));
 
         location[link_names.back()] = sphere_pose;
-        location[link_names.back()].translation() = Eigen::Vector3d(x * delta, y * delta, z * delta);
+        location[link_names.back()].translation() = Eigen::Vector3d(static_cast<double>(x) * delta,
+                                                                    static_cast<double>(y) * delta,
+                                                                    static_cast<double>(z) * delta);
         checker.addCollisionObject(link_names.back(), 0, obj3_shapes, obj3_poses, obj3_types);
       }
     }

--- a/tesseract_collision/test/collision_multi_threaded_unit.cpp
+++ b/tesseract_collision/test/collision_multi_threaded_unit.cpp
@@ -45,7 +45,9 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
         link_names.push_back("sphere_link_" + std::to_string(x) + std::to_string(y) + std::to_string(z));
 
         location[link_names.back()] = sphere_pose;
-        location[link_names.back()].translation() = Eigen::Vector3d(x * delta, y * delta, z * delta);
+        location[link_names.back()].translation() = Eigen::Vector3d(static_cast<double>(x) * delta,
+                                                                    static_cast<double>(y) * delta,
+                                                                    static_cast<double>(z) * delta);
         checker.addCollisionObject(link_names.back(), 0, obj3_shapes, obj3_poses, obj3_types);
       }
     }
@@ -71,7 +73,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
   {
     const int tn = omp_get_thread_num();
     ROS_DEBUG("Thread %i of %i", tn, omp_get_num_threads());
-    const tesseract::DiscreteContactManagerBasePtr& manager = contact_manager[tn];
+    const tesseract::DiscreteContactManagerBasePtr& manager = contact_manager[static_cast<size_t>(tn)];
     for (const auto& co : location)
     {
       if (tn == 0)
@@ -102,7 +104,7 @@ void runTest(tesseract::DiscreteContactManagerBase& checker, bool use_convex_mes
 
     tesseract::ContactResultMap result;
     manager->contactTest(result, tesseract::ContactTestType::ALL);
-    tesseract::moveContactResultsMapToContactResultsVector(result, result_vector[tn]);
+    tesseract::moveContactResultsMapToContactResultsVector(result, result_vector[static_cast<size_t>(tn)]);
   }
   ros::WallTime end_time = ros::WallTime::now();
   ROS_INFO_STREAM("DT: " << (end_time - start_time).toSec());

--- a/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_monitoring/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tesseract_monitoring)
 
-add_compile_options(
-  -std=c++11
-  -Wall
-  -Wextra
-  -Wsuggest-override
-  -Wconversion
-  -Wsign-conversion)
+add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -43,21 +37,20 @@ include_directories(
 # Tesseract ROS Nodes
 add_executable(${PROJECT_NAME}_contacts_node src/contact_monitor.cpp)
 target_link_libraries(${PROJECT_NAME}_contacts_node ${catkin_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_contacts_node PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
-add_library(${PROJECT_NAME}_environment
-  src/environment_monitor.cpp
-  src/current_state_monitor.cpp
-  )
-target_link_libraries(${PROJECT_NAME}_environment
-  ${catkin_LIBRARIES}
-  ${Boost_LIBRARIES})
+add_library(${PROJECT_NAME}_environment src/environment_monitor.cpp src/current_state_monitor.cpp)
+target_link_libraries(${PROJECT_NAME}_environment ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_environment PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 add_dependencies(${PROJECT_NAME}_environment ${PROJECT_NAME}_gencfg)
 
 add_executable(demo_scene demos/demo_scene.cpp)
 target_link_libraries(demo_scene ${PROJECT_NAME}_environment ${catkin_LIBRARIES})
+target_compile_options(demo_scene PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_executable(${PROJECT_NAME}_environment_node src/environment_monitor_node.cpp)
 target_link_libraries(${PROJECT_NAME}_environment_node ${PROJECT_NAME}_environment ${catkin_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_environment_node PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_environment ${PROJECT_NAME}_contacts_node ${PROJECT_NAME}_environment_node demo_scene

--- a/tesseract_planning/CMakeLists.txt
+++ b/tesseract_planning/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tesseract_planning)
 
-add_compile_options(
-  -std=c++11
-  -Wall
-  -Wextra
-  -Wsuggest-override
-  -Wconversion
-  -Wsign-conversion)
+add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -39,13 +33,9 @@ include_directories(
 )
 
 # Trajopt Planner
-add_library(${PROJECT_NAME}_trajopt
-  src/trajopt/trajopt_planner.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}_trajopt
-  ${catkin_LIBRARIES}
-)
+add_library(${PROJECT_NAME}_trajopt src/trajopt/trajopt_planner.cpp)
+target_link_libraries(${PROJECT_NAME}_trajopt ${catkin_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_trajopt PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # OMPL Planning Interface
 add_library(${PROJECT_NAME}_ompl
@@ -53,25 +43,15 @@ add_library(${PROJECT_NAME}_ompl
   src/ompl/conversions.cpp
   src/ompl/continuous_motion_validator.cpp
 )
-
 add_dependencies(${PROJECT_NAME}_ompl ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(${PROJECT_NAME}_ompl
-  ${catkin_LIBRARIES}
-  ${OMPL_LIBRARIES}
-)
+target_link_libraries(${PROJECT_NAME}_ompl ${catkin_LIBRARIES} ${OMPL_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_ompl PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # OMPL Planning Test/Example Program
-add_executable(${PROJECT_NAME}_ompl_test
-  src/ompl_planner_tests.cpp
-)
-
+add_executable(${PROJECT_NAME}_ompl_test src/ompl_planner_tests.cpp)
 add_dependencies(${PROJECT_NAME}_ompl_test ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(${PROJECT_NAME}_ompl_test
-  ${catkin_LIBRARIES}
-  ${PROJECT_NAME}_ompl
-)
+target_link_libraries(${PROJECT_NAME}_ompl_test ${catkin_LIBRARIES} ${PROJECT_NAME}_ompl)
+target_compile_options(${PROJECT_NAME}_ompl_test PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 #############
 ## Install ##

--- a/tesseract_ros/CMakeLists.txt
+++ b/tesseract_ros/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tesseract_ros)
 
-add_compile_options(
-  -std=c++11
-  -Wall
-  -Wextra
-  -Wsuggest-override
-  -Wconversion
-  -Wsign-conversion)
+add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
   tesseract_core
@@ -67,8 +61,8 @@ add_library(${PROJECT_NAME}_kdl
   src/kdl/kdl_joint_kin.cpp
   src/kdl/kdl_env.cpp
 )
-
 target_link_libraries(${PROJECT_NAME}_kdl ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${orocos_kdl_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_kdl PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_kdl
@@ -88,11 +82,9 @@ if (CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
 
-  include_directories(
-      ${catkin_INCLUDE_DIRS}
-  )
+  include_directories(${catkin_INCLUDE_DIRS})
 
   catkin_add_gtest(${PROJECT_NAME}_kdl_kin_unit test/kdl_kin_unit.cpp)
   target_link_libraries(${PROJECT_NAME}_kdl_kin_unit ${PROJECT_NAME}_kdl ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES} ${orocos_kdl_LIBRARIES})
-
+  target_compile_options(${PROJECT_NAME}_kdl_kin_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 endif()

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tesseract_rviz)
 
-add_compile_options(
-  -std=c++11
-  -Wall
-  -Wextra
-  -Wsuggest-override
-  -Wconversion
-  -Wsign-conversion)
+add_compile_options(-std=c++11 -Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -87,8 +81,6 @@ catkin_package(
     QT
 )
 
-
-
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
@@ -125,6 +117,8 @@ target_link_libraries(${PROJECT_NAME}_render_tools
   ${Boost_LIBRARIES}
 )
 
+target_compile_options(${PROJECT_NAME}_render_tools PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
+
 #add_library(${PROJECT_NAME}_scene_plugin_core
 #  src/tesseract_scene_plugin/tesseract_scene_display.cpp
 #  include/tesseract_rviz/tesseract_scene_plugin/tesseract_scene_display.h)
@@ -138,21 +132,26 @@ qt_wrap_cpp(${PROJECT_NAME}_state_plugin_core_cpp_MOCS include/tesseract_rviz/te
 
 add_library(${PROJECT_NAME}_state_plugin_core src/tesseract_state_plugin/tesseract_state_display.cpp ${${PROJECT_NAME}_state_plugin_core_cpp_MOCS})
 target_link_libraries(${PROJECT_NAME}_state_plugin_core ${PROJECT_NAME}_render_tools ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_state_plugin_core PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_library(${PROJECT_NAME}_state_plugin src/tesseract_state_plugin/plugin_init.cpp)
 target_link_libraries(${PROJECT_NAME}_state_plugin ${PROJECT_NAME}_state_plugin_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_state_plugin PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # Trajectory Display
 qt_wrap_cpp(${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS include/tesseract_rviz/tesseract_trajectory_plugin/tesseract_trajectory_display.h)
 
 add_library(${PROJECT_NAME}_trajectory_plugin_core src/tesseract_trajectory_plugin/tesseract_trajectory_display.cpp ${${PROJECT_NAME}_trajectory_plugin_core_cpp_MOCS})
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin_core ${PROJECT_NAME}_render_tools ${PROJECT_NAME}_state_plugin_core ${catkin_LIBRARIES} ${OGRE_LIBRARIES} ${QT_LIBRARIES} ${Boost_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_trajectory_plugin_core PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_library(${PROJECT_NAME}_trajectory_plugin src/tesseract_trajectory_plugin/plugin_init.cpp)
 target_link_libraries(${PROJECT_NAME}_trajectory_plugin ${PROJECT_NAME}_trajectory_plugin_core ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_trajectory_plugin PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 add_executable(${PROJECT_NAME}_test src/test.cpp)
 target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME}_trajectory_plugin_core ${catkin_LIBRARIES})
+target_compile_options(${PROJECT_NAME}_test PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 
 # Mark executables and/or libraries for installation


### PR DESCRIPTION
For some reason i was recieving several warnings from within gtest and the ignore warning was not solving the issue. In order to resolve the warnings was to using the `target_compiler_options` instead of `add_compiler_options`. 