### PR TITLE
WIP: Reverse order of PluginLoader and ContactManager

### DIFF
--- a/tesseract_ros/include/tesseract_ros/kdl/kdl_env.h
+++ b/tesseract_ros/include/tesseract_ros/kdl/kdl_env.h
@@ -178,10 +178,11 @@ private:
       allowed_collision_matrix_; /**< The allowed collision matrix used during collision checking */
   IsContactAllowedFn
       is_contact_allowed_fn_; /**< The function used to determine if two objects are allowed in collision */
-  DiscreteContactManagerBasePluginLoaderPtr discrete_manager_loader_;     /**< The discrete contact manager loader */
-  ContinuousContactManagerBasePluginLoaderPtr continuous_manager_loader_; /**< The continuous contact manager loader */
+
   DiscreteContactManagerBasePtr discrete_manager_;                        /**< The discrete contact manager object */
   ContinuousContactManagerBasePtr continuous_manager_;                    /**< The continuous contact manager object */
+  DiscreteContactManagerBasePluginLoaderPtr discrete_manager_loader_;     /**< The discrete contact manager loader */
+  ContinuousContactManagerBasePluginLoaderPtr continuous_manager_loader_; /**< The continuous contact manager loader */
 
   bool defaultIsContactAllowedFn(const std::string& link_name1, const std::string& link_name2) const;
 


### PR DESCRIPTION
I'm not really sure why this fixes it, but this seems to fix the error below in the TrajOpt examples.  (https://github.com/ros-industrial-consortium/trajopt_ros/issues/56) 

```
terminate called after throwing an instance of 'class_loader::LibraryUnloadException'
  what():  Attempt to unload library that class_loader is unaware of.
```