### PR TITLE
Add TrajOpt Freespace and Array Planners

### DIFF
--- a/tesseract_planning/CMakeLists.txt
+++ b/tesseract_planning/CMakeLists.txt
@@ -69,7 +69,7 @@ target_compile_options(${PROJECT_NAME}_ompl_test PRIVATE -Wsuggest-override -Wco
 ## Install ##
 #############
 
-install(TARGETS ${PROJECT_NAME}_ompl ${PROJECT_NAME}_trajopt
+install(TARGETS ${PROJECT_NAME}_ompl ${PROJECT_NAME}_trajopt ${PROJECT_NAME}_trajopt_freespace ${PROJECT_NAME}_trajopt_array
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/tesseract_planning/CMakeLists.txt
+++ b/tesseract_planning/CMakeLists.txt
@@ -19,6 +19,7 @@ catkin_package(
     ${PROJECT_NAME}_ompl
     ${PROJECT_NAME}_trajopt
     ${PROJECT_NAME}_trajopt_freespace
+    ${PROJECT_NAME}_trajopt_array
   CATKIN_DEPENDS
     roscpp
     tesseract_ros
@@ -42,6 +43,11 @@ target_compile_options(${PROJECT_NAME}_trajopt PRIVATE -Wsuggest-override -Wconv
 add_library(${PROJECT_NAME}_trajopt_freespace src/trajopt/trajopt_freespace_planner.cpp)
 target_link_libraries(${PROJECT_NAME}_trajopt_freespace ${catkin_LIBRARIES} ${PROJECT_NAME}_trajopt)
 target_compile_options(${PROJECT_NAME}_trajopt_freespace PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
+
+# Trajopt Array Planner
+add_library(${PROJECT_NAME}_trajopt_array src/trajopt/trajopt_array_planner.cpp)
+target_link_libraries(${PROJECT_NAME}_trajopt_array ${catkin_LIBRARIES} ${PROJECT_NAME}_trajopt)
+target_compile_options(${PROJECT_NAME}_trajopt_array PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # OMPL Planning Interface
 add_library(${PROJECT_NAME}_ompl

--- a/tesseract_planning/CMakeLists.txt
+++ b/tesseract_planning/CMakeLists.txt
@@ -18,6 +18,7 @@ catkin_package(
   LIBRARIES
     ${PROJECT_NAME}_ompl
     ${PROJECT_NAME}_trajopt
+    ${PROJECT_NAME}_trajopt_freespace
   CATKIN_DEPENDS
     roscpp
     tesseract_ros
@@ -36,6 +37,11 @@ include_directories(
 add_library(${PROJECT_NAME}_trajopt src/trajopt/trajopt_planner.cpp)
 target_link_libraries(${PROJECT_NAME}_trajopt ${catkin_LIBRARIES})
 target_compile_options(${PROJECT_NAME}_trajopt PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
+
+# Trajopt Freespace Planner
+add_library(${PROJECT_NAME}_trajopt_freespace src/trajopt/trajopt_freespace_planner.cpp)
+target_link_libraries(${PROJECT_NAME}_trajopt_freespace ${catkin_LIBRARIES} ${PROJECT_NAME}_trajopt)
+target_compile_options(${PROJECT_NAME}_trajopt_freespace PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
 
 # OMPL Planning Interface
 add_library(${PROJECT_NAME}_ompl

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
@@ -51,7 +51,6 @@ struct TrajOptArrayPlannerConfig
 
   TrajOptArrayPlannerConfig() {}
   virtual ~TrajOptArrayPlannerConfig() {}
-
   /** @brief Vector of target waypoints given as constraints to the optimization */
   std::vector<WaypointPtr> target_waypoints_;
 
@@ -114,7 +113,6 @@ public:
 
   // TODO: Not sure what to do here, but this is defined in the base as virtual
   bool solve(PlannerResponse& response) override { return false; };
-
   /**
    * @brief Sets up the TrajOpt problem then solves using TrajOptPlanner
    *

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
@@ -1,0 +1,136 @@
+/**
+ * @file trajopt_array_planner.h
+ * @brief Tesseract ROS TrajOpt Freespace planner
+ *
+ * @author Matthew Powelson
+ * @date February 27, 2019
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_PLANNING_TRAJOPT_ARRAY_PLANNER_H
+#define TESSERACT_PLANNING_TRAJOPT_ARRAY_PLANNER_H
+
+#include <tesseract_core/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <trajopt/problem_description.hpp>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <tesseract_planning/basic_planner.h>
+#include <tesseract_ros/ros_basic_plotting.h>
+#include <tesseract_planning/waypoint_definitions.h>
+
+namespace tesseract
+{
+namespace tesseract_planning
+{
+/**
+ * @brief Config to setup array planner. The input is a vector of waypoints
+ *
+ * While there are many parameters that can be set, the majority of them have defaults that will be suitable for many
+ * problems. These are always required: kin_, env_, end_effector
+ */
+struct TrajOptArrayPlannerConfig
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  TrajOptArrayPlannerConfig() {}
+  virtual ~TrajOptArrayPlannerConfig() {}
+
+  /** @brief Vector of target waypoints given as constraints to the optimization */
+  std::vector<WaypointPtr> target_waypoints_;
+
+  /** @brief Selects the type of initialization used for raster path. If GIVEN_TRAJ, then the seed_trajectory_ must be
+   * set */
+  trajopt::InitInfo::Type init_type_ = trajopt::InitInfo::STATIONARY;
+  /** @brief The trajectory used as the optimization seed when init_type_ is set to GIVEN_TRAJ */
+  trajopt::TrajArray seed_trajectory_;
+
+  /** @brief If true, collision checking will be enabled. Default: true*/
+  bool collision_check_ = true;
+  /** @brief If true, use continuous collision checking */
+  bool collision_continuous_ = true;
+  /** @brief Max distance over which collisions are checked */
+  double collision_safety_margin_ = 0.025;
+  /** @brief If true, a joint velocity cost with a target of 0 will be applied for all timesteps Default: true*/
+  bool smooth_velocities_ = true;
+  /** @brief If true, a joint acceleration cost with a target of 0 will be applied for all timesteps Default: false*/
+  bool smooth_accelerations_ = true;
+  /** @brief If true, a joint jerk cost with a target of 0 will be applied for all timesteps Default: false*/
+  bool smooth_jerks_ = true;
+  /** @brief If true, add a callback to plot each iteration */
+  bool plot_callback_ = false;
+
+  /** @brief Basic Kinematics object. ***REQUIRED*** */
+  tesseract::BasicKinConstPtr kin_;
+  /** @brief Basic Environment object. ***REQUIRED*** */
+  tesseract::tesseract_ros::ROSBasicEnvConstPtr env_;
+  /** @brief This is the link used for the cartesian positions ***REQUIRED*** */
+  std::string end_effector_;
+  /** @brief Manipulator used for pathplanning ***REQUIRED*** */
+  std::string manipulator_;
+
+  /** @brief Optimization parameters to be used (Optional) */
+  sco::BasicTrustRegionSQPParameters params_;
+
+  /** @brief Callback functions called on each iteration of the optimization (Optional) */
+  std::vector<sco::Optimizer::Callback> callbacks_;
+};
+
+/**
+ * @brief This planner is intended to provide an easy to use interface to TrajOpt for array planning. It takes an array
+ * of target waypoints and automates the creation and solve of the TrajOpt Problem
+ */
+class TrajOptArrayPlanner : public BasicPlanner
+{
+public:
+  /** @brief Construct a basic planner */
+  TrajOptArrayPlanner()
+  {
+    name_ = "TRAJOPT_ARRAY";
+
+    // Error Status Codes
+    status_code_map_[-1] = "Invalid config data format";
+    status_code_map_[-2] = "Failed to parse config data";
+    status_code_map_[-3] = "";
+
+    // Converge Status Codes
+  }
+
+  // TODO: Not sure what to do here, but this is defined in the base as virtual
+  bool solve(PlannerResponse& response) override { return false; };
+
+  /**
+   * @brief Sets up the TrajOpt problem then solves using TrajOptPlanner
+   *
+   *
+   * Note: This does not use the request information because everything is provided by config parameter
+   *
+   * @param response The results of the optimization. Primary output is the optimized joint trajectory
+   * @param config Configures the freespace planner
+   * @return true if optimization complete
+   */
+  bool solve(PlannerResponse& response, const TrajOptArrayPlannerConfig& config);
+
+  bool terminate() override;
+
+  void clear() override;
+};
+}  // namespace tesseract_planning
+}  // namespace tesseract
+#endif  // TESSERACT_PLANNING_TRAJOPT_PLANNER_H

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
@@ -53,15 +53,12 @@ struct TrajOptFreespacePlannerConfig
 
   TrajOptFreespacePlannerConfig() {}
   virtual ~TrajOptFreespacePlannerConfig() {}
-
   /** @brief Determines the constraint placed at the start of the trajectory */
   WaypointPtr start_waypoint_;
   /** @brief Determines the constraint placed at the end of the trajectory */
   WaypointPtr end_waypoint_;
-
   // TODO: These are waypoints the planner must hit in between
   std::vector<Waypoint> intermediate_waypoints;
-
   /** @brief The total number of timesteps used in the freespace motion. Default: 20 */
   int num_steps_ = 20;
 
@@ -118,7 +115,6 @@ public:
 
   // TODO: Not sure what to do here, but this is defined in the base as virtual
   bool solve(PlannerResponse& response) override { return false; };
-
   /**
    * @brief Sets up the TrajOpt problem then solves using TrajOptPlanner. It is intended to simplify setting up and
    * solving freespace motion problems.
@@ -133,7 +129,7 @@ public:
    * @param config Configures the freespace planner
    * @return true if optimization complete
    */
-  bool solve(PlannerResponse& response,  TrajOptFreespacePlannerConfig& config);
+  bool solve(PlannerResponse& response, TrajOptFreespacePlannerConfig& config);
 
   bool terminate() override;
 

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
@@ -1,0 +1,144 @@
+/**
+ * @file trajopt_freespace_planner.h
+ * @brief Tesseract ROS TrajOpt Freespace planner
+ *
+ * @author Matthew Powelson
+ * @date February 26, 2019
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_PLANNING_TRAJOPT_FREESPACE_PLANNER_H
+#define TESSERACT_PLANNING_TRAJOPT_FREESPACE_PLANNER_H
+
+#include <tesseract_core/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <trajopt/problem_description.hpp>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <tesseract_planning/basic_planner.h>
+#include <tesseract_ros/ros_basic_plotting.h>
+#include <tesseract_planning/waypoint_definitions.h>
+
+namespace tesseract
+{
+namespace tesseract_planning
+{
+/**
+ * @brief Config to setup freespace planner. Specify the start and end position. Freespace motion can be defined between
+ * either joint space positions or cartesian positions
+ *
+ * While there are many parameters that can be set, the majority of them have defaults that will be suitable for many
+ * problems. These are always required: kin_, env_, end_effector
+ *
+ */
+struct TrajOptFreespacePlannerConfig
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  TrajOptFreespacePlannerConfig() {}
+  virtual ~TrajOptFreespacePlannerConfig() {}
+
+  /** @brief Determines the constraint placed at the start of the trajectory */
+  WaypointPtr start_waypoint_;
+  /** @brief Determines the constraint placed at the end of the trajectory */
+  WaypointPtr end_waypoint_;
+
+  // TODO: These are waypoints the planner must hit in between
+  std::vector<Waypoint> intermediate_waypoints;
+
+  /** @brief The total number of timesteps used in the freespace motion. Default: 20 */
+  int num_steps_ = 20;
+
+  /** @brief If true, collision checking will be enabled. Default: true*/
+  bool collision_check_ = true;
+  /** @brief If true, use continuous collision checking */
+  bool collision_continuous_ = true;
+  /** @brief Max distance over which collisions are checked */
+  double collision_safety_margin_ = 0.025;
+  /** @brief If true, a joint velocity cost with a target of 0 will be applied for all timesteps Default: true*/
+  bool smooth_velocities_ = true;
+  /** @brief If true, a joint acceleration cost with a target of 0 will be applied for all timesteps Default: false*/
+  bool smooth_accelerations_ = true;
+  /** @brief If true, a joint jerk cost with a target of 0 will be applied for all timesteps Default: false*/
+  bool smooth_jerks_ = true;
+  /** @brief If true, add a callback to plot each iteration */
+  bool plot_callback_ = false;
+
+  /** @brief Basic Kinematics object. ***REQUIRED*** */
+  tesseract::BasicKinConstPtr kin_;
+  /** @brief Basic Environment object. ***REQUIRED*** */
+  tesseract::tesseract_ros::ROSBasicEnvConstPtr env_;
+  /** @brief This is the link used for the cartesian positions ***REQUIRED*** */
+  std::string end_effector_;
+  /** @brief Manipulator used for pathplanning ***REQUIRED*** */
+  std::string manipulator_;
+
+  /** @brief Optimization parameters to be used (Optional) */
+  sco::BasicTrustRegionSQPParameters params_;
+
+  /** @brief Callback functions called on each iteration of the optimization (Optional) */
+  std::vector<sco::Optimizer::Callback> callbacks_;
+};
+
+/**
+ * @brief This planner is intended to provide an easy to use interface to TrajOpt for freespace planning. It is made to
+ * take a start and end point and automate the generation of the TrajOpt problem.
+ */
+class TrajOptFreespacePlanner : public BasicPlanner
+{
+public:
+  /** @brief Construct a basic planner */
+  TrajOptFreespacePlanner()
+  {
+    name_ = "TRAJOPT_FREESPACE";
+
+    // Error Status Codes
+    status_code_map_[-1] = "Invalid config data format";
+    status_code_map_[-2] = "Failed to parse config data";
+    status_code_map_[-3] = "";
+
+    // Converge Status Codes
+  }
+
+  // TODO: Not sure what to do here, but this is defined in the base as virtual
+  bool solve(PlannerResponse& response) override { return false; };
+
+  /**
+   * @brief Sets up the TrajOpt problem then solves using TrajOptPlanner. It is intended to simplify setting up and
+   * solving freespace motion problems.
+   *
+   * This planner (and the associated config) does not expose all of the available configuration data in TrajOpt. This
+   * is done to simplify the interface. However, many problems may require more specific setups. In that case, the
+   * source code for this planner may be used as an example.
+   *
+   * Note: This does not use the request information because everything is provided by config parameter
+   *
+   * @param response The results of the optimization. Primary output is the optimized joint trajectory
+   * @param config Configures the freespace planner
+   * @return true if optimization complete
+   */
+  bool solve(PlannerResponse& response,  TrajOptFreespacePlannerConfig& config);
+
+  bool terminate() override;
+
+  void clear() override;
+};
+}  // namespace tesseract_planning
+}  // namespace tesseract
+#endif  // TESSERACT_PLANNING_TRAJOPT_PLANNER_H

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
@@ -67,6 +67,7 @@ public:
 
     // Converge Status Codes
   }
+//  virtual ~TrajOptPlanner(){}
 
   /**
    * @brief Sets up the opimizer and solves a SQP problem read from json with no callbacks and dafault parameterss

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_planner.h
@@ -67,8 +67,7 @@ public:
 
     // Converge Status Codes
   }
-//  virtual ~TrajOptPlanner(){}
-
+  virtual ~TrajOptPlanner() {}
   /**
    * @brief Sets up the opimizer and solves a SQP problem read from json with no callbacks and dafault parameterss
    * @param response The results of the optimization. Primary output is the optimized joint trajectory

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -46,27 +46,21 @@ class Waypoint
 public:
   Waypoint() {}
   virtual ~Waypoint() {}
-
   /** @brief Returns the type of waypoint so that it may be cast back to the derived type */
   WaypointType getType() const { return waypoint_type_; }
-
 protected:
   WaypointType waypoint_type_;
 };
-
 /** @brief Defines a joint position waypoint for use with Tesseract Planners*/
 class JointWaypoint : public Waypoint
 {
 public:
-  //TODO: constructor that takes joint position vector
+  // TODO: constructor that takes joint position vector
   JointWaypoint() { waypoint_type_ = JOINT_WAYPOINT; }
   virtual ~JointWaypoint() {}
-
   /** Stores the joint values associated with this waypoint (radians) */
   std::vector<double> joint_positions_;
-
 };
-
 /** @brief Defines a cartesian position waypoint for use with Tesseract Planners*/
 class CartesianWaypoint : public Waypoint
 {
@@ -75,7 +69,6 @@ public:
 
   CartesianWaypoint() { waypoint_type_ = CARTESIAN_WAYPOINT; }
   virtual ~CartesianWaypoint() {}
-
   Eigen::Isometry3d cartesian_position_;
 
   Eigen::Vector3d getPosition() { return cartesian_position_.translation(); }  // TODO
@@ -84,7 +77,6 @@ public:
     Eigen::Quaterniond q(cartesian_position_.rotation());
     return Eigen::Vector4d(q.x(), q.y(), q.z(), q.w());
   }
-
 };
 
 typedef std::shared_ptr<Waypoint> WaypointPtr;

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -75,11 +75,11 @@ public:
 
   /** @brief Convenience function that returns the xyz cartesian position contained in cartesian_position_ */
   Eigen::Vector3d getPosition() { return cartesian_position_.translation(); }
-  /** @brief Convenience function that returns the xyzw rotation quarternion contained in cartesian_position_ */
+  /** @brief Convenience function that returns the wxyz rotation quarternion contained in cartesian_position_ */
   Eigen::Vector4d getOrientation()
   {
     Eigen::Quaterniond q(cartesian_position_.rotation());
-    return Eigen::Vector4d(q.x(), q.y(), q.z(), q.w());
+    return Eigen::Vector4d(q.w(), q.x(), q.y(), q.z());
   }
 };
 

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -1,0 +1,95 @@
+/**
+ * @file waypoint_definitions.h
+ * @brief The class that defines common types of waypoints that can be sent to the planners
+ *
+ * @author Matthew Powelson
+ * @date February 29, 2019
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_PLANNING_WAYPOINT_DEFINITIONS_H
+#define TESSERACT_PLANNING_WAYPOINT_DEFINITIONS_H
+
+#include <Eigen/Dense>
+#include <memory>
+
+namespace tesseract
+{
+namespace tesseract_planning
+{
+/** @brief Used to specify the type of waypoint. Corresponds to a derived class of Waypoint*/
+enum WaypointType
+{
+  JOINT_WAYPOINT = 0x1,      // 0000 0001
+  CARTESIAN_WAYPOINT = 0x2,  // 0000 0010
+};
+// TODO: Doxygen
+/** @brief Defines a generic way of sending waypoints to a Tesseract Planner */
+class Waypoint
+{
+public:
+  Waypoint() {}
+  virtual ~Waypoint() {}
+
+  /** @brief Returns the type of waypoint so that it may be cast back to the derived type */
+  WaypointType getType() const { return waypoint_type_; }
+
+protected:
+  WaypointType waypoint_type_;
+};
+
+/** @brief Defines a joint position waypoint for use with Tesseract Planners*/
+class JointWaypoint : public Waypoint
+{
+public:
+  //TODO: constructor that takes joint position vector
+  JointWaypoint() { waypoint_type_ = JOINT_WAYPOINT; }
+  virtual ~JointWaypoint() {}
+
+  /** Stores the joint values associated with this waypoint (radians) */
+  std::vector<double> joint_positions_;
+
+};
+
+/** @brief Defines a cartesian position waypoint for use with Tesseract Planners*/
+class CartesianWaypoint : public Waypoint
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  CartesianWaypoint() { waypoint_type_ = CARTESIAN_WAYPOINT; }
+  virtual ~CartesianWaypoint() {}
+
+  Eigen::Isometry3d cartesian_position_;
+
+  Eigen::Vector3d getPosition() { return cartesian_position_.translation(); }  // TODO
+  Eigen::Vector4d getOrientation()
+  {
+    Eigen::Quaterniond q(cartesian_position_.rotation());
+    return Eigen::Vector4d(q.x(), q.y(), q.z(), q.w());
+  }
+
+};
+
+typedef std::shared_ptr<Waypoint> WaypointPtr;
+typedef std::shared_ptr<JointWaypoint> JointWaypointPtr;
+typedef std::shared_ptr<CartesianWaypoint> CartesianWaypointPtr;
+}  // namespace tesseract_planning
+}  // namespace tesseract
+#endif

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -34,7 +34,7 @@ namespace tesseract
 namespace tesseract_planning
 {
 /** @brief Used to specify the type of waypoint. Corresponds to a derived class of Waypoint*/
-enum WaypointType
+enum class WaypointType
 {
   JOINT_WAYPOINT = 0x1,      // 0000 0001
   CARTESIAN_WAYPOINT = 0x2,  // 0000 0010
@@ -49,6 +49,7 @@ public:
   /** @brief Returns the type of waypoint so that it may be cast back to the derived type */
   WaypointType getType() const { return waypoint_type_; }
 protected:
+  /** @brief Should be set by the derived class for casting Waypoint back to appropriate derived class type */
   WaypointType waypoint_type_;
 };
 /** @brief Defines a joint position waypoint for use with Tesseract Planners*/
@@ -56,22 +57,25 @@ class JointWaypoint : public Waypoint
 {
 public:
   // TODO: constructor that takes joint position vector
-  JointWaypoint() { waypoint_type_ = JOINT_WAYPOINT; }
+  JointWaypoint() { waypoint_type_ = WaypointType::JOINT_WAYPOINT; }
   virtual ~JointWaypoint() {}
-  /** Stores the joint values associated with this waypoint (radians) */
+  /** @brief Stores the joint values associated with this waypoint (radians) */
   std::vector<double> joint_positions_;
 };
-/** @brief Defines a cartesian position waypoint for use with Tesseract Planners*/
+/** @brief Defines a cartesian position waypoint for use with Tesseract Planners */
 class CartesianWaypoint : public Waypoint
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  CartesianWaypoint() { waypoint_type_ = CARTESIAN_WAYPOINT; }
+  CartesianWaypoint() { waypoint_type_ = WaypointType::CARTESIAN_WAYPOINT; }
   virtual ~CartesianWaypoint() {}
+  /** @brief Contains the position and orientation of this waypoint */
   Eigen::Isometry3d cartesian_position_;
 
-  Eigen::Vector3d getPosition() { return cartesian_position_.translation(); }  // TODO
+  /** @brief Convenience function that returns the xyz cartesian position contained in cartesian_position_ */
+  Eigen::Vector3d getPosition() { return cartesian_position_.translation(); }
+  /** @brief Convenience function that returns the xyzw rotation quarternion contained in cartesian_position_ */
   Eigen::Vector4d getOrientation()
   {
     Eigen::Quaterniond q(cartesian_position_.rotation());
@@ -80,8 +84,11 @@ public:
 };
 
 typedef std::shared_ptr<Waypoint> WaypointPtr;
+typedef std::shared_ptr<const Waypoint> WaypointConstPtr;
 typedef std::shared_ptr<JointWaypoint> JointWaypointPtr;
+typedef std::shared_ptr<const JointWaypoint> JointWaypointConstPtr;
 typedef std::shared_ptr<CartesianWaypoint> CartesianWaypointPtr;
+typedef std::shared_ptr<const CartesianWaypoint> CartesianWaypointConstPtr;
 }  // namespace tesseract_planning
 }  // namespace tesseract
 #endif

--- a/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
@@ -78,7 +78,7 @@ bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPla
     auto waypoint_type = config.target_waypoints_[ind]->getType();
     switch (waypoint_type)
     {
-      case tesseract::tesseract_planning::JOINT_WAYPOINT:
+      case tesseract::tesseract_planning::WaypointType::JOINT_WAYPOINT:
       {
         JointWaypointPtr joint_waypoint = std::static_pointer_cast<JointWaypoint>(config.target_waypoints_[ind]);
         // Add initial joint position constraint
@@ -92,7 +92,7 @@ bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPla
         pci.cnt_infos.push_back(jv);
         break;
       }
-      case tesseract::tesseract_planning::CARTESIAN_WAYPOINT:
+      case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
       {
         CartesianWaypointPtr cart_waypoint = std::static_pointer_cast<CartesianWaypoint>(config.target_waypoints_[ind]);
         std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);

--- a/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
@@ -63,7 +63,7 @@ bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPla
 
   // Populate Basic Info
   pci.basic_info.n_steps = static_cast<int>(config.target_waypoints_.size());
-  pci.basic_info.manip = manipulator_;
+  pci.basic_info.manip = config.manipulator_;
   pci.basic_info.start_fixed = false;
   pci.basic_info.use_time = false;
 

--- a/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
@@ -1,0 +1,189 @@
+/**
+ * @file trajopt_planner.cpp
+ * @brief Tesseract ROS Trajopt planner
+ *
+ * @author Levi Armstrong
+ * @date April 18, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_core/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <jsoncpp/json/json.h>
+#include <ros/console.h>
+#include <trajopt/plot_callback.hpp>
+#include <trajopt/problem_description.hpp>
+#include <trajopt_utils/config.hpp>
+#include <trajopt_utils/logging.hpp>
+#include <trajopt_sco/optimizers.hpp>
+#include <trajopt_sco/sco_common.hpp>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <tesseract_planning/trajopt/trajopt_array_planner.h>
+#include <tesseract_planning/trajopt/trajopt_planner.h>
+
+// This is probably an issue
+#include <tesseract_ros/ros_basic_plotting.h>
+#include <trajopt/plot_callback.hpp>
+
+using namespace trajopt;
+
+namespace tesseract
+{
+namespace tesseract_planning
+{
+bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPlannerConfig& config)
+{
+  // Check that parameters are valid
+  if (config.env_ == nullptr)
+    throw std::invalid_argument("In trajopt_array_planner: env_ is a required parameter and has not been set");
+  if (config.kin_ == nullptr)
+    throw std::invalid_argument("In trajopt_array_planner: kin_ is a required parameter and has not been set");
+
+  // -------- Construct the problem ------------
+  // -------------------------------------------
+  ProblemConstructionInfo pci(config.env_);
+  pci.kin = config.kin_;
+
+  // Populate Basic Info
+  pci.basic_info.n_steps = static_cast<int>(config.target_waypoints_.size());
+  pci.basic_info.manip = manipulator_;
+  pci.basic_info.start_fixed = false;
+  pci.basic_info.use_time = false;
+
+  // Populate Init Info
+  pci.init_info.type = config.init_type_;
+  if (config.init_type_ == trajopt::InitInfo::GIVEN_TRAJ)
+    pci.init_info.data = config.seed_trajectory_;
+
+  // Add constraints
+  for (std::size_t ind = 0; ind < config.target_waypoints_.size(); ind++)
+  {
+    auto waypoint_type = config.target_waypoints_[ind]->getType();
+    switch (waypoint_type)
+    {
+      case tesseract::tesseract_planning::JOINT_WAYPOINT:
+      {
+        JointWaypointPtr joint_waypoint = std::static_pointer_cast<JointWaypoint>(config.target_waypoints_[ind]);
+        // Add initial joint position constraint
+        std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+        jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+        jv->targets = joint_waypoint->joint_positions_;
+        jv->first_step = static_cast<int>(ind);
+        jv->last_step = static_cast<int>(ind);
+        jv->name = "joint_position";
+        jv->term_type = TT_CNT;
+        pci.cnt_infos.push_back(jv);
+        break;
+      }
+      case tesseract::tesseract_planning::CARTESIAN_WAYPOINT:
+      {
+        CartesianWaypointPtr cart_waypoint = std::static_pointer_cast<CartesianWaypoint>(config.target_waypoints_[ind]);
+        std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
+        pose->term_type = TT_CNT;
+        pose->name = "cartesian_position";
+        pose->link = config.end_effector_;
+        pose->timestep = static_cast<int>(ind);
+        pose->xyz = cart_waypoint->getPosition();
+        pose->wxyz = cart_waypoint->getOrientation();
+        pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+        pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+        pci.cnt_infos.push_back(pose);
+        break;
+      }
+    }
+  }
+
+  // Set costs for the rest of the points
+  if (config.collision_check_)
+  {
+    std::shared_ptr<CollisionTermInfo> collision = std::shared_ptr<CollisionTermInfo>(new CollisionTermInfo);
+    collision->name = "collision_cost";
+    collision->term_type = TT_COST;
+    collision->continuous = config.collision_continuous_;
+    collision->first_step = 0;
+    collision->last_step = pci.basic_info.n_steps - 1;
+    collision->gap = 1;
+    collision->info = createSafetyMarginDataVector(pci.basic_info.n_steps, config.collision_safety_margin_, 20);
+    pci.cost_infos.push_back(collision);
+  }
+  if (config.smooth_velocities_)
+  {
+    std::shared_ptr<JointVelTermInfo> jv = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
+    jv->coeffs = std::vector<double>(pci.kin->numJoints(), 5.0);
+    jv->targets = std::vector<double>(pci.kin->numJoints(), 0.0);
+    jv->first_step = 0;
+    jv->last_step = pci.basic_info.n_steps - 1;
+    jv->name = "joint_velocity_cost";
+    jv->term_type = TT_COST;
+    pci.cost_infos.push_back(jv);
+  }
+  if (config.smooth_accelerations_)
+  {
+    std::shared_ptr<JointAccTermInfo> ja = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+    ja->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+    ja->targets = std::vector<double>(pci.kin->numJoints(), 0.0);
+    ja->first_step = 0;
+    ja->last_step = pci.basic_info.n_steps - 1;
+    ja->name = "joint_accel_cost";
+    ja->term_type = TT_COST;
+    pci.cost_infos.push_back(ja);
+  }
+  if (config.smooth_jerks_)
+  {
+    std::shared_ptr<JointJerkTermInfo> jj = std::shared_ptr<JointJerkTermInfo>(new JointJerkTermInfo);
+    jj->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+    jj->targets = std::vector<double>(pci.kin->numJoints(), 0.0);
+    jj->first_step = 0;
+    jj->last_step = pci.basic_info.n_steps - 1;
+    jj->name = "joint_jerk_cost";
+    jj->term_type = TT_COST;
+    pci.cost_infos.push_back(jj);
+  }
+  trajopt::TrajOptProbPtr prob = ConstructProblem(pci);
+
+  // -------- Solve the problem ------------
+  // ---------------------------------------
+  // Set the parameters in trajopt_planner
+  tesseract::tesseract_planning::TrajOptPlannerConfig config_planner(prob);
+  config_planner.params = config.params_;
+  config_planner.callbacks = config.callbacks_;
+
+  // Create Plot Callback
+  if (config.plot_callback_)
+  {
+    tesseract::tesseract_ros::ROSBasicPlottingPtr plotter_ptr(
+        new tesseract::tesseract_ros::ROSBasicPlotting(config.env_));
+    config_planner.callbacks.push_back(PlotCallback(*prob, plotter_ptr));
+  }
+
+  tesseract::tesseract_planning::TrajOptPlanner planner;
+  tesseract::tesseract_planning::PlannerResponse planning_response;
+
+  // Solve problem. Results are stored in the response
+  bool success = planner.solve(planning_response, config_planner);
+  response = planning_response;
+
+  return success;
+}
+
+bool TrajOptArrayPlanner::terminate() { return false; }
+void TrajOptArrayPlanner::clear() { request_ = PlannerRequest(); }
+}  // namespace tesseract_planning
+}  // namespace tesseract

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -63,7 +63,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
 
   // Populate Basic Info
   pci.basic_info.n_steps = config.num_steps_;
-  pci.basic_info.manip = manipulator_;
+  pci.basic_info.manip = config.manipulator_;
   pci.basic_info.start_fixed = false;
   pci.basic_info.use_time = false;
 

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -1,0 +1,217 @@
+/**
+ * @file trajopt_planner.cpp
+ * @brief Tesseract ROS Trajopt planner
+ *
+ * @author Levi Armstrong
+ * @date April 18, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_core/macros.h>
+TESSERACT_IGNORE_WARNINGS_PUSH
+#include <jsoncpp/json/json.h>
+#include <ros/console.h>
+#include <trajopt/plot_callback.hpp>
+#include <trajopt/problem_description.hpp>
+#include <trajopt_utils/config.hpp>
+#include <trajopt_utils/logging.hpp>
+#include <trajopt_sco/optimizers.hpp>
+#include <trajopt_sco/sco_common.hpp>
+TESSERACT_IGNORE_WARNINGS_POP
+
+#include <tesseract_planning/trajopt/trajopt_freespace_planner.h>
+#include <tesseract_planning/trajopt/trajopt_planner.h>
+
+// This is probably an issue
+#include <tesseract_ros/ros_basic_plotting.h>
+#include <trajopt/plot_callback.hpp>
+
+using namespace trajopt;
+
+namespace tesseract
+{
+namespace tesseract_planning
+{
+bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespacePlannerConfig& config)
+{
+  // Check that parameters are valid
+  if (config.env_ == nullptr)
+    throw std::invalid_argument("In trajopt_freespace_planner: env_ is a required parameter and has not been set");
+  if (config.kin_ == nullptr)
+    throw std::invalid_argument("In trajopt_freespace_planner: kin_ is a required parameter and has not been set");
+
+  // -------- Construct the problem ------------
+  // -------------------------------------------
+  ProblemConstructionInfo pci(config.env_);
+  pci.kin = config.kin_;
+
+  // Populate Basic Info
+  pci.basic_info.n_steps = config.num_steps_;
+  pci.basic_info.manip = manipulator_;
+  pci.basic_info.start_fixed = false;
+  pci.basic_info.use_time = false;
+
+  // Populate Init Info
+  pci.init_info.type = trajopt::InitInfo::STATIONARY;
+
+  // Set initial point
+  auto start_type = config.start_waypoint_->getType();
+  switch (start_type)
+  {
+    case tesseract::tesseract_planning::JOINT_WAYPOINT:
+    {
+      JointWaypointPtr start_position = std::static_pointer_cast<JointWaypoint>(config.start_waypoint_);
+      // Add initial joint position constraint
+      std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+      jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+      jv->targets = start_position->joint_positions_;
+      jv->first_step = 0;
+      jv->last_step = 0;
+      jv->name = "initial_joint_position";
+      jv->term_type = TT_CNT;
+      pci.cnt_infos.push_back(jv);
+      break;
+    }
+    case tesseract::tesseract_planning::CARTESIAN_WAYPOINT:
+    {
+      CartesianWaypointPtr start_pose = std::static_pointer_cast<CartesianWaypoint>(config.start_waypoint_);
+      std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
+      pose->term_type = TT_CNT;
+      pose->name = "initial_cartesian_position";
+      pose->link = config.end_effector_;
+      pose->timestep = 0;
+      pose->xyz = start_pose->getPosition();
+      pose->wxyz = start_pose->getOrientation();
+      pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+      pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+      pci.cnt_infos.push_back(pose);
+      break;
+    }
+  }
+
+  // Set final point
+  auto end_type = config.end_waypoint_->getType();
+  switch (end_type)
+  {
+    case tesseract::tesseract_planning::JOINT_WAYPOINT:
+    {
+      JointWaypointPtr end_position = std::static_pointer_cast<JointWaypoint>(config.end_waypoint_);
+      // Add initial joint position constraint
+      std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+      jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+      jv->targets = end_position->joint_positions_;
+      jv->first_step = pci.basic_info.n_steps - 1;
+      jv->last_step = pci.basic_info.n_steps - 1;
+      jv->name = "target_joint_position";
+      jv->term_type = TT_CNT;
+      pci.cnt_infos.push_back(jv);
+    }
+    case tesseract::tesseract_planning::CARTESIAN_WAYPOINT:
+    {
+      CartesianWaypointPtr end_pose = std::static_pointer_cast<CartesianWaypoint>(config.end_waypoint_);
+      std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
+      pose->term_type = TT_CNT;
+      pose->name = "target_cartesian_position";
+      pose->link = config.end_effector_;
+      pose->timestep = pci.basic_info.n_steps - 1;
+      pose->xyz = end_pose->getPosition();
+      pose->wxyz = end_pose->getOrientation();
+      pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+      pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+      pci.cnt_infos.push_back(pose);
+    }
+  }
+
+  // Set costs for the rest of the points
+  if (config.collision_check_)
+  {
+    std::shared_ptr<CollisionTermInfo> collision = std::shared_ptr<CollisionTermInfo>(new CollisionTermInfo);
+    collision->name = "collision_cost";
+    collision->term_type = TT_COST;
+    collision->continuous = config.collision_continuous_;
+    collision->first_step = 0;
+    collision->last_step = pci.basic_info.n_steps - 1;
+    collision->gap = 1;
+    collision->info = createSafetyMarginDataVector(pci.basic_info.n_steps, config.collision_safety_margin_, 20);
+    pci.cost_infos.push_back(collision);
+  }
+  if (config.smooth_velocities_)
+  {
+    std::shared_ptr<JointVelTermInfo> jv = std::shared_ptr<JointVelTermInfo>(new JointVelTermInfo);
+    jv->coeffs = std::vector<double>(pci.kin->numJoints(), 5.0);
+    jv->targets = std::vector<double>(pci.kin->numJoints(), 0.0);
+    jv->first_step = 0;
+    jv->last_step = pci.basic_info.n_steps - 1;
+    jv->name = "joint_velocity_cost";
+    jv->term_type = TT_COST;
+    pci.cost_infos.push_back(jv);
+  }
+  if (config.smooth_accelerations_)
+  {
+    std::shared_ptr<JointAccTermInfo> ja = std::shared_ptr<JointAccTermInfo>(new JointAccTermInfo);
+    ja->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+    ja->targets = std::vector<double>(pci.kin->numJoints(), 0.0);
+    ja->first_step = 0;
+    ja->last_step = pci.basic_info.n_steps - 1;
+    ja->name = "joint_accel_cost";
+    ja->term_type = TT_COST;
+    pci.cost_infos.push_back(ja);
+  }
+  if (config.smooth_jerks_)
+  {
+    std::shared_ptr<JointJerkTermInfo> jj = std::shared_ptr<JointJerkTermInfo>(new JointJerkTermInfo);
+    jj->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+    jj->targets = std::vector<double>(pci.kin->numJoints(), 0.0);
+    jj->first_step = 0;
+    jj->last_step = pci.basic_info.n_steps - 1;
+    jj->name = "joint_jerk_cost";
+    jj->term_type = TT_COST;
+    pci.cost_infos.push_back(jj);
+  }
+  trajopt::TrajOptProbPtr prob = ConstructProblem(pci);
+
+  // -------- Solve the problem ------------
+  // ---------------------------------------
+  // Set the parameters in trajopt_planner
+  tesseract::tesseract_planning::TrajOptPlannerConfig config_planner(prob);
+  config_planner.params = config.params_;
+  config_planner.callbacks = config.callbacks_;
+
+  // Create Plot Callback
+  if (config.plot_callback_)
+  {
+    tesseract::tesseract_ros::ROSBasicPlottingPtr plotter_ptr(
+        new tesseract::tesseract_ros::ROSBasicPlotting(config.env_));
+    config_planner.callbacks.push_back(PlotCallback(*prob, plotter_ptr));
+  }
+
+  tesseract::tesseract_planning::TrajOptPlanner planner;
+  tesseract::tesseract_planning::PlannerResponse planning_response;
+
+  // Solve problem. Results are stored in the response
+  bool success = planner.solve(planning_response, config_planner);
+  response = planning_response;
+
+  return success;
+}
+
+bool TrajOptFreespacePlanner::terminate() { return false; }
+void TrajOptFreespacePlanner::clear() { request_ = PlannerRequest(); }
+}  // namespace tesseract_planning
+}  // namespace tesseract

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -74,7 +74,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
   auto start_type = config.start_waypoint_->getType();
   switch (start_type)
   {
-    case tesseract::tesseract_planning::JOINT_WAYPOINT:
+    case tesseract::tesseract_planning::WaypointType::JOINT_WAYPOINT:
     {
       JointWaypointPtr start_position = std::static_pointer_cast<JointWaypoint>(config.start_waypoint_);
       // Add initial joint position constraint
@@ -88,7 +88,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       pci.cnt_infos.push_back(jv);
       break;
     }
-    case tesseract::tesseract_planning::CARTESIAN_WAYPOINT:
+    case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
     {
       CartesianWaypointPtr start_pose = std::static_pointer_cast<CartesianWaypoint>(config.start_waypoint_);
       std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
@@ -109,7 +109,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
   auto end_type = config.end_waypoint_->getType();
   switch (end_type)
   {
-    case tesseract::tesseract_planning::JOINT_WAYPOINT:
+    case tesseract::tesseract_planning::WaypointType::JOINT_WAYPOINT:
     {
       JointWaypointPtr end_position = std::static_pointer_cast<JointWaypoint>(config.end_waypoint_);
       // Add initial joint position constraint
@@ -122,7 +122,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       jv->term_type = TT_CNT;
       pci.cnt_infos.push_back(jv);
     }
-    case tesseract::tesseract_planning::CARTESIAN_WAYPOINT:
+    case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
     {
       CartesianWaypointPtr end_pose = std::static_pointer_cast<CartesianWaypoint>(config.end_waypoint_);
       std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);


### PR DESCRIPTION
I imagine we will want to revisit these at some point when we figure out exactly what we want this API to look like, but they do work. They solve the immediate need of an easier way to use Trajopt.

This adds a freespace planner and an array planner. The freespace planner plans between a start and end position with some number of steps. The array planner plans along a given list of poses (e.g. like you might find in a ROS PoseArray msg). Both of them generate the TrajOpt problem and solve it internally based on the information in the config file. I also add the Waypoint base class along with cartesian_waypoint and joint_waypoint. Again, we may want to revisit exactly what is in those at a later date.

To test, you can use my example here https://github.com/mpowelson/trajopt_ros/tree/feature/tesseract_planner_example
`roslaunch trajopt_examples raster_path_plan.launch`