### PR TITLE
Tesseract planner improvements

### DIFF
--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
@@ -59,6 +59,12 @@ struct TrajOptArrayPlannerConfig
   trajopt::InitInfo::Type init_type_ = trajopt::InitInfo::STATIONARY;
   /** @brief The trajectory used as the optimization seed when init_type_ is set to GIVEN_TRAJ */
   trajopt::TrajArray seed_trajectory_;
+  /** @brief This joint waypoint represents the desired configuration (Optional). This is not guaranteed, but a small equality cost
+   * is set to the joint position for all points to pull the optimization in that direction.
+   *
+   * An example use case is setting it to be at the center of the joint limits. This tends to pull the robot away from
+   * singularities */
+  JointWaypointConstPtr configuration_ = std::make_shared<JointWaypoint>();
 
   /** @brief If true, collision checking will be enabled. Default: true*/
   bool collision_check_ = true;

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_array_planner.h
@@ -50,7 +50,6 @@ struct TrajOptArrayPlannerConfig
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   TrajOptArrayPlannerConfig() {}
-  virtual ~TrajOptArrayPlannerConfig() {}
   /** @brief Vector of target waypoints given as constraints to the optimization */
   std::vector<WaypointPtr> target_waypoints_;
 
@@ -59,8 +58,8 @@ struct TrajOptArrayPlannerConfig
   trajopt::InitInfo::Type init_type_ = trajopt::InitInfo::STATIONARY;
   /** @brief The trajectory used as the optimization seed when init_type_ is set to GIVEN_TRAJ */
   trajopt::TrajArray seed_trajectory_;
-  /** @brief This joint waypoint represents the desired configuration (Optional). This is not guaranteed, but a small equality cost
-   * is set to the joint position for all points to pull the optimization in that direction.
+  /** @brief This joint waypoint represents the desired configuration (Optional). This is not guaranteed, but a small
+   * equality cost is set to the joint position for all points to pull the optimization in that direction.
    *
    * An example use case is setting it to be at the center of the joint limits. This tends to pull the robot away from
    * singularities */

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
@@ -67,6 +67,12 @@ struct TrajOptFreespacePlannerConfig
   trajopt::InitInfo::Type init_type_ = trajopt::InitInfo::STATIONARY;
   /** @brief The trajectory used as the optimization seed when init_type_ is set to GIVEN_TRAJ */
   trajopt::TrajArray seed_trajectory_;
+  /** @brief This joint waypoint represents the desired configuration (Optional). This is not guaranteed, but a small equality cost
+   * is set to the joint position for all points to pull the optimization in that direction.
+   *
+   * An example use case is setting it to be at the center of the joint limits. This tends to pull the robot away from
+   * singularities */
+  JointWaypointConstPtr configuration_ = std::make_shared<JointWaypoint>();
 
   /** @brief If true, collision checking will be enabled. Default: true*/
   bool collision_check_ = true;

--- a/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
+++ b/tesseract_planning/include/tesseract_planning/trajopt/trajopt_freespace_planner.h
@@ -52,7 +52,6 @@ struct TrajOptFreespacePlannerConfig
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   TrajOptFreespacePlannerConfig() {}
-  virtual ~TrajOptFreespacePlannerConfig() {}
   /** @brief Determines the constraint placed at the start of the trajectory */
   WaypointPtr start_waypoint_;
   /** @brief Determines the constraint placed at the end of the trajectory */
@@ -67,8 +66,8 @@ struct TrajOptFreespacePlannerConfig
   trajopt::InitInfo::Type init_type_ = trajopt::InitInfo::STATIONARY;
   /** @brief The trajectory used as the optimization seed when init_type_ is set to GIVEN_TRAJ */
   trajopt::TrajArray seed_trajectory_;
-  /** @brief This joint waypoint represents the desired configuration (Optional). This is not guaranteed, but a small equality cost
-   * is set to the joint position for all points to pull the optimization in that direction.
+  /** @brief This joint waypoint represents the desired configuration (Optional). This is not guaranteed, but a small
+   * equality cost is set to the joint position for all points to pull the optimization in that direction.
    *
    * An example use case is setting it to be at the center of the joint limits. This tends to pull the robot away from
    * singularities */

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -41,13 +41,11 @@ enum class WaypointType
   JOINT_TOLERANCED_WAYPOINT,
   CARTESIAN_WAYPOINT,
 };
-// TODO: Doxygen
 /** @brief Defines a generic way of sending waypoints to a Tesseract Planner */
 class Waypoint
 {
 public:
   Waypoint() {}
-  virtual ~Waypoint() {}
   /** @brief Returns the type of waypoint so that it may be cast back to the derived type */
   WaypointType getType() const { return waypoint_type_; }
   /** @brief Used to weight different terms in the waypoint. (Optional)
@@ -59,6 +57,7 @@ public:
 
   Example: In Trajopt, is_critical=true => constraint, is_critical=false => cost*/
   bool is_critical_ = true;
+
 protected:
   /** @brief Should be set by the derived class for casting Waypoint back to appropriate derived class type */
   WaypointType waypoint_type_;
@@ -69,8 +68,8 @@ class JointWaypoint : public Waypoint
 public:
   // TODO: constructor that takes joint position vector
   JointWaypoint() { waypoint_type_ = WaypointType::JOINT_WAYPOINT; }
-  virtual ~JointWaypoint() {}
-  /** Stores the joint values associated with this waypoint (radians) */
+  /** Stores the joint values associated with this waypoint (radians). Must be in the same order as the joints in the
+   * kinematics object*/
   Eigen::VectorXd joint_positions_;
 };
 /** @brief Defines a cartesian position waypoint for use with Tesseract Planners */
@@ -80,7 +79,6 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CartesianWaypoint() { waypoint_type_ = WaypointType::CARTESIAN_WAYPOINT; }
-  virtual ~CartesianWaypoint() {}
   /** @brief Contains the position and orientation of this waypoint */
   Eigen::Isometry3d cartesian_position_;
 
@@ -103,7 +101,6 @@ class JointTolerancedWaypoint : public Waypoint
 public:
   // TODO: constructor that takes joint position vector
   JointTolerancedWaypoint() { waypoint_type_ = WaypointType::JOINT_TOLERANCED_WAYPOINT; }
-  virtual ~JointTolerancedWaypoint() {}
   /** @brief Stores the joint values associated with this waypoint (radians) */
   Eigen::VectorXd joint_positions_;
   /** @brief Amount over joint_positions_ that is allowed (positive radians).

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -37,8 +37,9 @@ namespace tesseract_planning
 /** @brief Used to specify the type of waypoint. Corresponds to a derived class of Waypoint*/
 enum class WaypointType
 {
-  JOINT_WAYPOINT = 0x1,      // 0000 0001
-  CARTESIAN_WAYPOINT = 0x2,  // 0000 0010
+  JOINT_WAYPOINT,
+  JOINT_TOLERANCED_WAYPOINT,
+  CARTESIAN_WAYPOINT,
 };
 // TODO: Doxygen
 /** @brief Defines a generic way of sending waypoints to a Tesseract Planner */
@@ -96,12 +97,34 @@ public:
   }
 };
 
+/** @brief Defines a joint toleranced position waypoint for use with Tesseract Planners*/
+class JointTolerancedWaypoint : public Waypoint
+{
+public:
+  // TODO: constructor that takes joint position vector
+  JointTolerancedWaypoint() { waypoint_type_ = WaypointType::JOINT_TOLERANCED_WAYPOINT; }
+  virtual ~JointTolerancedWaypoint() {}
+  /** @brief Stores the joint values associated with this waypoint (radians) */
+  Eigen::VectorXd joint_positions_;
+  /** @brief Amount over joint_positions_ that is allowed (positive radians).
+
+  The allowed range is joint_positions-lower_tolerance_ to joint_positions_+upper_tolerance*/
+  Eigen::VectorXd upper_tolerance_;
+  /** @brief Amount under joint_positions_ that is allowed (negative radians).
+
+  The allowed range is joint_positions-lower_tolerance_ to joint_positions_+upper_tolerance*/
+  Eigen::VectorXd lower_tolerance_;
+};
+
 typedef std::shared_ptr<Waypoint> WaypointPtr;
 typedef std::shared_ptr<const Waypoint> WaypointConstPtr;
 typedef std::shared_ptr<JointWaypoint> JointWaypointPtr;
 typedef std::shared_ptr<const JointWaypoint> JointWaypointConstPtr;
+typedef std::shared_ptr<JointTolerancedWaypoint> JointTolerancedWaypointPtr;
+typedef std::shared_ptr<const JointTolerancedWaypoint> JointTolerancedWaypointConstPtr;
 typedef std::shared_ptr<CartesianWaypoint> CartesianWaypointPtr;
 typedef std::shared_ptr<const CartesianWaypoint> CartesianWaypointConstPtr;
+
 }  // namespace tesseract_planning
 }  // namespace tesseract
 #endif

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -49,6 +49,11 @@ public:
   virtual ~Waypoint() {}
   /** @brief Returns the type of waypoint so that it may be cast back to the derived type */
   WaypointType getType() const { return waypoint_type_; }
+  /** @brief Used to weight different terms in the waypoint. (Optional)
+   *
+   * For example: joint 1 vs joint 2 of the same waypoint or waypoint 1 vs waypoint 2
+   * Note: Each planner should define defaults for this when they are not set.*/
+  Eigen::VectorXd coeffs_;
 protected:
   /** @brief Should be set by the derived class for casting Waypoint back to appropriate derived class type */
   WaypointType waypoint_type_;

--- a/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
+++ b/tesseract_planning/include/tesseract_planning/waypoint_definitions.h
@@ -54,6 +54,10 @@ public:
    * For example: joint 1 vs joint 2 of the same waypoint or waypoint 1 vs waypoint 2
    * Note: Each planner should define defaults for this when they are not set.*/
   Eigen::VectorXd coeffs_;
+  /** @brief If false, this value is used as a guide rather than a rigid waypoint (Default=true)
+
+  Example: In Trajopt, is_critical=true => constraint, is_critical=false => cost*/
+  bool is_critical_ = true;
 protected:
   /** @brief Should be set by the derived class for casting Waypoint back to appropriate derived class type */
   WaypointType waypoint_type_;

--- a/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
@@ -93,15 +93,15 @@ bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPla
         jv->first_step = static_cast<int>(ind);
         jv->last_step = static_cast<int>(ind);
         jv->name = "joint_position";
-        jv->term_type = TT_CNT;
-        pci.cnt_infos.push_back(jv);
+        jv->term_type = joint_waypoint->is_critical_ ? TT_CNT : TT_COST;
+        joint_waypoint->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
         break;
       }
       case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
       {
         CartesianWaypointPtr cart_waypoint = std::static_pointer_cast<CartesianWaypoint>(config.target_waypoints_[ind]);
         std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
-        pose->term_type = TT_CNT;
+        pose->term_type = cart_waypoint->is_critical_ ? TT_CNT : TT_COST;
         pose->name = "cartesian_position";
         pose->link = config.link_;
         pose->tcp = config.tcp_;
@@ -119,7 +119,7 @@ bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPla
           pose->pos_coeffs = coeffs.head<3>();
           pose->rot_coeffs = coeffs.tail<3>();
         }
-        pci.cnt_infos.push_back(pose);
+        cart_waypoint->is_critical_ ? pci.cnt_infos.push_back(pose) : pci.cost_infos.push_back(pose);
         break;
       }
     }

--- a/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_array_planner.cpp
@@ -215,6 +215,27 @@ bool TrajOptArrayPlanner::solve(PlannerResponse& response, const TrajOptArrayPla
     jj->term_type = TT_COST;
     pci.cost_infos.push_back(jj);
   }
+  // Add configuration cost
+  if (config.configuration_->joint_positions_.size() > 0)
+  {
+    assert(config.configuration_->joint_positions_.size() == pci.kin->numJoints());
+    JointWaypointConstPtr joint_waypoint = config.configuration_;
+    std::shared_ptr<JointPosTermInfo> jp = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+    Eigen::VectorXd coeffs = joint_waypoint->coeffs_;
+    if (coeffs.size() != pci.kin->numJoints())
+      jp->coeffs = std::vector<double>(pci.kin->numJoints(), 0.1);  // Default value
+    else
+      jp->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
+    jp->targets =
+        std::vector<double>(joint_waypoint->joint_positions_.data(),
+                            joint_waypoint->joint_positions_.data() + joint_waypoint->joint_positions_.size());
+    jp->first_step = 0;
+    jp->last_step = pci.basic_info.n_steps - 1;
+    jp->name = "configuration_cost";
+    jp->term_type = TT_COST;
+    pci.cost_infos.push_back(jp);
+  }
+
   trajopt::TrajOptProbPtr prob = ConstructProblem(pci);
 
   // -------- Solve the problem ------------

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -96,6 +96,47 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       start_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
       break;
     }
+  case tesseract::tesseract_planning::WaypointType::JOINT_TOLERANCED_WAYPOINT:
+  {
+    // For a toleranced waypoint we add an inequality term and a smaller equality term. This acts as a "leaky" hinge
+    // to keep the problem numerically stable.
+    JointTolerancedWaypointPtr start_position = std::static_pointer_cast<JointTolerancedWaypoint>(config.start_waypoint_);
+    std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+    Eigen::VectorXd coeffs = start_position->coeffs_;
+    if (coeffs.size() != pci.kin->numJoints())
+      jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);  // Default value
+    else
+      jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
+    jv->targets = std::vector<double>(start_position->joint_positions_.data(),
+                                      start_position->joint_positions_.data() + start_position->joint_positions_.size());
+    jv->upper_tols =
+        std::vector<double>(start_position->upper_tolerance_.data(),
+                            start_position->upper_tolerance_.data() + start_position->upper_tolerance_.size());
+    jv->lower_tols =
+        std::vector<double>(start_position->lower_tolerance_.data(),
+                            start_position->lower_tolerance_.data() + start_position->lower_tolerance_.size());
+    jv->first_step = pci.basic_info.n_steps - 1;
+    jv->last_step = pci.basic_info.n_steps - 1;
+    jv->name = "initial_joint_toleranced_position";
+    jv->term_type = start_position->is_critical_ ? TT_CNT : TT_COST;
+    start_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
+
+    // Equality cost with coeffs much smaller than inequality
+    std::shared_ptr<JointPosTermInfo> jv_equal = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+    std::vector<double> leaky_coeffs;
+    for (auto& ind : jv->coeffs)
+      leaky_coeffs.push_back(ind * 0.1);
+    jv_equal->coeffs = leaky_coeffs;
+    jv_equal->targets = std::vector<double>(start_position->joint_positions_.data(),
+                                      start_position->joint_positions_.data() + start_position->joint_positions_.size());
+    jv_equal->first_step = pci.basic_info.n_steps - 1;
+    jv_equal->last_step = pci.basic_info.n_steps - 1;
+    jv_equal->name = "initial_joint_toleranced_position_leaky";
+    // If this was a CNT, then the inequality tolernce would not do anything
+    jv_equal->term_type = TT_COST;
+    pci.cost_infos.push_back(jv_equal);
+    break;
+  }
     case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
     {
       CartesianWaypointPtr start_pose = std::static_pointer_cast<CartesianWaypoint>(config.start_waypoint_);
@@ -144,6 +185,47 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       jv->name = "target_joint_position";
       jv->term_type = end_position->is_critical_ ? TT_CNT : TT_COST;
       end_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
+      break;
+    }
+    case tesseract::tesseract_planning::WaypointType::JOINT_TOLERANCED_WAYPOINT:
+    {
+      // For a toleranced waypoint we add an inequality term and a smaller equality term. This acts as a "leaky" hinge
+      // to keep the problem numerically stable.
+      JointTolerancedWaypointPtr end_position = std::static_pointer_cast<JointTolerancedWaypoint>(config.end_waypoint_);
+      std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+      Eigen::VectorXd coeffs = end_position->coeffs_;
+      if (coeffs.size() != pci.kin->numJoints())
+        jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);  // Default value
+      else
+        jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
+      jv->targets = std::vector<double>(end_position->joint_positions_.data(),
+                                        end_position->joint_positions_.data() + end_position->joint_positions_.size());
+      jv->upper_tols =
+          std::vector<double>(end_position->upper_tolerance_.data(),
+                              end_position->upper_tolerance_.data() + end_position->upper_tolerance_.size());
+      jv->lower_tols =
+          std::vector<double>(end_position->lower_tolerance_.data(),
+                              end_position->lower_tolerance_.data() + end_position->lower_tolerance_.size());
+      jv->first_step = pci.basic_info.n_steps - 1;
+      jv->last_step = pci.basic_info.n_steps - 1;
+      jv->name = "target_joint_toleranced_position";
+      jv->term_type = end_position->is_critical_ ? TT_CNT : TT_COST;
+      end_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
+
+      // Equality cost with coeffs much smaller than inequality
+      std::shared_ptr<JointPosTermInfo> jv_equal = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+      std::vector<double> leaky_coeffs;
+      for (auto& ind : jv->coeffs)
+        leaky_coeffs.push_back(ind * 0.1);
+      jv_equal->coeffs = leaky_coeffs;
+      jv_equal->targets = std::vector<double>(end_position->joint_positions_.data(),
+                                        end_position->joint_positions_.data() + end_position->joint_positions_.size());
+      jv_equal->first_step = pci.basic_info.n_steps - 1;
+      jv_equal->last_step = pci.basic_info.n_steps - 1;
+      jv_equal->name = "joint_toleranced_position_leaky";
+      // If this was a CNT, then the inequality tolernce would not do anything
+      jv_equal->term_type = TT_COST;
+      pci.cost_infos.push_back(jv_equal);
       break;
     }
     case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -96,47 +96,50 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       start_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
       break;
     }
-  case tesseract::tesseract_planning::WaypointType::JOINT_TOLERANCED_WAYPOINT:
-  {
-    // For a toleranced waypoint we add an inequality term and a smaller equality term. This acts as a "leaky" hinge
-    // to keep the problem numerically stable.
-    JointTolerancedWaypointPtr start_position = std::static_pointer_cast<JointTolerancedWaypoint>(config.start_waypoint_);
-    std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
-    Eigen::VectorXd coeffs = start_position->coeffs_;
-    if (coeffs.size() != pci.kin->numJoints())
-      jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);  // Default value
-    else
-      jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
-    jv->targets = std::vector<double>(start_position->joint_positions_.data(),
-                                      start_position->joint_positions_.data() + start_position->joint_positions_.size());
-    jv->upper_tols =
-        std::vector<double>(start_position->upper_tolerance_.data(),
-                            start_position->upper_tolerance_.data() + start_position->upper_tolerance_.size());
-    jv->lower_tols =
-        std::vector<double>(start_position->lower_tolerance_.data(),
-                            start_position->lower_tolerance_.data() + start_position->lower_tolerance_.size());
-    jv->first_step = pci.basic_info.n_steps - 1;
-    jv->last_step = pci.basic_info.n_steps - 1;
-    jv->name = "initial_joint_toleranced_position";
-    jv->term_type = start_position->is_critical_ ? TT_CNT : TT_COST;
-    start_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
+    case tesseract::tesseract_planning::WaypointType::JOINT_TOLERANCED_WAYPOINT:
+    {
+      // For a toleranced waypoint we add an inequality term and a smaller equality term. This acts as a "leaky" hinge
+      // to keep the problem numerically stable.
+      JointTolerancedWaypointPtr start_position =
+          std::static_pointer_cast<JointTolerancedWaypoint>(config.start_waypoint_);
+      std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+      Eigen::VectorXd coeffs = start_position->coeffs_;
+      if (coeffs.size() != pci.kin->numJoints())
+        jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);  // Default value
+      else
+        jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
+      jv->targets =
+          std::vector<double>(start_position->joint_positions_.data(),
+                              start_position->joint_positions_.data() + start_position->joint_positions_.size());
+      jv->upper_tols =
+          std::vector<double>(start_position->upper_tolerance_.data(),
+                              start_position->upper_tolerance_.data() + start_position->upper_tolerance_.size());
+      jv->lower_tols =
+          std::vector<double>(start_position->lower_tolerance_.data(),
+                              start_position->lower_tolerance_.data() + start_position->lower_tolerance_.size());
+      jv->first_step = pci.basic_info.n_steps - 1;
+      jv->last_step = pci.basic_info.n_steps - 1;
+      jv->name = "initial_joint_toleranced_position";
+      jv->term_type = start_position->is_critical_ ? TT_CNT : TT_COST;
+      start_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
 
-    // Equality cost with coeffs much smaller than inequality
-    std::shared_ptr<JointPosTermInfo> jv_equal = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
-    std::vector<double> leaky_coeffs;
-    for (auto& ind : jv->coeffs)
-      leaky_coeffs.push_back(ind * 0.1);
-    jv_equal->coeffs = leaky_coeffs;
-    jv_equal->targets = std::vector<double>(start_position->joint_positions_.data(),
-                                      start_position->joint_positions_.data() + start_position->joint_positions_.size());
-    jv_equal->first_step = pci.basic_info.n_steps - 1;
-    jv_equal->last_step = pci.basic_info.n_steps - 1;
-    jv_equal->name = "initial_joint_toleranced_position_leaky";
-    // If this was a CNT, then the inequality tolernce would not do anything
-    jv_equal->term_type = TT_COST;
-    pci.cost_infos.push_back(jv_equal);
-    break;
-  }
+      // Equality cost with coeffs much smaller than inequality
+      std::shared_ptr<JointPosTermInfo> jv_equal = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
+      std::vector<double> leaky_coeffs;
+      for (auto& ind : jv->coeffs)
+        leaky_coeffs.push_back(ind * 0.1);
+      jv_equal->coeffs = leaky_coeffs;
+      jv_equal->targets =
+          std::vector<double>(start_position->joint_positions_.data(),
+                              start_position->joint_positions_.data() + start_position->joint_positions_.size());
+      jv_equal->first_step = pci.basic_info.n_steps - 1;
+      jv_equal->last_step = pci.basic_info.n_steps - 1;
+      jv_equal->name = "initial_joint_toleranced_position_leaky";
+      // If this was a CNT, then the inequality tolernce would not do anything
+      jv_equal->term_type = TT_COST;
+      pci.cost_infos.push_back(jv_equal);
+      break;
+    }
     case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
     {
       CartesianWaypointPtr start_pose = std::static_pointer_cast<CartesianWaypoint>(config.start_waypoint_);
@@ -218,8 +221,9 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       for (auto& ind : jv->coeffs)
         leaky_coeffs.push_back(ind * 0.1);
       jv_equal->coeffs = leaky_coeffs;
-      jv_equal->targets = std::vector<double>(end_position->joint_positions_.data(),
-                                        end_position->joint_positions_.data() + end_position->joint_positions_.size());
+      jv_equal->targets =
+          std::vector<double>(end_position->joint_positions_.data(),
+                              end_position->joint_positions_.data() + end_position->joint_positions_.size());
       jv_equal->first_step = pci.basic_info.n_steps - 1;
       jv_equal->last_step = pci.basic_info.n_steps - 1;
       jv_equal->name = "joint_toleranced_position_leaky";

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -81,7 +81,11 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       JointWaypointPtr start_position = std::static_pointer_cast<JointWaypoint>(config.start_waypoint_);
       // Add initial joint position constraint
       std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
-      jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+      Eigen::VectorXd coeffs = start_position->coeffs_;
+      if (coeffs.size() != pci.kin->numJoints())
+        jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);  // Default value
+      else
+        jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
       jv->targets =
           std::vector<double>(start_position->joint_positions_.data(),
                               start_position->joint_positions_.data() + start_position->joint_positions_.size());
@@ -103,8 +107,17 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       pose->timestep = 0;
       pose->xyz = start_pose->getPosition();
       pose->wxyz = start_pose->getOrientation();
-      pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
-      pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+      Eigen::VectorXd coeffs = start_pose->coeffs_;
+      if (coeffs.size() != 6)
+      {
+        pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+        pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+      }
+      else
+      {
+        pose->pos_coeffs = coeffs.head<3>();
+        pose->rot_coeffs = coeffs.tail<3>();
+      }
       pci.cnt_infos.push_back(pose);
       break;
     }
@@ -119,7 +132,11 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       JointWaypointPtr end_position = std::static_pointer_cast<JointWaypoint>(config.end_waypoint_);
       // Add initial joint position constraint
       std::shared_ptr<JointPosTermInfo> jv = std::shared_ptr<JointPosTermInfo>(new JointPosTermInfo);
-      jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);
+      Eigen::VectorXd coeffs = end_position->coeffs_;
+      if (coeffs.size() != pci.kin->numJoints())
+        jv->coeffs = std::vector<double>(pci.kin->numJoints(), 1.0);  // Default value
+      else
+        jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
       jv->targets = std::vector<double>(end_position->joint_positions_.data(),
                                         end_position->joint_positions_.data() + end_position->joint_positions_.size());
       jv->first_step = pci.basic_info.n_steps - 1;
@@ -140,8 +157,17 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       pose->timestep = pci.basic_info.n_steps - 1;
       pose->xyz = end_pose->getPosition();
       pose->wxyz = end_pose->getOrientation();
-      pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
-      pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+      Eigen::VectorXd coeffs = end_pose->coeffs_;
+      if (coeffs.size() != 6)
+      {
+        pose->pos_coeffs = Eigen::Vector3d(10, 10, 10);
+        pose->rot_coeffs = Eigen::Vector3d(10, 10, 10);
+      }
+      else
+      {
+        pose->pos_coeffs = coeffs.head<3>();
+        pose->rot_coeffs = coeffs.tail<3>();
+      }
       pci.cnt_infos.push_back(pose);
       break;
     }

--- a/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
+++ b/tesseract_planning/src/trajopt/trajopt_freespace_planner.cpp
@@ -92,15 +92,15 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       jv->first_step = 0;
       jv->last_step = 0;
       jv->name = "initial_joint_position";
-      jv->term_type = TT_CNT;
-      pci.cnt_infos.push_back(jv);
+      jv->term_type = start_position->is_critical_ ? TT_CNT : TT_COST;
+      start_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
       break;
     }
     case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
     {
       CartesianWaypointPtr start_pose = std::static_pointer_cast<CartesianWaypoint>(config.start_waypoint_);
       std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
-      pose->term_type = TT_CNT;
+      pose->term_type = start_pose->is_critical_ ? TT_CNT : TT_COST;
       pose->name = "initial_cartesian_position";
       pose->link = config.link_;
       pose->tcp = config.tcp_;
@@ -118,7 +118,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
         pose->pos_coeffs = coeffs.head<3>();
         pose->rot_coeffs = coeffs.tail<3>();
       }
-      pci.cnt_infos.push_back(pose);
+      start_pose->is_critical_ ? pci.cnt_infos.push_back(pose) : pci.cost_infos.push_back(pose);
       break;
     }
   }
@@ -142,15 +142,15 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
       jv->first_step = pci.basic_info.n_steps - 1;
       jv->last_step = pci.basic_info.n_steps - 1;
       jv->name = "target_joint_position";
-      jv->term_type = TT_CNT;
-      pci.cnt_infos.push_back(jv);
+      jv->term_type = end_position->is_critical_ ? TT_CNT : TT_COST;
+      end_position->is_critical_ ? pci.cnt_infos.push_back(jv) : pci.cost_infos.push_back(jv);
       break;
     }
     case tesseract::tesseract_planning::WaypointType::CARTESIAN_WAYPOINT:
     {
       CartesianWaypointPtr end_pose = std::static_pointer_cast<CartesianWaypoint>(config.end_waypoint_);
       std::shared_ptr<CartPoseTermInfo> pose = std::shared_ptr<CartPoseTermInfo>(new CartPoseTermInfo);
-      pose->term_type = TT_CNT;
+      pose->term_type = end_pose->is_critical_ ? TT_CNT : TT_COST;
       pose->name = "target_cartesian_position";
       pose->link = config.link_;
       pose->tcp = config.tcp_;
@@ -168,7 +168,7 @@ bool TrajOptFreespacePlanner::solve(PlannerResponse& response, TrajOptFreespaceP
         pose->pos_coeffs = coeffs.head<3>();
         pose->rot_coeffs = coeffs.tail<3>();
       }
-      pci.cnt_infos.push_back(pose);
+      end_pose->is_critical_ ? pci.cnt_infos.push_back(pose) : pci.cost_infos.push_back(pose);
       break;
     }
   }


### PR DESCRIPTION
Adds some desired functions to the array and freespace planners. These correspond to the commits. They should be more or less independent of each other.

- Ability to pass coeffs through for each waypoing
- Ability to declare a waypoint a cost or constraint (note: Naming of this could change)
- Add a toleranced joint waypoint  (No cartesian mostly b/c its not in trajopt yet)
- Add desired configuration parameter - This is a joint cost applied to all of the points in the trajectory to pull it toward a desired configuration. Motivation was a desire to pull the trajectory away from singularities
- Fixed clang warnings