### PR TITLE
Remove catkin buildtool dependencies from tesseract_ext packages

### DIFF
--- a/tesseract_ext/bullet3_ros/package.xml
+++ b/tesseract_ext/bullet3_ros/package.xml
@@ -6,8 +6,6 @@
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/tesseract_ext/fcl_ros/package.xml
+++ b/tesseract_ext/fcl_ros/package.xml
@@ -6,7 +6,6 @@
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
   <depend>libccd</depend>
 
   <export>

--- a/tesseract_ext/libccd_ros/package.xml
+++ b/tesseract_ext/libccd_ros/package.xml
@@ -6,8 +6,6 @@
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
No longer needed since these are ROS-agnostic packages.