### PR TITLE
Avoid flattening collision meshes when parsing URDFs

### DIFF
--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/parser/urdf_parser.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/parser/urdf_parser.h
@@ -205,7 +205,7 @@ inline std::vector<tesseract_geometry::Geometry::Ptr> convert(const urdf::Geomet
             locator(ug.filename), Eigen::Vector3d(ug.scale.x, ug.scale.y, ug.scale.z), true, true);
       else
         meshes = createMeshFromPath<tesseract_geometry::Mesh>(
-            locator(ug.filename), Eigen::Vector3d(ug.scale.x, ug.scale.y, ug.scale.z), true, true);
+            locator(ug.filename), Eigen::Vector3d(ug.scale.x, ug.scale.y, ug.scale.z), true, false);
 
       assert(!meshes.empty());
       g.insert(g.end(), meshes.begin(), meshes.end());


### PR DESCRIPTION
Fix for #114

Does changing this flag break anything else?