### PR TITLE
Update current state

### DIFF
--- a/tesseract/tesseract_environment/src/core/environment.cpp
+++ b/tesseract/tesseract_environment/src/core/environment.cpp
@@ -352,6 +352,10 @@ bool Environment::setActiveDiscreteContactManager(const std::string& name)
 
   discrete_manager_name_ = name;
   discrete_manager_ = std::move(manager);
+
+  // Update the current state information since the contact manager has been created/set
+  currentStateChanged();
+
   return true;
 }
 
@@ -379,6 +383,10 @@ bool Environment::setActiveContinuousContactManager(const std::string& name)
 
   continuous_manager_name_ = name;
   continuous_manager_ = std::move(manager);
+
+  // Update the current state information since the contact manager has been created/set
+  currentStateChanged();
+
   return true;
 }
 


### PR DESCRIPTION
When the environment is created through the `tesseract` pointer, contact managers are initialized after the environment is created, and the initial world transforms for all collision objects don't get set correctly. This PR fixes this issue by calling the `currentStateChanged` method after setting an active contact manager to set the initial transforms of all collision objects.