### PR TITLE
Modifying Flags in GetEnvironmentInformation.srv

### DIFF
--- a/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/environment_monitor.cpp
@@ -859,6 +859,29 @@ bool EnvironmentMonitor::getEnvironmentInformationCallback(tesseract_msgs::GetEn
     }
   }
 
+  if (req.flags & tesseract_msgs::GetEnvironmentInformationRequest::JOINT_TRANSFORMS)
+  {
+    tesseract_environment::EnvState::ConstPtr current_state = tesseract_->getEnvironmentConst()->getCurrentState();
+    for (const auto& joint : tesseract_->getEnvironmentConst()->getSceneGraph()->getJoints())
+    {
+      res.joint_transforms.names.push_back(joint->getName());
+      geometry_msgs::Pose pose;
+      tf::poseEigenToMsg(
+          current_state->transforms.at(joint->parent_link_name) * joint->parent_to_joint_origin_transform, pose);
+      res.joint_transforms.transforms.push_back(pose);
+    }
+  }
+
+  if (req.flags & tesseract_msgs::GetEnvironmentInformationRequest::ALLOWED_COLLISION_MATRIX)
+  {
+    if (!tesseract_rosutils::toMsg(res.allowed_collision_matrix,
+                                   *tesseract_->getEnvironmentConst()->getAllowedCollisionMatrix()))
+    {
+      res.success = false;
+      return false;
+    }
+  }
+
   res.success = true;
   return true;
 }

--- a/tesseract_ros/tesseract_msgs/srv/GetEnvironmentInformation.srv
+++ b/tesseract_ros/tesseract_msgs/srv/GetEnvironmentInformation.srv
@@ -1,20 +1,23 @@
-uint8 COMMAND_HISTORY=0             # Get the current change history
+# You can combine the requests using a bitwise OR operation (In C++, use
+# the | operator).  They are extracted from the `flags` variable using a
+# bitwise AND operator.
+uint16 COMMAND_HISTORY=1             # Get the current change history
 
-uint8 LINK_LIST=1                   # Get the current list of links
-uint8 JOINT_LIST=2                  # Get the current list of links
+uint16 LINK_LIST=2                   # Get the current list of links
+uint16 JOINT_LIST=4                  # Get the current list of links
 
-uint8 LINK_NAMES=4                  # Get the current list of links
-uint8 JOINT_NAMES=8                 # Get the current list of links
+uint16 LINK_NAMES=8                  # Get the current list of links
+uint16 JOINT_NAMES=16                # Get the current list of links
 
-uint8 ACTIVE_LINK_NAMES=16          # Get the current list of active links
-uint8 ACTIVE_JOINT_NAMES=32         # Get the current list of active joints
+uint16 ACTIVE_LINK_NAMES=32          # Get the current list of active links
+uint16 ACTIVE_JOINT_NAMES=64         # Get the current list of active joints
 
-uint8 LINK_TRANSFORMS=64            # Get the current list of link transforms
-uint8 JOINT_TRANSFORMS=128          # Get the current list of joint transforms
+uint16 LINK_TRANSFORMS=128           # Get the current list of link transforms
+uint16 JOINT_TRANSFORMS=256          # Get the current list of joint transforms
 
-uint8 ALLOWED_COLLISION_MATRIX=254  # Get the current list of joint transforms
+uint16 ALLOWED_COLLISION_MATRIX=512  # Get the current list of joint transforms
 
-uint8 flags # The flags indicating what information should be returned.
+uint16 flags # The flags indicating what information should be returned.
 ---
 bool success
 string id # Name/Id of the environment

--- a/tesseract_ros/tesseract_msgs/srv/GetEnvironmentInformation.srv
+++ b/tesseract_ros/tesseract_msgs/srv/GetEnvironmentInformation.srv
@@ -32,3 +32,4 @@ string[] active_link_names
 string[] active_joint_names
 tesseract_msgs/TransformMap link_transforms
 tesseract_msgs/TransformMap joint_transforms
+tesseract_msgs/AllowedCollisionEntry[] allowed_collision_matrix

--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -51,6 +51,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_msgs/JointMimic.h>
 #include <tesseract_msgs/JointSafety.h>
 #include <tesseract_msgs/ProcessPlan.h>
+#include <tesseract_msgs/AllowedCollisionEntry.h>
 
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/PoseArray.h>
@@ -1570,6 +1571,27 @@ inline bool toMsg(geometry_msgs::PoseArray& pose_array,
       if (!toMsg(pose_array, process_definition.transitions[i].transition_from_end))
         return false;
     }
+  }
+
+  return true;
+}
+
+/**
+ * @brief Convert allowed collision matrix to a vector of allowed collision entry messages
+ * @param acm_msg Vector of allowed collision entries to populate
+ * @param acm Allowed collision matrix to convert to message
+ * @return True if successful, otherwise false
+ */
+inline bool toMsg(std::vector<tesseract_msgs::AllowedCollisionEntry>& acm_msg,
+                  const tesseract_scene_graph::AllowedCollisionMatrix& acm)
+{
+  for (const auto& entry : acm.getAllAllowedCollisions())
+  {
+    tesseract_msgs::AllowedCollisionEntry entry_msg;
+    entry_msg.link_1 = entry.first.first;
+    entry_msg.link_2 = entry.first.second;
+    entry_msg.reason = entry.second;
+    acm_msg.push_back(entry_msg);
   }
 
   return true;


### PR DESCRIPTION
The GetEnvironmentInformation service uses the bitwise AND operator to separate user requests and send only certain information.  However, there are two things that seem incorrect.
- the 'flag' for ALLOWED_COLLISION_MATRIX was 254.  254 converts to 1111 1110.  Requesting this matrix was identical to requesting everything from LINK_LIST through JOINT_TRANSFORM.  Therefore, all of those would return if the ACM was requested, and the ACM would return if any of those were requested.
- the 'flag' for COMMAND_HISTORY was 0.  0 converts to 0000 0000.  Since bitwise AND between any number and 0 is 0 (which C++ translates as false), COMMAND_HISTORY was never returned.

In order to fix this:
- Changed from 8-bit ints to 16-bit ints (needed the room, since there are 10 items to 'flag')
- Incremented all 'flag' numbers (0->1, 1->2, 2->4, etc.)
- Added a comment to the srv file explaining how these values are used.