### PR TITLE
Add DescartesTesseractKinematics wrapper

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_tesseract_kinematics.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_tesseract_kinematics.h
@@ -1,10 +1,38 @@
-#ifndef DESCARTES_TESSERACT_KINEMATICS_H
-#define DESCARTES_TESSERACT_KINEMATICS_H
+/**
+ * @file descartes_tesseract_kinematics.h
+ * @brief A wrapper around tesseract kinematics for the descartes_light kinematics interface
+ *
+ * @author Matthew Powelson
+ * @author Levi Armstrong
+ * @date September 17, 2019
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_DESCARTES_TESSERACT_KINEMATICS_H
+#define TESSERACT_MOTION_PLANNERS_DESCARTES_TESSERACT_KINEMATICS_H
 
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
 #include <vector>
 #include <descartes_light/interface/kinematics_interface.h>
 #include <descartes_light/utils.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_kinematics/core/forward_kinematics.h>
 #include <tesseract_kinematics/core/inverse_kinematics.h>
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_tesseract_kinematics.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_tesseract_kinematics.h
@@ -1,0 +1,100 @@
+#ifndef DESCARTES_TESSERACT_KINEMATICS_H
+#define DESCARTES_TESSERACT_KINEMATICS_H
+
+#include <Eigen/Geometry>
+#include <vector>
+#include <descartes_light/interface/kinematics_interface.h>
+#include <descartes_light/utils.h>
+#include <tesseract_kinematics/core/forward_kinematics.h>
+#include <tesseract_kinematics/core/inverse_kinematics.h>
+
+namespace tesseract_motion_planners
+{
+/** @brief Provides a Descartes interface for Tesseract Kinematics
+ */
+template <typename FloatType>
+class DescartesTesseractKinematics : public descartes_light::KinematicsInterface<FloatType>
+{
+public:
+  using Ptr = std::shared_ptr<DescartesTesseractKinematics>;
+  using ConstPtr = std::shared_ptr<const DescartesTesseractKinematics>;
+
+  /**
+   * @brief This constructor defaults to using isWithinLimits as the isValidFn and gets redundant solutions within joint
+   * limits
+   * @param tesseract_fk Forward kinematics object
+   * @param tesseract_ik Inverse kinematics object
+   */
+  DescartesTesseractKinematics(const tesseract_kinematics::ForwardKinematics::ConstPtr tesseract_fk,
+                               const tesseract_kinematics::InverseKinematics::ConstPtr tesseract_ik)
+    : DescartesTesseractKinematics(tesseract_fk,
+                                   tesseract_ik,
+                                   std::bind(&descartes_light::isWithinLimits<FloatType>,
+                                             std::placeholders::_1,
+                                             tesseract_fk->getLimits().cast<FloatType>()),
+                                   std::bind(&descartes_light::getRedundantSolutions<FloatType>,
+                                             std::placeholders::_1,
+                                             tesseract_fk->getLimits().cast<FloatType>()))
+  {
+    ik_seed_ = Eigen::VectorXd::Zero(dof());
+  }
+
+  /**
+   * @brief DescartesTesseractKinematics
+   * @param tesseract_fk Forward kinematics object
+   * @param tesseract_ik Inverse kinematic object
+   * @param is_valid_fn Function that is used to determine if a vertex is valid
+   * @param redundant_sol_fn Function called to get redundant solutions beyond what tesseract_ik returns
+   */
+  DescartesTesseractKinematics(const tesseract_kinematics::ForwardKinematics::ConstPtr tesseract_fk,
+                               const tesseract_kinematics::InverseKinematics::ConstPtr tesseract_ik,
+                               const descartes_light::IsValidFn<FloatType>& is_valid_fn,
+                               const descartes_light::GetRedundantSolutionsFn<FloatType>& redundant_sol_fn)
+    : tesseract_fk_(tesseract_fk)
+    , tesseract_ik_(tesseract_ik)
+    , is_valid_fn_(is_valid_fn)
+    , redundant_sol_fn_(redundant_sol_fn)
+  {
+    ik_seed_ = Eigen::VectorXd::Zero(dof());
+  }
+
+  /** @brief Calculate inverse kinematics using isValidFn, GetRedundantSolutionsFn, and ik_seed provided
+
+  Note: This currenlty only supports single solutions*/
+  bool ik(const Eigen::Transform<FloatType, 3, Eigen::Isometry>& p,
+          std::vector<FloatType>& solution_set) const override;
+
+  /** @brief Calculate forward kinematics */
+  bool fk(const FloatType* pose, Eigen::Transform<FloatType, 3, Eigen::Isometry>& solution) const override;
+
+  /** @brief Returns the number of joints in the kinematics object */
+  int dof() const override;
+
+  /** @brief Analyzes the effect of the isValidFn and redundant solutions on the number of returned solutions and prints
+   * the results*/
+  void analyzeIK(const Eigen::Transform<FloatType, 3, Eigen::Isometry>& p) const override;
+
+  /** @brief Sets the seed used by inverse kinematics. Must be length dof(). Default: Eigen::VectorXd::Zero(dof())*/
+  void setIKSeed(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1> >& seed);
+
+  /** @brief Sets the seed used by inverse kinematics. Must be length dof(). Default: Eigen::VectorXd::Zero(dof())**/
+  void setIKSeed(const std::vector<FloatType>& seed);
+
+protected:
+  tesseract_kinematics::ForwardKinematics::ConstPtr tesseract_fk_;
+  tesseract_kinematics::InverseKinematics::ConstPtr tesseract_ik_;
+  descartes_light::IsValidFn<FloatType> is_valid_fn_;
+  descartes_light::GetRedundantSolutionsFn<FloatType> redundant_sol_fn_;
+  Eigen::VectorXd ik_seed_;
+
+  bool ik(const Eigen::Transform<FloatType, 3, Eigen::Isometry>& p,
+          const descartes_light::IsValidFn<FloatType>& is_valid_fn,
+          const descartes_light::GetRedundantSolutionsFn<FloatType>& redundant_sol_fn,
+          std::vector<FloatType>& solution_set) const;
+};
+
+using DescartesTesseractKinematicsD = DescartesTesseractKinematics<double>;
+using DescartesTesseractKinematicsF = DescartesTesseractKinematics<float>;
+}  // namespace tesseract_motion_planners
+
+#endif

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_tesseract_kinematics.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_tesseract_kinematics.hpp
@@ -1,6 +1,37 @@
+/**
+ * @file descartes_tesseract_kinematics.h
+ * @brief Implememntatino of a wrapper around tesseract kinematics for the descartes_light kinematics interface
+ *
+ * @author Matthew Powelson
+ * @author Levi Armstrong
+ * @date September 17, 2019
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_DESCARTES_TESSERACT_KINEMATICS_HPP
+#define TESSERACT_MOTION_PLANNERS_DESCARTES_TESSERACT_KINEMATICS_HPP
+
 #include <tesseract_motion_planners/descartes/descartes_tesseract_kinematics.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Eigen>
 #include <console_bridge/console.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_motion_planners
 {
@@ -35,9 +66,6 @@ bool DescartesTesseractKinematics<FloatType>::ik(
   FloatType* sol = solution_float_type.data();
 
   // Apply is_valid_fn and redundant_sol_fn
-
-  // Levi - Do we need harmonizeTowardZero(sol) here?
-
   if (is_valid_fn && redundant_sol_fn)
   {
     if (is_valid_fn_(sol))
@@ -60,6 +88,13 @@ bool DescartesTesseractKinematics<FloatType>::ik(
   {
     if (is_valid_fn(sol))
       solution_set.insert(end(solution_set), sol, sol + dof);  // If good then add to solution set
+    else
+    {
+      // If it failed the is_valid_fn get solution that is +/-pi and retry
+      descartes_light::harmonizeTowardZero<FloatType>(sol, dof);
+      if (is_valid_fn(sol))
+        solution_set.insert(end(solution_set), sol, sol + dof);
+    }
   }
   else if (!is_valid_fn && redundant_sol_fn)
   {
@@ -168,3 +203,4 @@ void DescartesTesseractKinematics<FloatType>::setIKSeed(const std::vector<FloatT
   ik_seed_ = Eigen::Map<Eigen::VectorXd>(seed_copy.data(), seed_copy.size());
 }
 }  // namespace tesseract_motion_planners
+#endif

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_tesseract_kinematics.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_tesseract_kinematics.hpp
@@ -1,0 +1,170 @@
+#include <tesseract_motion_planners/descartes/descartes_tesseract_kinematics.h>
+#include <Eigen/Eigen>
+#include <console_bridge/console.h>
+
+namespace tesseract_motion_planners
+{
+template <typename FloatType>
+bool DescartesTesseractKinematics<FloatType>::ik(const Eigen::Transform<FloatType, 3, Eigen::Isometry>& p,
+                                                 std::vector<FloatType>& solution_set) const
+{
+  return ik(p, is_valid_fn_, redundant_sol_fn_, solution_set);
+}
+
+template <typename FloatType>
+bool DescartesTesseractKinematics<FloatType>::ik(
+    const Eigen::Transform<FloatType, 3, Eigen::Isometry>& p,
+    const descartes_light::IsValidFn<FloatType>& is_valid_fn,
+    const descartes_light::GetRedundantSolutionsFn<FloatType>& redundant_sol_fn,
+    std::vector<FloatType>& solution_set) const
+{
+  unsigned int dof = tesseract_ik_->numJoints();
+
+  // Convert to appropriate Eigen types
+  Eigen::Isometry3d p_double;
+  p_double = p.template cast<double>();
+  Eigen::VectorXd solution_eigen;
+
+  // Solve IK
+  if (!tesseract_ik_->calcInvKin(solution_eigen, p_double, ik_seed_))
+    return false;
+
+  // Convert back to a float array
+  Eigen::Matrix<FloatType, Eigen::Dynamic, 1> solution_float_type;
+  solution_float_type = solution_eigen.template cast<FloatType>();
+  FloatType* sol = solution_float_type.data();
+
+  // Apply is_valid_fn and redundant_sol_fn
+
+  // Levi - Do we need harmonizeTowardZero(sol) here?
+
+  if (is_valid_fn && redundant_sol_fn)
+  {
+    if (is_valid_fn_(sol))
+      solution_set.insert(end(solution_set), sol, sol + dof);  // If good then add to solution set
+
+    std::vector<FloatType> redundant_sols = redundant_sol_fn(sol);
+    if (!redundant_sols.empty())
+    {
+      int num_sol = redundant_sols.size() / dof;
+      for (int s = 0; s < num_sol; ++s)
+      {
+        FloatType* redundant_sol = redundant_sols.data() + dof * s;
+        if (is_valid_fn_(redundant_sol))
+          solution_set.insert(end(solution_set), redundant_sol, redundant_sol + dof);  // If good then add to solution
+                                                                                       // set
+      }
+    }
+  }
+  else if (is_valid_fn && !redundant_sol_fn)
+  {
+    if (is_valid_fn(sol))
+      solution_set.insert(end(solution_set), sol, sol + dof);  // If good then add to solution set
+  }
+  else if (!is_valid_fn && redundant_sol_fn)
+  {
+    solution_set.insert(end(solution_set), sol, sol + dof);  // If good then add to solution set
+
+    std::vector<FloatType> redundant_sols = redundant_sol_fn(sol);
+    if (!redundant_sols.empty())
+    {
+      unsigned int num_sol = redundant_sols.size() / dof;
+      for (unsigned int s = 0; s < num_sol; ++s)
+      {
+        FloatType* redundant_sol = redundant_sols.data() + dof * s;
+        solution_set.insert(end(solution_set), redundant_sol, redundant_sol + dof);  // If good then add to solution
+                                                                                     // set
+      }
+    }
+  }
+  else
+  {
+    solution_set.insert(end(solution_set), sol, sol + dof);
+  }
+  return !solution_set.empty();
+}
+
+template <typename FloatType>
+bool DescartesTesseractKinematics<FloatType>::fk(const FloatType* pose,
+                                                 Eigen::Transform<FloatType, 3, Eigen::Isometry>& solution) const
+{
+  assert(pose);
+
+  // Convert the Array to an Eigen VectorXd
+  Eigen::VectorXd joints(tesseract_fk_->numJoints());
+  for (int i = 0; static_cast<unsigned int>(i) < tesseract_fk_->numJoints(); i++)
+    joints(i, 0) = pose[i];
+
+  // Get the solution from the Tesseract Kinematics
+  Eigen::Isometry3d solution_double;
+  bool success = tesseract_fk_->calcFwdKin(solution_double, joints);
+
+  // Cast from double to FloatType
+  solution = solution_double.cast<FloatType>();
+  return success;
+}
+
+template <typename FloatType>
+int DescartesTesseractKinematics<FloatType>::dof() const
+{
+  assert(tesseract_fk_->numJoints() < std::numeric_limits<int>::max());
+  return static_cast<int>(tesseract_fk_->numJoints());
+}
+
+template <typename FloatType>
+void DescartesTesseractKinematics<FloatType>::analyzeIK(const Eigen::Transform<FloatType, 3, Eigen::Isometry>& p) const
+{
+  Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", "AnalyzeIK: ", ";");
+
+  std::stringstream ss;
+  ss << p.matrix().format(CommaInitFmt);
+  CONSOLE_BRIDGE_logInform(ss.str().c_str());
+
+  std::string valid_fn_defined = "\tIs Valid Function: " + std::string(is_valid_fn_ ? "True" : "False");
+  CONSOLE_BRIDGE_logInform(valid_fn_defined.c_str());
+  std::string redundant_fn_defined = "\tIs Valid Function: " + std::string(is_valid_fn_ ? "True" : "False");
+  CONSOLE_BRIDGE_logInform(redundant_fn_defined.c_str());
+
+  std::vector<FloatType> solution_set;
+  ik(p, nullptr, nullptr, solution_set);
+  ss.clear();
+  ss << "\tSampling without functions, found solutions: " << solution_set.size() / 8;
+  CONSOLE_BRIDGE_logInform(ss.str().c_str());
+
+  solution_set.clear();
+  ik(p, is_valid_fn_, nullptr, solution_set);
+  ss.clear();
+  ss << "\tSampling with only IsValid functions, found solutions: " << solution_set.size() / 8;
+  CONSOLE_BRIDGE_logInform(ss.str().c_str());
+
+  solution_set.clear();
+  ik(p, nullptr, redundant_sol_fn_, solution_set);
+  ss.clear();
+  ss << "\tSampling with only Redundant Solutions functions, found solutions: " << solution_set.size() / 8;
+  CONSOLE_BRIDGE_logInform(ss.str().c_str());
+
+  solution_set.clear();
+  ik(p, is_valid_fn_, redundant_sol_fn_, solution_set);
+  ss.clear();
+  ss << "\tSampling with both functions, found solutions: " << solution_set.size() / 8;
+  CONSOLE_BRIDGE_logInform(ss.str().c_str());
+}
+
+template <typename FloatType>
+void DescartesTesseractKinematics<FloatType>::setIKSeed(
+    const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1> >& seed)
+{
+  assert(seed.size() == dof());
+  ik_seed_ = seed.template cast<double>();
+}
+
+template <typename FloatType>
+void DescartesTesseractKinematics<FloatType>::setIKSeed(const std::vector<FloatType>& seed)
+{
+  assert(seed.size() == dof());
+  std::vector<double> seed_copy;
+  for (auto& i : seed)
+    seed_copy.push_back(static_cast<double>(i));
+  ik_seed_ = Eigen::Map<Eigen::VectorXd>(seed_copy.data(), seed_copy.size());
+}
+}  // namespace tesseract_motion_planners

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/CMakeLists.txt
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/CMakeLists.txt
@@ -1,6 +1,24 @@
 find_package(GTest REQUIRED)
 find_package(tesseract_support REQUIRED)
 
+# Descartes Tesseract Kinematics Test
+add_executable(${PROJECT_NAME}_descartes_kin_unit descartes_tesseract_kinematics_tests.cpp)
+target_link_libraries(${PROJECT_NAME}_descartes_kin_unit ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME}_descartes tesseract::tesseract_support)
+target_compile_options(${PROJECT_NAME}_descartes_kin_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_descartes_kin_unit PUBLIC -std=c++11)
+else()
+    target_compile_features(${PROJECT_NAME}_descartes_kin_unit PRIVATE cxx_std_11)
+endif()
+target_include_directories(${PROJECT_NAME}_descartes_kin_unit PRIVATE ${GTEST_INCLUDE_DIRS})
+if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+    gtest_add_tests(${PROJECT_NAME}_descartes_kin_unit "" AUTO)
+else()
+    gtest_discover_tests(${PROJECT_NAME}_descartes_kin_unit)
+endif()
+add_dependencies(${PROJECT_NAME}_descartes_kin_unit ${PACKAGE_LIBRARIES})
+add_dependencies(run_tests ${PROJECT_NAME}_descartes_kin_unit)
+
 # OMPL Planning Test/Example Program
 add_executable(${PROJECT_NAME}_ompl_unit ompl_planner_tests.cpp)
 target_link_libraries(${PROJECT_NAME}_ompl_unit ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME}_ompl_freespace tesseract::tesseract_support)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_tesseract_kinematics_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_tesseract_kinematics_tests.cpp
@@ -1,0 +1,346 @@
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+#include <fstream>
+#include <console_bridge/console.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <urdf_parser/urdf_parser.h>
+#include <tesseract/tesseract.h>
+
+#include <tesseract_motion_planners/descartes/impl/descartes_tesseract_kinematics.hpp>
+
+using namespace tesseract;
+using namespace tesseract_scene_graph;
+using namespace tesseract_motion_planners;
+
+std::string locateResource(const std::string& url)
+{
+  std::string mod_url = url;
+  if (url.find("package://tesseract_support") == 0)
+  {
+    mod_url.erase(0, strlen("package://tesseract_support"));
+    size_t pos = mod_url.find("/");
+    if (pos == std::string::npos)
+    {
+      return std::string();
+    }
+
+    std::string package = mod_url.substr(0, pos);
+    mod_url.erase(0, pos);
+    std::string package_path = std::string(TESSERACT_SUPPORT_DIR);
+
+    if (package_path.empty())
+    {
+      return std::string();
+    }
+
+    mod_url = package_path + mod_url;  // "file://" + package_path + mod_url;
+  }
+
+  return mod_url;
+}
+
+/** @brief Always returns false */
+template <typename FloatType>
+inline bool isNotValid(const FloatType* vertex)
+{
+  return false;
+}
+
+/** @brief Always returns true */
+template <typename FloatType>
+inline bool isCompletelyValid(const FloatType* vertex)
+{
+  return true;
+}
+
+/** @brief Returns an empty vector corresponding to no redundant solutions*/
+template <typename FloatType>
+inline std::vector<FloatType> noRedundantSolutions(const FloatType* sol, unsigned int& dof)
+{
+  std::vector<FloatType> redundant_sols;
+  redundant_sols.clear();
+  return redundant_sols;
+}
+
+/** @brief Returns the first solution as a duplicate redundant solution */
+template <typename FloatType>
+inline std::vector<FloatType> oneRedundantSolution(const FloatType* sol, unsigned int& dof)
+{
+  std::vector<FloatType> redundant_sols(sol, sol + dof);
+  return redundant_sols;
+}
+
+/** @brief This is used to test that private members are set correctly */
+template <typename FloatType>
+class DescartesTesseractKinematicsTest : public tesseract_motion_planners::DescartesTesseractKinematics<FloatType>
+{
+public:
+  using tesseract_motion_planners::DescartesTesseractKinematics<FloatType>::DescartesTesseractKinematics;
+
+  Eigen::VectorXd getIKSeed() { return this->ik_seed_; }
+};
+
+class DescartesTesseractKinematicsUnit : public ::testing::Test
+{
+protected:
+  Tesseract::Ptr tesseract_ptr_;
+  tesseract_motion_planners::DescartesTesseractKinematics<double>::Ptr descartes_tesseract_kinematics_d_;
+  tesseract_motion_planners::DescartesTesseractKinematics<float>::Ptr descartes_tesseract_kinematics_f_;
+
+  tesseract_kinematics::ForwardKinematics::Ptr kdl_fk_;
+  tesseract_kinematics::InverseKinematics::Ptr kdl_ik_;
+
+  void SetUp() override
+  {
+    // Set up the Tesseract
+    ResourceLocatorFn locator = locateResource;
+    Tesseract::Ptr tesseract = std::make_shared<Tesseract>();
+    boost::filesystem::path urdf_path(std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.urdf");
+    boost::filesystem::path srdf_path(std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.srdf");
+    ASSERT_TRUE(tesseract->init(urdf_path, srdf_path, locator));
+    tesseract_ptr_ = tesseract;
+
+    // Set up the kinematics objects
+    kdl_fk_ = tesseract_ptr_->getFwdKinematicsManagerConst()->getFwdKinematicSolver("manipulator");
+    kdl_ik_ = tesseract_ptr_->getInvKinematicsManagerConst()->getInvKinematicSolver("manipulator");
+
+    descartes_tesseract_kinematics_d_ =
+        std::make_shared<tesseract_motion_planners::DescartesTesseractKinematics<double>>(kdl_fk_, kdl_ik_);
+    descartes_tesseract_kinematics_f_ =
+        std::make_shared<tesseract_motion_planners::DescartesTesseractKinematics<float>>(kdl_fk_, kdl_ik_);
+  }
+};
+
+/** @brief Used to test IK by running the IK results through FK to check that they match up. This also checks that the
+ * number of solutions matches the user defined expected number and that ik returns false when no solutions are found*/
+static void testIKDouble(tesseract_motion_planners::DescartesTesseractKinematics<double> kin,
+                         Eigen::Isometry3d pose_d,
+                         Eigen::VectorXd seed_d,
+                         int expected_sols)
+{
+  int dof = kin.dof();
+  kin.setIKSeed(seed_d);
+  std::vector<double> ik_solutions;
+  // IK should fail if there are no solutions
+  EXPECT_EQ(kin.ik(pose_d, ik_solutions), static_cast<bool>(expected_sols));
+
+  int num_sols = ik_solutions.size() / dof;
+  EXPECT_EQ(num_sols, expected_sols);
+
+  // Passing each solution through FK should yield the input to IK
+  for (int i = 0; i < num_sols; i++)
+  {
+    Eigen::Isometry3d fk_result;
+    EXPECT_TRUE(kin.fk(ik_solutions.data() + i * dof, fk_result));
+    EXPECT_TRUE(pose_d.translation().isApprox(fk_result.translation(), 1e-4));
+
+    Eigen::Quaterniond rot_pose(pose_d.rotation());
+    Eigen::Quaterniond rot_result(fk_result.rotation());
+    EXPECT_TRUE(rot_pose.isApprox(rot_result, 1e-3));
+  }
+}
+
+/** @brief Used to test IK by running the IK results through FK to check that they match up. This also checks that the
+ * number of solutions matches the user defined expected number and that ik returns false when no solutions are found*/
+static void testIKFloat(tesseract_motion_planners::DescartesTesseractKinematics<float> kin,
+                        Eigen::Isometry3f pose_f,
+                        Eigen::VectorXf seed_f,
+                        int expected_sols)
+{
+  int dof = kin.dof();
+  kin.setIKSeed(seed_f);
+  std::vector<float> ik_solutions;
+  // IK should fail if there are no solutions
+  EXPECT_EQ(kin.ik(pose_f, ik_solutions), static_cast<bool>(expected_sols));
+
+  int num_sols = ik_solutions.size() / dof;
+  EXPECT_EQ(num_sols, expected_sols);
+
+  // Passing each solution through FK should yield the input to IK
+  for (int i = 0; i < num_sols; i++)
+  {
+    Eigen::Isometry3f fk_result;
+    EXPECT_TRUE(kin.fk(ik_solutions.data() + i * dof, fk_result));
+    EXPECT_TRUE(pose_f.translation().isApprox(fk_result.translation(), 1e-4));
+
+    Eigen::Quaternionf rot_pose(pose_f.rotation());
+    Eigen::Quaternionf rot_result(fk_result.rotation());
+    EXPECT_TRUE(rot_pose.isApprox(rot_result, 1e-3));
+  }
+}
+
+/** @brief Tests IK by calculating it for a pose and then testing each solution that is returned against the fk solution
+ *
+ * Note that these tests assume that the default IK solver only returns one solution
+ */
+TEST_F(DescartesTesseractKinematicsUnit, IKTest)
+{
+  unsigned int dof = kdl_ik_->numJoints();
+  Eigen::Isometry3d pose_d;
+  pose_d.setIdentity();
+  pose_d.translation()[0] = 0;
+  pose_d.translation()[1] = 0;
+  pose_d.translation()[2] = 1.306;
+  Eigen::Isometry3f pose_f = pose_d.cast<float>();
+
+  Eigen::VectorXd seed_d;
+  seed_d.resize(7);
+  seed_d(0) = -0.785398;
+  seed_d(1) = 0.785398;
+  seed_d(2) = -0.785398;
+  seed_d(3) = 0.785398;
+  seed_d(4) = -0.785398;
+  seed_d(5) = 0.785398;
+  seed_d(6) = -0.785398;
+  Eigen::VectorXf seed_f = seed_d.cast<float>();
+
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(kdl_fk_, kdl_ik_);
+    CONSOLE_BRIDGE_logDebug("Double: default, default");
+    testIKDouble(kin, pose_d, seed_d, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(kdl_fk_, kdl_ik_);
+    CONSOLE_BRIDGE_logDebug("Float: default, default");
+    testIKFloat(kin, pose_f, seed_f, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(kdl_fk_, kdl_ik_, nullptr, nullptr);
+    CONSOLE_BRIDGE_logDebug("Double: nullptr, nullptr");
+    testIKDouble(kin, pose_d, seed_d, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(kdl_fk_, kdl_ik_, nullptr, nullptr);
+    CONSOLE_BRIDGE_logDebug("Float: nullptr, nullptr");
+    testIKFloat(kin, pose_f, seed_f, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(kdl_fk_, kdl_ik_, &isNotValid<double>, nullptr);
+    CONSOLE_BRIDGE_logDebug("Double: isNotValid, nullptr");
+    testIKDouble(kin, pose_d, seed_d, 0);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(kdl_fk_, kdl_ik_, &isNotValid<float>, nullptr);
+    CONSOLE_BRIDGE_logDebug("Float: isNotValid, nullptr");
+    testIKFloat(kin, pose_f, seed_f, 0);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(
+        kdl_fk_, kdl_ik_, &isCompletelyValid<double>, nullptr);
+    CONSOLE_BRIDGE_logDebug("Double: isCompletelyValid, nullptr");
+    testIKDouble(kin, pose_d, seed_d, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(
+        kdl_fk_, kdl_ik_, &isCompletelyValid<float>, nullptr);
+    CONSOLE_BRIDGE_logDebug("Float: isCompletelyValid, nullptr");
+    testIKFloat(kin, pose_f, seed_f, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(
+        kdl_fk_, kdl_ik_, nullptr, std::bind(&noRedundantSolutions<double>, std::placeholders::_1, dof));
+    CONSOLE_BRIDGE_logDebug("Double: nullptr, noRedundantSolutions");
+    testIKDouble(kin, pose_d, seed_d, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(
+        kdl_fk_, kdl_ik_, nullptr, std::bind(&noRedundantSolutions<float>, std::placeholders::_1, dof));
+    CONSOLE_BRIDGE_logDebug("Float: nullptr, noRedundantSolutions");
+    testIKFloat(kin, pose_f, seed_f, 1);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(
+        kdl_fk_, kdl_ik_, nullptr, std::bind(&oneRedundantSolution<double>, std::placeholders::_1, dof));
+    CONSOLE_BRIDGE_logDebug("Double: nullptr, oneRedundantSolution");
+    testIKDouble(kin, pose_d, seed_d, 2);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(
+        kdl_fk_, kdl_ik_, nullptr, std::bind(&oneRedundantSolution<float>, std::placeholders::_1, dof));
+    CONSOLE_BRIDGE_logDebug("Float: nullptr, oneRedundantSolution");
+    testIKFloat(kin, pose_f, seed_f, 2);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<double> kin(
+        kdl_fk_, kdl_ik_, &isNotValid<double>, std::bind(&noRedundantSolutions<double>, std::placeholders::_1, dof));
+    CONSOLE_BRIDGE_logDebug("Double: isNotValid, noRedundantSolutions");
+    testIKDouble(kin, pose_d, seed_d, 0);
+  }
+  {
+    tesseract_motion_planners::DescartesTesseractKinematics<float> kin(
+        kdl_fk_, kdl_ik_, &isNotValid<float>, std::bind(&noRedundantSolutions<float>, std::placeholders::_1, dof));
+    CONSOLE_BRIDGE_logDebug("Float: isNotValid, noRedundantSolutions");
+    testIKFloat(kin, pose_f, seed_f, 0);
+  }
+}
+
+/** @brief This checks fk() against calling the tesseract kinematics object directly */
+TEST_F(DescartesTesseractKinematicsUnit, FKTest)
+{
+  Eigen::VectorXd joints_d(7);
+  Eigen::VectorXf joints_f(7);
+  joints_d << 0., 0.25, 0.5, 0.75, 1.0, 1.25, 1.5;
+  joints_f << 0., 0.25, 0.5, 0.75, 1.0, 1.25, 1.5;
+  Eigen::Isometry3d kdl_result_d = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d result_d = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3f result_f = Eigen::Isometry3f::Identity();
+
+  // Test the fk against the tesseract object directly
+  kdl_fk_->calcFwdKin(kdl_result_d, joints_d);
+  EXPECT_TRUE(descartes_tesseract_kinematics_d_->fk(joints_d.data(), result_d));
+  EXPECT_TRUE(descartes_tesseract_kinematics_f_->fk(joints_f.data(), result_f));
+
+  EXPECT_TRUE(result_d.isApprox(kdl_result_d, 0.00001));
+  EXPECT_TRUE(result_f.isApprox(kdl_result_d.cast<float>(), 0.00001f));
+}
+
+/** @brief This checks that that dof() returns the correct value*/
+TEST_F(DescartesTesseractKinematicsUnit, DOFTest)
+{
+  // Sanity Check that urdf has 7 joints
+  EXPECT_EQ(kdl_fk_->numJoints(), 7);
+  // Actual Check
+  EXPECT_EQ(descartes_tesseract_kinematics_d_->dof(), 7);
+  EXPECT_EQ(descartes_tesseract_kinematics_f_->dof(), 7);
+}
+
+/** @brief Since analyzeIK() does not have any results, this just checkst that it doesn't crash */
+TEST_F(DescartesTesseractKinematicsUnit, AnalyzeIKTest)
+{
+  // Check that this doesn't crash
+  descartes_tesseract_kinematics_d_->analyzeIK(Eigen::Isometry3d::Identity());
+  descartes_tesseract_kinematics_f_->analyzeIK(Eigen::Isometry3f::Identity());
+  EXPECT_TRUE(true);
+}
+
+/** @brief This tests that the ik seed is set correctly */
+TEST_F(DescartesTesseractKinematicsUnit, SetIKSeedTest)
+{
+  auto kin_d = DescartesTesseractKinematicsTest<double>(kdl_fk_, kdl_ik_);
+  auto kin_f = DescartesTesseractKinematicsTest<float>(kdl_fk_, kdl_ik_);
+
+  std::vector<double> double_vec(7, 1.234567);
+  std::vector<float> float_vec(7, 1.234567f);
+  Eigen::Map<Eigen::VectorXd> double_eigen(double_vec.data(), 7);
+  Eigen::Map<Eigen::VectorXf> float_eigen(float_vec.data(), 7);
+
+  // Check when using std::vector
+  kin_d.setIKSeed(double_vec);
+  EXPECT_TRUE(kin_d.getIKSeed().isApprox(double_eigen, 0.00001));
+  kin_f.setIKSeed(float_vec);
+  EXPECT_TRUE(kin_f.getIKSeed().isApprox(double_eigen, 0.00001));
+
+  // Check when using Eigen::VectorX
+  kin_d.setIKSeed(double_eigen);
+  EXPECT_TRUE(kin_d.getIKSeed().isApprox(double_eigen, 0.00001));
+  kin_f.setIKSeed(float_eigen);
+  EXPECT_TRUE(kin_f.getIKSeed().isApprox(double_eigen, 0.00001));  // Note that the seed is stored as a VectorXd
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This adds a wrapper for a TesseractKinematics object such that it can be used with Descartes. It has currently only been tested with the default KDL kinematics, but ideally it would eventually provide an interface for any of Tesseract's kinematics solvers to be used with descartes.