### PR TITLE
Allow tesseract_collision plugins to be found by ROS2 packages

### DIFF
--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -114,6 +114,8 @@ install(DIRECTORY include/${PROJECT_NAME}
 
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 
+file(WRITE ${CMAKE_INSTALL_PREFIX}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+
 # Create cmake config files
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}-config.cmake.in

--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -114,6 +114,9 @@ install(DIRECTORY include/${PROJECT_NAME}
 
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 
+# Create an ament_index resource file to allow ROS2 ament_index_cpp to locate the installed path to this package.
+# This is a workaround to let the ROS2 version of pluginlib find tesseract_collision's plugins, since tesseract_collision is a non-ROS CMake package.
+# ADDITIONAL REQUIREMENT: The installed path must be added to the AMENT_PREFIX_PATH environment variable at runtime, which is outside the scope of CMakeLists.txt.
 file(WRITE ${CMAKE_INSTALL_PREFIX}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
 
 # Create cmake config files


### PR DESCRIPTION
This is part of a workaround for an issue in ROS2 pluginlib (https://github.com/ros/pluginlib/issues/161). Briefly, the ROS2 implementation of ClassLoader uses `ament_index_cpp::get_package_prefix()` when loading plugins, which makes it difficult to load plugins from non-ROS libraries since they aren't added to the `AMENT_PREFIX_PATH` environment variable and don't have some ROS2-specific config files in their package `share` directory.

This change solves the second of these problems by writing an empty file to `ros2_ws/install/tesseract_collision/share/ament_index/resource_index/packages/tesseract_collision` when the package is built.

I think that the first problem will need to be handled separately. So far I've been adding the path to the installed location of `tesseract_collision` to `AMENT_PREFIX_PATH` in my launch files.