### PR TITLE
Remove unused ROS1 header from Descartes motion planner impl

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -34,7 +34,6 @@
 #include <tesseract_motion_planners/core/waypoint.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <jsoncpp/json/json.h>
-#include <ros/console.h>
 #include <descartes_light/descartes_light.h>
 #include <descartes_light/interface/position_sampler.h>
 #include <descartes_samplers/samplers/railed_cartesian_point_sampler.h>


### PR DESCRIPTION
I don't think this header is used for anything in this file, and it causes build failures under ROS2.