### PR TITLE
Fix check for duplicate joints in urdf_parser.cpp

### DIFF
--- a/tesseract/tesseract_urdf/src/urdf_parser.cpp
+++ b/tesseract/tesseract_urdf/src/urdf_parser.cpp
@@ -102,7 +102,7 @@ tesseract_common::StatusCode::Ptr parseURDFString(tesseract_scene_graph::SceneGr
           URDFStatusCategory::ErrorParsingLinkElement, status_cat, status);
 
     // Check if joint name is unique
-    if (sg->getLink(j->getName()) != nullptr)
+    if (sg->getJoint(j->getName()) != nullptr)
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorJointNamesNotUnique, status_cat, status);
 


### PR DESCRIPTION
The `urdf_parser.cpp` file was checking for duplicate joint names using the getLink() function instead of getJoint(). This is incorrect since joints and links can have the same name in URDF.