### PR TITLE
Fix getMarkerCylinderMsg header frame id

### DIFF
--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/plotting.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/plotting.h
@@ -240,7 +240,7 @@ private:
                                                   double scale)
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = env_->getSceneGraph()->getName();
+    marker.header.frame_id = env_->getSceneGraph()->getRoot();
     marker.header.stamp = ros::Time::now();
     marker.ns = "trajopt";
     marker.id = ++marker_counter_;


### PR DESCRIPTION
The getMarkerCylinderMsg function was setting the header frame id to the name of the urdf when it should be set to the root link name of the urdf.