### PR TITLE
OMPL Planner Simplification

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
@@ -94,8 +94,7 @@ bool OMPLFreespacePlanner<PlannerType>::terminate()
 }
 
 template <typename PlannerType>
-tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::solve(PlannerResponse& response,
-                                                                      const bool verbose)
+tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::solve(PlannerResponse& response, const bool verbose)
 {
   tesseract_common::StatusCode config_status = isConfigured();
   if (!config_status)
@@ -335,8 +334,8 @@ bool OMPLFreespacePlanner<PlannerType>::setConfiguration(const OMPLFreespacePlan
 }
 
 template <typename PlannerType>
-ompl::base::StateSamplerPtr OMPLFreespacePlanner<PlannerType>::allocWeightedRealVectorStateSampler(
-    const ompl::base::StateSpace* space) const
+ompl::base::StateSamplerPtr
+OMPLFreespacePlanner<PlannerType>::allocWeightedRealVectorStateSampler(const ompl::base::StateSpace* space) const
 {
   return std::make_shared<WeightedRealVectorStateSampler>(space, config_->weights);
 }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
@@ -301,21 +301,27 @@ bool OMPLFreespacePlanner<PlannerType>::setConfiguration(const OMPLFreespacePlan
   if (config_->svc != nullptr)
     simple_setup_->setStateValidityChecker(config_->svc);
 
-  if (config_->collision_check && config_->collision_continuous && config_->mv == nullptr)
-  {
-    ompl::base::MotionValidatorPtr mv =
-        std::make_shared<ContinuousMotionValidator>(simple_setup_->getSpaceInformation(), env, kin_);
-    simple_setup_->getSpaceInformation()->setMotionValidator(std::move(mv));
-  }
-  else if (config_->collision_check && !config_->collision_continuous && config_->mv == nullptr)
-  {
-    ompl::base::MotionValidatorPtr mv =
-        std::make_shared<DiscreteMotionValidator>(simple_setup_->getSpaceInformation(), env, kin_);
-    simple_setup_->getSpaceInformation()->setMotionValidator(std::move(mv));
-  }
-  else if (config_->mv != nullptr)
+  // Setup motion validation (i.e. collision checking)
+  if (config_->mv != nullptr)
   {
     simple_setup_->getSpaceInformation()->setMotionValidator(config_->mv);
+  }
+  else
+  {
+    if (config_->collision_check)
+    {
+      ompl::base::MotionValidatorPtr mv;
+      if(config_->collision_continuous)
+      {
+        mv = std::make_shared<ContinuousMotionValidator>(simple_setup_->getSpaceInformation(), env, kin_);
+        simple_setup_->getSpaceInformation()->setMotionValidator(std::move(mv));
+      }
+      else
+      {
+        mv = std::make_shared<DiscreteMotionValidator>(simple_setup_->getSpaceInformation(), env, kin_);
+        simple_setup_->getSpaceInformation()->setMotionValidator(std::move(mv));
+      }
+    }
   }
 
   // make sure the planners run until the time limit, and get the best possible solution

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
@@ -128,6 +128,10 @@ tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::solve(PlannerRes
 
   ompl::geometric::PathGeometric& path = simple_setup_->getSolutionPath();
 
+  // Interpolate the path if it shouldn't be simplified and there are currently fewer states than requested
+  if (!config_->simplify && path.getStateCount() < config_->n_output_states)
+    path.interpolate(config_->n_output_states);
+
   planning_response.status =
       tesseract_common::StatusCode(OMPLFreespacePlannerStatusCategory::SolutionFound, status_category_);
   planning_response.joint_trajectory.trajectory = toTrajArray(path);
@@ -311,7 +315,7 @@ bool OMPLFreespacePlanner<PlannerType>::setConfiguration(const OMPLFreespacePlan
     if (config_->collision_check)
     {
       ompl::base::MotionValidatorPtr mv;
-      if(config_->collision_continuous)
+      if (config_->collision_continuous)
       {
         mv = std::make_shared<ContinuousMotionValidator>(simple_setup_->getSpaceInformation(), env, kin_);
         simple_setup_->getSpaceInformation()->setMotionValidator(std::move(mv));

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
@@ -78,24 +78,24 @@ std::string OMPLFreespacePlannerStatusCategory::message(int code) const
 }
 
 /** @brief Construct a basic planner */
-template <typename PlannerType, typename PlannerSettingsType>
-OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::OMPLFreespacePlanner(std::string name)
+template <typename PlannerType>
+OMPLFreespacePlanner<PlannerType>::OMPLFreespacePlanner(std::string name)
   : MotionPlanner(std::move(name))
   , config_(nullptr)
   , status_category_(std::make_shared<const OMPLFreespacePlannerStatusCategory>(name))
 {
 }
 
-template <typename PlannerType, typename PlannerSettingsType>
-bool OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::terminate()
+template <typename PlannerType>
+bool OMPLFreespacePlanner<PlannerType>::terminate()
 {
   CONSOLE_BRIDGE_logWarn("Termination of ongoing optimization is not implemented yet");
   return false;
 }
 
-template <typename PlannerType, typename PlannerSettingsType>
-tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::solve(PlannerResponse& response,
-                                                                                           const bool verbose)
+template <typename PlannerType>
+tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::solve(PlannerResponse& response,
+                                                                      const bool verbose)
 {
   tesseract_common::StatusCode config_status = isConfigured();
   if (!config_status)
@@ -135,11 +135,11 @@ tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType, PlannerSettingsTy
   planning_response.joint_trajectory.joint_names = kin_->getJointNames();
 
   response = std::move(planning_response);
-  return planning_response.status;
+  return response.status;
 }
 
-template <typename PlannerType, typename PlannerSettingsType>
-void OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::clear()
+template <typename PlannerType>
+void OMPLFreespacePlanner<PlannerType>::clear()
 {
   request_ = PlannerRequest();
   config_ = nullptr;
@@ -150,8 +150,8 @@ void OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::clear()
   simple_setup_ = nullptr;
 }
 
-template <typename PlannerType, typename PlannerSettingsType>
-tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::isConfigured() const
+template <typename PlannerType>
+tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::isConfigured() const
 {
   if (config_ == nullptr)
     return tesseract_common::StatusCode(OMPLFreespacePlannerStatusCategory::ErrorIsNotConfigured, status_category_);
@@ -159,11 +159,10 @@ tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType, PlannerSettingsTy
   return tesseract_common::StatusCode(OMPLFreespacePlannerStatusCategory::IsConfigured, status_category_);
 }
 
-template <typename PlannerType, typename PlannerSettingsType>
-bool OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::setConfiguration(
-    const OMPLFreespacePlannerConfig<PlannerSettingsType>& config)
+template <typename PlannerType>
+bool OMPLFreespacePlanner<PlannerType>::setConfiguration(const OMPLFreespacePlannerConfig<PlannerType>& config)
 {
-  config_ = std::make_shared<OMPLFreespacePlannerConfig<PlannerSettingsType>>(config);
+  config_ = std::make_shared<OMPLFreespacePlannerConfig<PlannerType>>(config);
 
   // Check that parameters are valid
   if (config_->tesseract == nullptr)
@@ -335,8 +334,8 @@ bool OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::setConfiguration(
   return true;
 }
 
-template <typename PlannerType, typename PlannerSettingsType>
-ompl::base::StateSamplerPtr OMPLFreespacePlanner<PlannerType, PlannerSettingsType>::allocWeightedRealVectorStateSampler(
+template <typename PlannerType>
+ompl::base::StateSamplerPtr OMPLFreespacePlanner<PlannerType>::allocWeightedRealVectorStateSampler(
     const ompl::base::StateSpace* space) const
 {
   return std::make_shared<WeightedRealVectorStateSampler>(space, config_->weights);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_freespace_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_freespace_planner.h
@@ -75,6 +75,8 @@ struct OMPLFreespacePlannerConfig
   int num_threads = 1;
   /** @brief Simplify trajectory */
   bool simplify = true;
+  /** @brief Number of states in the output trajectory - note: this is ignored if the trajectory is simplified */
+  int n_output_states = 20;
   /** @brief This scales the variables search space. Must be same size as number of joints.
    *         If empty it defaults to all ones */
   Eigen::VectorXd weights;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_freespace_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_freespace_planner.h
@@ -34,17 +34,17 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/core/planner.h>
 #include <tesseract_motion_planners/core/waypoint.h>
+#include <tesseract_motion_planners/ompl/ompl_settings.h>
 
 namespace tesseract_motion_planners
 {
 class OMPLFreespacePlannerStatusCategory;
 
-template <typename PlannerSettingsType>
+template <typename PlannerType>
 struct OMPLFreespacePlannerConfig
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  OMPLFreespacePlannerConfig() {}
   /**
    * @brief Determines the constraint placed at the start of the trajectory
    *
@@ -84,7 +84,7 @@ struct OMPLFreespacePlannerConfig
   double longest_valid_segment_fraction = 0.01;  // 1%
 
   /** @brief Planner settings */
-  PlannerSettingsType settings;
+  OMPLSettings<PlannerType> settings;
 
   /** @brief Tesseract object. ***REQUIRED*** */
   tesseract::Tesseract::ConstPtr tesseract;
@@ -104,7 +104,7 @@ struct OMPLFreespacePlannerConfig
  * @brief This planner is intended to provide an easy to use interface to OMPL for freespace planning. It is made to
  * take a start and end point and automate the generation of the OMPL problem.
  */
-template <typename PlannerType, typename PlannerSettingsType>
+template <typename PlannerType>
 class OMPLFreespacePlanner : public MotionPlanner
 {
 public:
@@ -119,7 +119,7 @@ public:
    * @param config The planners configuration
    * @return True if successful otherwise false
    */
-  bool setConfiguration(const OMPLFreespacePlannerConfig<PlannerSettingsType>& config);
+  bool setConfiguration(const OMPLFreespacePlannerConfig<PlannerType>& config);
 
   /**
    * @brief Sets up the OMPL problem then solves. It is intended to simplify setting up
@@ -151,7 +151,7 @@ private:
 
 protected:
   /** @brief The ompl planner planner */
-  std::shared_ptr<OMPLFreespacePlannerConfig<PlannerSettingsType>> config_;
+  std::shared_ptr<OMPLFreespacePlannerConfig<PlannerType>> config_;
 
   /** @brief The planners status codes */
   std::shared_ptr<const OMPLFreespacePlannerStatusCategory> status_category_;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_settings.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_settings.h
@@ -48,12 +48,19 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <ompl/geometric/planners/prm/LazyPRMstar.h>
 #include <ompl/geometric/planners/prm/SPARS.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_motion_planners/ompl/ompl_settings.h>
 
 namespace tesseract_motion_planners
 {
-class SBLConfig
+template <typename PlannerT>
+struct OMPLSettings
 {
-public:
+  void apply(PlannerT& planner) const;
+};
+
+template<>
+struct OMPLSettings<ompl::geometric::SBL>
+{
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -61,9 +68,9 @@ public:
   void apply(ompl::geometric::SBL& planner) const { planner.setRange(range); }
 };
 
-class ESTConfig
+template<>
+struct OMPLSettings<ompl::geometric::EST>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -78,9 +85,9 @@ public:
   }
 };
 
-class LBKPIECEConfig
+template<>
+struct OMPLSettings<ompl::geometric::LBKPIECE1>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -99,9 +106,9 @@ public:
   }
 };
 
-class BKPIECEConfig
+template<>
+struct OMPLSettings<ompl::geometric::BKPIECE1>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -124,9 +131,9 @@ public:
   }
 };
 
-class KPIECEConfig
+template<>
+struct OMPLSettings<ompl::geometric::KPIECE1>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -153,9 +160,9 @@ public:
   }
 };
 
-class RRTConfig
+template<>
+struct OMPLSettings<ompl::geometric::RRT>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -170,9 +177,9 @@ public:
   }
 };
 
-class RRTConnectConfig
+template<>
+struct OMPLSettings<ompl::geometric::RRTConnect>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -180,9 +187,9 @@ public:
   void apply(ompl::geometric::RRTConnect& planner) const { planner.setRange(range); }
 };
 
-class RRTstarConfig
+template<>
+struct OMPLSettings<ompl::geometric::RRTstar>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -201,9 +208,9 @@ public:
   }
 };
 
-class TRRTConfig
+template<>
+struct OMPLSettings<ompl::geometric::TRRT>
 {
-public:
   /** @brief Max motion added to tree */
   double range = 0;
 
@@ -217,10 +224,10 @@ public:
   double init_temperature = 10e-6;
 
   /** @brief Dist new state to nearest neighbor to disqualify as frontier. */
-  double frountier_threshold = 0.0;
+  double frontier_threshold = 0.0;
 
   /** @brief 1/10, or 1 nonfrontier for every 10 frontier. */
-  double frountier_node_ratio = 0.1;
+  double frontier_node_ratio = 0.1;
 
   /** @brief Apply settings to planner */
   void apply(ompl::geometric::TRRT& planner) const
@@ -229,14 +236,14 @@ public:
     planner.setGoalBias(goal_bias);
     planner.setTempChangeFactor(temp_change_factor);
     planner.setInitTemperature(init_temperature);
-    planner.setFrontierThreshold(frountier_threshold);
-    planner.setFrontierNodeRatio(frountier_node_ratio);
+    planner.setFrontierThreshold(frontier_threshold);
+    planner.setFrontierNodeRatio(frontier_node_ratio);
   }
 };
 
-class PRMConfig
+template<>
+struct OMPLSettings<ompl::geometric::PRM>
 {
-public:
   /** @brief Use k nearest neighbors. */
   int max_nearest_neighbors = 10;
 
@@ -247,21 +254,22 @@ public:
   }
 };
 
-class PRMstarConfig
+template<>
+struct OMPLSettings<ompl::geometric::PRMstar>
 {
-public:
   /** @brief Apply settings to planner */
   void apply(ompl::geometric::PRMstar& /*planner*/) const {}
 };
 
-class LazyPRMstarConfig
+template<>
+struct OMPLSettings<ompl::geometric::LazyPRMstar>
 {
-public:
   /** @brief Apply settings to planner */
   void apply(ompl::geometric::LazyPRMstar& /*planner*/) const {}
 };
 
-class SPARSConfig
+template<>
+struct OMPLSettings<ompl::geometric::SPARS>
 {
 public:
   /** @brief The maximum number of failures before terminating the algorithm */
@@ -286,6 +294,6 @@ public:
   }
 };
 
-}  // namespace tesseract_motion_planners
+} // namespace tesseract_motion_planners
 
 #endif  // TESSERACT_MOTION_PLANNERS_OMPL_SETTINGS_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_settings.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_settings.h
@@ -58,7 +58,7 @@ struct OMPLSettings
   void apply(PlannerT& planner) const;
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::SBL>
 {
   /** @brief Max motion added to tree */
@@ -68,7 +68,7 @@ struct OMPLSettings<ompl::geometric::SBL>
   void apply(ompl::geometric::SBL& planner) const { planner.setRange(range); }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::EST>
 {
   /** @brief Max motion added to tree */
@@ -85,7 +85,7 @@ struct OMPLSettings<ompl::geometric::EST>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::LBKPIECE1>
 {
   /** @brief Max motion added to tree */
@@ -106,7 +106,7 @@ struct OMPLSettings<ompl::geometric::LBKPIECE1>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::BKPIECE1>
 {
   /** @brief Max motion added to tree */
@@ -131,7 +131,7 @@ struct OMPLSettings<ompl::geometric::BKPIECE1>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::KPIECE1>
 {
   /** @brief Max motion added to tree */
@@ -160,7 +160,7 @@ struct OMPLSettings<ompl::geometric::KPIECE1>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::RRT>
 {
   /** @brief Max motion added to tree */
@@ -177,7 +177,7 @@ struct OMPLSettings<ompl::geometric::RRT>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::RRTConnect>
 {
   /** @brief Max motion added to tree */
@@ -187,7 +187,7 @@ struct OMPLSettings<ompl::geometric::RRTConnect>
   void apply(ompl::geometric::RRTConnect& planner) const { planner.setRange(range); }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::RRTstar>
 {
   /** @brief Max motion added to tree */
@@ -208,7 +208,7 @@ struct OMPLSettings<ompl::geometric::RRTstar>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::TRRT>
 {
   /** @brief Max motion added to tree */
@@ -241,7 +241,7 @@ struct OMPLSettings<ompl::geometric::TRRT>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::PRM>
 {
   /** @brief Use k nearest neighbors. */
@@ -254,21 +254,21 @@ struct OMPLSettings<ompl::geometric::PRM>
   }
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::PRMstar>
 {
   /** @brief Apply settings to planner */
   void apply(ompl::geometric::PRMstar& /*planner*/) const {}
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::LazyPRMstar>
 {
   /** @brief Apply settings to planner */
   void apply(ompl::geometric::LazyPRMstar& /*planner*/) const {}
 };
 
-template<>
+template <>
 struct OMPLSettings<ompl::geometric::SPARS>
 {
 public:
@@ -294,6 +294,6 @@ public:
   }
 };
 
-} // namespace tesseract_motion_planners
+}  // namespace tesseract_motion_planners
 
 #endif  // TESSERACT_MOTION_PLANNERS_OMPL_SETTINGS_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_freespace_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_freespace_planner.cpp
@@ -47,18 +47,18 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_motion_planners
 {
 // Explicit template instantiation
-template class OMPLFreespacePlanner<ompl::geometric::SBL, SBLConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::EST, ESTConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::LBKPIECE1, LBKPIECEConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::BKPIECE1, BKPIECEConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::KPIECE1, KPIECEConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::RRT, RRTConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::RRTConnect, RRTConnectConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::RRTstar, RRTstarConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::TRRT, TRRTConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::PRM, PRMConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::PRMstar, PRMstarConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::LazyPRMstar, LazyPRMstarConfig>;
-template class OMPLFreespacePlanner<ompl::geometric::SPARS, SPARSConfig>;
+template class OMPLFreespacePlanner<ompl::geometric::SBL>;
+template class OMPLFreespacePlanner<ompl::geometric::EST>;
+template class OMPLFreespacePlanner<ompl::geometric::LBKPIECE1>;
+template class OMPLFreespacePlanner<ompl::geometric::BKPIECE1>;
+template class OMPLFreespacePlanner<ompl::geometric::KPIECE1>;
+template class OMPLFreespacePlanner<ompl::geometric::RRT>;
+template class OMPLFreespacePlanner<ompl::geometric::RRTConnect>;
+template class OMPLFreespacePlanner<ompl::geometric::RRTstar>;
+template class OMPLFreespacePlanner<ompl::geometric::TRRT>;
+template class OMPLFreespacePlanner<ompl::geometric::PRM>;
+template class OMPLFreespacePlanner<ompl::geometric::PRMstar>;
+template class OMPLFreespacePlanner<ompl::geometric::LazyPRMstar>;
+template class OMPLFreespacePlanner<ompl::geometric::SPARS>;
 
 }  // namespace tesseract_motion_planners

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -127,7 +127,7 @@ typedef ::testing::Types<ompl::geometric::SBL,
                          ompl::geometric::KPIECE1,
                          ompl::geometric::RRT,
                          ompl::geometric::RRTConnect,
-//                         ompl::geometric::RRTstar,
+                         //                         ompl::geometric::RRTstar,
                          ompl::geometric::TRRT,
                          ompl::geometric::SPARS>
     Implementations;
@@ -153,10 +153,8 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
 
   tesseract_motion_planners::OMPLFreespacePlannerConfig<TypeParam> ompl_config;
 
-  ompl_config.start_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  ompl_config.end_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
+  ompl_config.start_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
+  ompl_config.end_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
   ompl_config.tesseract = tesseract;
   ompl_config.manipulator = "manipulator";
   ompl_config.collision_safety_margin = 0.01;
@@ -174,8 +172,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
 
   // Check for start state in collision error
   swp = { 0, 0.7, 0.0, 0, 0.0, 0, 0.0 };
-  ompl_config.start_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
+  ompl_config.start_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
 
   this->ompl_planner.setConfiguration(ompl_config);
   status = this->ompl_planner.solve(ompl_planning_response);
@@ -185,10 +182,8 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
   // Check for start state in collision error
   swp = { -1.2, 0.5, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
   ewp = { 0, 0.7, 0.0, 0, 0.0, 0, 0.0 };
-  ompl_config.start_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  ompl_config.end_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
+  ompl_config.start_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
+  ompl_config.end_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
 
   this->ompl_planner.setConfiguration(ompl_config);
   status = this->ompl_planner.solve(ompl_planning_response);
@@ -198,10 +193,8 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
   // Reset start and end waypoints
   swp = { -1.2, 0.5, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
   ewp = { 1.2, 0.2762, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
-  ompl_config.start_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  ompl_config.end_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
+  ompl_config.start_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
+  ompl_config.end_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
 }
 
 int main(int argc, char** argv)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -27,7 +27,16 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/filesystem/path.hpp>
+
+#include <ompl/geometric/planners/sbl/SBL.h>
+#include <ompl/geometric/planners/est/EST.h>
+#include <ompl/geometric/planners/kpiece/LBKPIECE1.h>
+#include <ompl/geometric/planners/kpiece/BKPIECE1.h>
+#include <ompl/geometric/planners/kpiece/KPIECE1.h>
+#include <ompl/geometric/planners/rrt/RRT.h>
 #include <ompl/geometric/planners/rrt/RRTConnect.h>
+#include <ompl/geometric/planners/rrt/RRTstar.h>
+#include <ompl/geometric/planners/rrt/TRRT.h>
 #include <ompl/geometric/planners/prm/PRM.h>
 #include <ompl/geometric/planners/prm/PRMstar.h>
 #include <ompl/geometric/planners/prm/LazyPRMstar.h>
@@ -40,9 +49,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/ompl/conversions.h>
 #include <tesseract/tesseract.h>
 #include <tesseract_environment/core/utils.h>
-#include <tesseract_motion_planners/ompl/continuous_motion_validator.h>
 #include <tesseract_motion_planners/ompl/ompl_freespace_planner.h>
-#include <tesseract_motion_planners/ompl/ompl_settings.h>
 
 using namespace tesseract;
 using namespace tesseract_scene_graph;
@@ -102,7 +109,32 @@ static void addBox(tesseract_environment::Environment& env)
   env.addLink(link_1, joint_1);
 }
 
-TEST(TesseractPlanningUnit, OMPLFreespacePlannerUnit)
+template <typename PlannerType>
+class OMPLTestFixture : public ::testing::Test
+{
+public:
+  using ::testing::Test::Test;
+  tesseract_motion_planners::OMPLFreespacePlanner<PlannerType> ompl_planner;
+};
+
+typedef ::testing::Types<ompl::geometric::SBL,
+                         ompl::geometric::PRM,
+                         ompl::geometric::PRMstar,
+                         ompl::geometric::LazyPRMstar,
+                         ompl::geometric::EST,
+                         ompl::geometric::LBKPIECE1,
+                         ompl::geometric::BKPIECE1,
+                         ompl::geometric::KPIECE1,
+                         ompl::geometric::RRT,
+                         ompl::geometric::RRTConnect,
+//                         ompl::geometric::RRTstar,
+                         ompl::geometric::TRRT,
+                         ompl::geometric::SPARS>
+    Implementations;
+
+TYPED_TEST_CASE(OMPLTestFixture, Implementations);
+
+TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
 {
   // Step 1: Load scene and srdf
   ResourceLocatorFn locator = locateResource;
@@ -118,120 +150,58 @@ TEST(TesseractPlanningUnit, OMPLFreespacePlannerUnit)
   auto kin = tesseract->getFwdKinematicsManagerConst()->getFwdKinematicSolver("manipulator");
   std::vector<double> swp = { -1.2, 0.5, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
   std::vector<double> ewp = { 1.2, 0.2762, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
-  tesseract_motion_planners::OMPLFreespacePlannerConfig<RRTConnectConfig> rrt_connect_config;
-  rrt_connect_config.start_waypoint =
+
+  tesseract_motion_planners::OMPLFreespacePlannerConfig<TypeParam> ompl_config;
+
+  ompl_config.start_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  rrt_connect_config.end_waypoint =
+  ompl_config.end_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
-  rrt_connect_config.tesseract = tesseract;
-  rrt_connect_config.manipulator = "manipulator";
-  rrt_connect_config.collision_safety_margin = 0.01;
-  rrt_connect_config.planning_time = 5;
-  rrt_connect_config.num_threads = 4;
-  rrt_connect_config.max_solutions = 4;
-  rrt_connect_config.settings.range = 0.1;
+  ompl_config.tesseract = tesseract;
+  ompl_config.manipulator = "manipulator";
+  ompl_config.collision_safety_margin = 0.01;
+  ompl_config.planning_time = 5.0;
+  ompl_config.num_threads = 4;
+  ompl_config.max_solutions = 4;
 
-  // RRTConnect Solve
-  tesseract_motion_planners::OMPLFreespacePlanner<ompl::geometric::RRTConnect, RRTConnectConfig> rrt_connect_planner;
-  rrt_connect_planner.setConfiguration(rrt_connect_config);
+  // Set the planner configuration
+  this->ompl_planner.setConfiguration(ompl_config);
 
-  tesseract_motion_planners::PlannerResponse rrt_connect_planning_response;
-  tesseract_common::StatusCode status = rrt_connect_planner.solve(rrt_connect_planning_response);
+  tesseract_motion_planners::PlannerResponse ompl_planning_response;
+  tesseract_common::StatusCode status = this->ompl_planner.solve(ompl_planning_response);
 
   EXPECT_TRUE(status);
 
   // Check for start state in collision error
   swp = { 0, 0.7, 0.0, 0, 0.0, 0, 0.0 };
-  rrt_connect_config.start_waypoint =
+  ompl_config.start_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
 
-  rrt_connect_planner.setConfiguration(rrt_connect_config);
-  status = rrt_connect_planner.solve(rrt_connect_planning_response);
+  this->ompl_planner.setConfiguration(ompl_config);
+  status = this->ompl_planner.solve(ompl_planning_response);
 
   EXPECT_FALSE(status);
 
   // Check for start state in collision error
   swp = { -1.2, 0.5, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
   ewp = { 0, 0.7, 0.0, 0, 0.0, 0, 0.0 };
-  rrt_connect_config.start_waypoint =
+  ompl_config.start_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  rrt_connect_config.end_waypoint =
+  ompl_config.end_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
 
-  rrt_connect_planner.setConfiguration(rrt_connect_config);
-  status = rrt_connect_planner.solve(rrt_connect_planning_response);
+  this->ompl_planner.setConfiguration(ompl_config);
+  status = this->ompl_planner.solve(ompl_planning_response);
 
   EXPECT_FALSE(status);
 
   // Reset start and end waypoints
   swp = { -1.2, 0.5, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
   ewp = { 1.2, 0.2762, 0.0, -1.3348, 0.0, 1.4959, 0.0 };
-  rrt_connect_config.start_waypoint =
+  ompl_config.start_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  rrt_connect_config.end_waypoint =
+  ompl_config.end_waypoint =
       std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
-
-  // PRM Solve
-  tesseract_motion_planners::OMPLFreespacePlannerConfig<PRMConfig> prm_config;
-  prm_config.start_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  prm_config.end_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
-  prm_config.tesseract = tesseract;
-  prm_config.manipulator = "manipulator";
-  prm_config.collision_safety_margin = 0.01;
-  prm_config.planning_time = 5;
-  prm_config.num_threads = 4;
-  prm_config.max_solutions = 4;
-  prm_config.settings.max_nearest_neighbors = 5;
-
-  tesseract_motion_planners::OMPLFreespacePlanner<ompl::geometric::PRM, PRMConfig> prm_planner;
-  prm_planner.setConfiguration(prm_config);
-
-  tesseract_motion_planners::PlannerResponse prm_planning_response;
-  status = prm_planner.solve(prm_planning_response);
-
-  EXPECT_TRUE(status);
-
-  // PRMstar Solve
-  tesseract_motion_planners::OMPLFreespacePlannerConfig<PRMstarConfig> prm_star_config;
-  prm_star_config.start_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  prm_star_config.end_waypoint = std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
-  prm_star_config.tesseract = tesseract;
-  prm_star_config.manipulator = "manipulator";
-  prm_star_config.collision_safety_margin = 0.01;
-  prm_star_config.planning_time = 5;
-  prm_star_config.num_threads = 4;
-  prm_star_config.max_solutions = 4;
-
-  tesseract_motion_planners::OMPLFreespacePlanner<ompl::geometric::PRMstar, PRMstarConfig> prm_star_planner;
-  prm_star_planner.setConfiguration(prm_star_config);
-
-  tesseract_motion_planners::PlannerResponse prm_star_planning_response;
-  status = prm_star_planner.solve(prm_star_planning_response);
-
-  EXPECT_TRUE(status);
-
-  // LazyPRMstar Solve
-  tesseract_motion_planners::OMPLFreespacePlannerConfig<LazyPRMstarConfig> lazy_prm_star_config;
-  lazy_prm_star_config.start_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(swp, kin->getJointNames());
-  lazy_prm_star_config.end_waypoint =
-      std::make_shared<tesseract_motion_planners::JointWaypoint>(ewp, kin->getJointNames());
-  lazy_prm_star_config.tesseract = tesseract;
-  lazy_prm_star_config.manipulator = "manipulator";
-  lazy_prm_star_config.collision_safety_margin = 0.01;
-  lazy_prm_star_config.planning_time = 5;
-  lazy_prm_star_config.num_threads = 4;
-  lazy_prm_star_config.max_solutions = 4;
-
-  tesseract_motion_planners::OMPLFreespacePlanner<ompl::geometric::LazyPRMstar, LazyPRMstarConfig>
-      lazy_prm_star_planner;
-  lazy_prm_star_planner.setConfiguration(lazy_prm_star_config);
-
-  tesseract_motion_planners::PlannerResponse lazy_prm_star_planning_response;
-  status = lazy_prm_star_planner.solve(lazy_prm_star_planning_response);
-
-  EXPECT_TRUE(status);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR updates the OMPL planner to simplify configuration; it also refactors the unit test to be able to test all types of OMPL planners. I wasn't able to get the RRT* planner to converge in the unit test scenario, but all of the other planners work. The refactor of the OMPL planner part of an effort to create a hybrid OMPL planner that is still in progress