### PR TITLE
Fix removing joint in RViz

### DIFF
--- a/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
+++ b/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
@@ -365,10 +365,10 @@ bool EnvironmentWidget::applyEnvironmentCommands(const std::vector<tesseract_msg
         std::vector<std::string> child_link_names =
             tesseract_->getEnvironment()->getSceneGraph()->getLinkChildrenNames(remove_joint->child_link_name);
 
-        if (!visualization_->removeLink(remove_joint->child_link_name))
+        if (!visualization_->removeJoint(joints[0]->getName()))
           return false;
 
-        if (!visualization_->removeJoint(joints[0]->getName()))
+        if (!visualization_->removeLink(remove_joint->child_link_name))
           return false;
 
         for (const auto& link_name : child_link_names)

--- a/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
+++ b/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
@@ -328,10 +328,10 @@ bool EnvironmentWidget::applyEnvironmentCommands(const std::vector<tesseract_msg
         std::vector<std::string> child_link_names =
             tesseract_->getEnvironment()->getSceneGraph()->getLinkChildrenNames(command.remove_link);
 
-        if (!visualization_->removeLink(command.remove_link))
+        if (!visualization_->removeJoint(joints[0]->getName()))
           return false;
 
-        if (!visualization_->removeJoint(joints[0]->getName()))
+        if (!visualization_->removeLink(command.remove_link))
           return false;
 
         for (const auto& link_name : child_link_names)

--- a/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
+++ b/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
@@ -365,7 +365,7 @@ bool EnvironmentWidget::applyEnvironmentCommands(const std::vector<tesseract_msg
         std::vector<std::string> child_link_names =
             tesseract_->getEnvironment()->getSceneGraph()->getLinkChildrenNames(remove_joint->child_link_name);
 
-        if (!visualization_->removeLink(command.remove_link))
+        if (!visualization_->removeLink(remove_joint->child_link_name))
           return false;
 
         if (!visualization_->removeJoint(joints[0]->getName()))


### PR DESCRIPTION
I was playing with the RViz visualizer, and noticed a crash when trying to remove a joint from the environment. I had two errors pop up:
- `The link () does not exist`: caused by trying to remove `remove_link` which is not set as this is a `REMOVE_JOINT` command
- `The link (child_link_name) does not exist`: Caused by removing the link before the joint. When the link is removed, the widget is updated, and walks the list of joints. When it hits the joint to be removed, the child link no longer exists and crashes.

This PR thus removes the joint, then the child link (instead of `remove_link`).

As a side note, it seems like travis supports `xvfb`, so it might be possible to run tests against RViz in CI, but it doesn't seem that easy to set up.