### PR TITLE
Trajopt Planner: Switch setConfiguration to pass shared_ptr by value

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
@@ -54,7 +54,7 @@ public:
    * @param config The planners configuration
    * @return True if successful otherwise false
    */
-  bool setConfiguration(const TrajOptPlannerConfig::Ptr& config);
+  bool setConfiguration(const TrajOptPlannerConfig::Ptr config);
 
   /**
    * @brief Sets up the opimizer and solves a SQP problem read from json with no callbacks and dafault parameterss

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -191,7 +191,7 @@ tesseract_common::StatusCode TrajOptMotionPlanner::isConfigured() const
     return tesseract_common::StatusCode(TrajOptMotionPlannerStatusCategory::IsNotConfigured, status_category_);
 }
 
-bool TrajOptMotionPlanner::setConfiguration(const TrajOptPlannerConfig::Ptr& config)
+bool TrajOptMotionPlanner::setConfiguration(const TrajOptPlannerConfig::Ptr config)
 {
   config_ = config;
   return config_->generate();


### PR DESCRIPTION
When passed by reference, calling clear on the planner also clears the config that was passed in. If it is by value, you will just be setting the planners config to nullptr not the original.