### PR TITLE
Adjust for joint waypoint joint name order

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
@@ -292,12 +292,14 @@ bool OMPLFreespacePlanner<PlannerType>::setConfiguration(const OMPLFreespacePlan
   };
 
   ompl::base::ScopedState<> start_state(simple_setup_->getStateSpace());
+  const Eigen::VectorXd sp = start_position->getPositions(kin_->getJointNames());
   for (unsigned i = 0; i < dof; ++i)
-    start_state[i] = start_position->getPositions()[i];
+    start_state[i] = sp[i];
 
   ompl::base::ScopedState<> goal_state(simple_setup_->getStateSpace());
+  const Eigen::VectorXd ep = end_position->getPositions(kin_->getJointNames());
   for (unsigned i = 0; i < dof; ++i)
-    goal_state[i] = end_position->getPositions()[i];
+    goal_state[i] = ep[i];
 
   simple_setup_->setStartAndGoalStates(start_state, goal_state);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
@@ -72,17 +72,40 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig:
   pci.basic_info.use_time = false;
   pci.basic_info.convex_solver = optimizer;
 
-  // Populate Init Info
-  pci.init_info.type = init_type;
-  if (init_type == trajopt::InitInfo::GIVEN_TRAJ)
-    pci.init_info.data = seed_trajectory;
-
+  // Get kinematics information
   tesseract_environment::Environment::ConstPtr env = tesseract->getEnvironmentConst();
   tesseract_kinematics::ForwardKinematics::ConstPtr kin =
       tesseract->getFwdKinematicsManagerConst()->getFwdKinematicSolver(manipulator);
   tesseract_environment::AdjacencyMap map(
       env->getSceneGraph(), kin->getActiveLinkNames(), env->getCurrentState()->transforms);
   std::vector<std::string> adjacency_links = map.getActiveLinkNames();
+
+  // Populate Init Info
+  pci.init_info.type = init_type;
+  if (init_type == trajopt::InitInfo::GIVEN_TRAJ)
+  {
+    pci.init_info.data = seed_trajectory;
+
+    // Add check to make sure if starts with joint waypoint that the seed trajectory also starts at this waypoint
+    // If it does not start this causes issues in trajopt and it will never converge.
+    if (isJointWaypointType(target_waypoints.front()->getType()))
+    {
+      const auto jwp = std::static_pointer_cast<JointWaypoint>(target_waypoints.front());
+      const Eigen::VectorXd position = jwp->getPositions(kin->getJointNames());
+      for (int i = 0; i < static_cast<int>(kin->numJoints()); ++i)
+      {
+        if (std::abs(position[i] - seed_trajectory(0, i)) > static_cast<double>(std::numeric_limits<float>::epsilon()))
+        {
+          std::stringstream ss;
+          ss << "Seed trajectory start position does not match starting joint waypoint position!";
+          ss << "    waypoint: " << position.transpose().matrix() << std::endl;
+          ss << "  seed start: " << seed_trajectory.row(0).transpose().matrix() << std::endl;
+          CONSOLE_BRIDGE_logError(ss.str().c_str());
+          return nullptr;
+        }
+      }
+    }
+  }
 
   // Add the first waypoint
   {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
@@ -34,14 +34,13 @@ trajopt::TermInfo::Ptr createJointWaypointTermInfo(const JointWaypoint::ConstPtr
                                                    const std::string& name)
 {
   std::shared_ptr<trajopt::JointPosTermInfo> jv = std::make_shared<trajopt::JointPosTermInfo>();
-  const Eigen::VectorXd& coeffs = waypoint->getCoefficients();
-  assert(std::equal(joint_names.begin(), joint_names.end(), waypoint->getNames().begin()));
+  const Eigen::VectorXd& coeffs = waypoint->getCoefficients(joint_names);
+  const Eigen::VectorXd position = waypoint->getPositions(joint_names);
   if (static_cast<std::size_t>(coeffs.size()) != joint_names.size())
     jv->coeffs = std::vector<double>(joint_names.size(), coeff);  // Default value
   else
     jv->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
-  jv->targets = std::vector<double>(waypoint->getPositions().data(),
-                                    waypoint->getPositions().data() + waypoint->getPositions().size());
+  jv->targets = std::vector<double>(position.data(), position.data() + position.rows() * position.cols());
   jv->first_step = static_cast<int>(ind);
   jv->last_step = static_cast<int>(ind);
   jv->name = name + "_" + std::to_string(ind);
@@ -60,9 +59,13 @@ trajopt::TermInfo::Ptr createJointTolerancedWaypointTermInfo(const JointToleranc
   // hinge to keep the problem numerically stable.
   // Equality cost with coeffs much smaller than inequality
   std::shared_ptr<trajopt::JointPosTermInfo> jv_equal = std::make_shared<trajopt::JointPosTermInfo>();
-  jv_equal->coeffs = std::vector<double>(joint_names.size(), coeff);
-  jv_equal->targets = std::vector<double>(waypoint->getPositions().data(),
-                                          waypoint->getPositions().data() + waypoint->getPositions().size());
+  const Eigen::VectorXd& coeffs = waypoint->getCoefficients(joint_names);
+  const Eigen::VectorXd position = waypoint->getPositions(joint_names);
+  if (static_cast<std::size_t>(coeffs.size()) != joint_names.size())
+    jv_equal->coeffs = std::vector<double>(joint_names.size(), coeff);  // Default value
+  else
+    jv_equal->coeffs = std::vector<double>(coeffs.data(), coeffs.data() + coeffs.rows() * coeffs.cols());
+  jv_equal->targets = std::vector<double>(position.data(), position.data() + position.rows() * position.cols());
   jv_equal->first_step = static_cast<int>(ind);
   jv_equal->last_step = static_cast<int>(ind);
   jv_equal->name = name + "_" + std::to_string(ind);


### PR DESCRIPTION
Since joint waypoint order is not guaranteed to match the manipulator the planners must adjust the waypoint data to match the manipulator.