### PR TITLE
Replace raw lock / unlock by lock_guard

### DIFF
--- a/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -99,6 +99,12 @@ void runAddandRemoveLinkTest(const tesseract_environment::Environment::Ptr& env)
   EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_1.getName()) == joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/after_remove_link_unit.dot");
+
+  // Test against double removing
+  EXPECT_FALSE(env->removeLink(link_1.getName()));
+  EXPECT_FALSE(env->removeLink(link_2.getName()));
+  EXPECT_FALSE(env->removeJoint(joint_1.getName()));
+  EXPECT_FALSE(env->removeJoint("joint_" + link_1.getName()));
 }
 
 void runMoveLinkandJointTest(const tesseract_environment::Environment::Ptr& env)


### PR DESCRIPTION
This is to avoid potential deadlock when returning early
e.g. when deleting a non-existing link.

Currently, if any of the calls to `Environment` that's mutex-protected and can fail does fail, the mutex is left locked, and any subsequent calls will fail.

Also updated the test to check double-removing, maybe it should be done for other functions as well.