### PR TITLE
Expose the contact distance threshold for DescartesCollision

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
@@ -99,8 +99,8 @@ private:
   std::vector<std::string> active_link_names_;                       /**< @brief A vector of active link names */
   std::vector<std::string> joint_names_;                             /**< @brief A vector of joint names */
   tesseract_collision::DiscreteContactManager::Ptr contact_manager_; /**< @brief The discrete contact manager */
-  double contact_dist_threshold_;
-  bool debug_; /**< @brief Enable debug information to be printed to the terminal */
+  double contact_dist_threshold_; /**< @brief Distance in meters for evaluating collisions */
+  bool debug_;                    /**< @brief Enable debug information to be printed to the terminal */
 };
 
 using DescartesCollisionF = DescartesCollision<float>;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
@@ -50,6 +50,7 @@ public:
   DescartesCollision(const tesseract_environment::Environment::ConstPtr& collision_env,
                      std::vector<std::string> active_links,
                      std::vector<std::string> joint_names,
+                     double contact_dist_threshold = 0.025,
                      bool debug = false);
   ~DescartesCollision() override = default;
 
@@ -98,6 +99,7 @@ private:
   std::vector<std::string> active_link_names_;                       /**< @brief A vector of active link names */
   std::vector<std::string> joint_names_;                             /**< @brief A vector of joint names */
   tesseract_collision::DiscreteContactManager::Ptr contact_manager_; /**< @brief The discrete contact manager */
+  double contact_dist_threshold_;
   bool debug_; /**< @brief Enable debug information to be printed to the terminal */
 };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision.hpp
@@ -40,15 +40,18 @@ template <typename FloatType>
 DescartesCollision<FloatType>::DescartesCollision(const tesseract_environment::Environment::ConstPtr& collision_env,
                                                   std::vector<std::string> active_links,
                                                   std::vector<std::string> joint_names,
+                                                  double contact_dist_threshold,
                                                   bool debug)
   : state_solver_(collision_env->getStateSolver())
   , acm_(*(collision_env->getAllowedCollisionMatrix()))
   , active_link_names_(std::move(active_links))
   , joint_names_(std::move(joint_names))
   , contact_manager_(collision_env->getDiscreteContactManager())
+  , contact_dist_threshold_(contact_dist_threshold)
   , debug_(debug)
 {
   contact_manager_->setActiveCollisionObjects(active_link_names_);
+  contact_manager_->setContactDistanceThreshold(contact_dist_threshold_);
   contact_manager_->setIsContactAllowedFn(
       std::bind(&tesseract_motion_planners::DescartesCollision<FloatType>::isContactAllowed,
                 this,
@@ -63,9 +66,11 @@ DescartesCollision<FloatType>::DescartesCollision(const DescartesCollision& coll
   , active_link_names_(collision_interface.active_link_names_)
   , joint_names_(collision_interface.joint_names_)
   , contact_manager_(collision_interface.contact_manager_->clone())
+  , contact_dist_threshold_(collision_interface.contact_dist_threshold_)
   , debug_(collision_interface.debug_)
 {
   contact_manager_->setActiveCollisionObjects(active_link_names_);
+  contact_manager_->setContactDistanceThreshold(contact_dist_threshold_);
   contact_manager_->setIsContactAllowedFn(
       std::bind(&tesseract_motion_planners::DescartesCollision<FloatType>::isContactAllowed,
                 this,


### PR DESCRIPTION
Add a parameter to the constructor of `tesseract_motion_planners::DescartesCollision` that sets the contact distance threshold of its underlying `DiscreteContactManager`. This is useful if you want Descartes to provide a seed trajectory that leaves a buffer vs. collision geometry near the process waypoints, since I think the distance threshold defaults to 0.0 m otherwise.