### PR TITLE
Add descartes collision edge eval, Fix manipulation widget

### DIFF
--- a/tesseract/tesseract_environment/include/tesseract_environment/core/utils.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/utils.h
@@ -267,8 +267,8 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
               ss << " " << name;
 
             ss << std::endl
-               << "    State0: " << subtraj.row(iStep) << std::endl
-               << "    State1: " << subtraj.row(iStep + 1) << std::endl;
+               << "    State0: " << subtraj.row(iSubStep) << std::endl
+               << "    State1: " << subtraj.row(iSubStep + 1) << std::endl;
 
             CONSOLE_BRIDGE_logError(ss.str().c_str());
           }

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/utils.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/utils.h
@@ -83,12 +83,13 @@ inline void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
  * @param verbose Print out found collisions
  * @return True if collision was found, otherwise false.
  */
-inline bool checkTrajectorySegment(std::vector<tesseract_collision::ContactResultMap>& contacts,
-                                   tesseract_collision::ContinuousContactManager& manager,
-                                   const tesseract_environment::EnvState::Ptr& state0,
-                                   const tesseract_environment::EnvState::Ptr& state1,
-                                   tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
-                                   bool verbose = false)
+inline bool
+checkTrajectorySegment(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                       tesseract_collision::ContinuousContactManager& manager,
+                       const tesseract_environment::EnvState::Ptr& state0,
+                       const tesseract_environment::EnvState::Ptr& state1,
+                       tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
+                       bool verbose = false)
 {
   for (const auto& link_name : manager.getActiveCollisionObjects())
     manager.setCollisionObjectsTransform(link_name, state0->transforms[link_name], state1->transforms[link_name]);
@@ -126,11 +127,12 @@ inline bool checkTrajectorySegment(std::vector<tesseract_collision::ContactResul
  * @param verbose Print out found collisions
  * @return True if collision was found, otherwise false.
  */
-inline bool checkTrajectoryState(std::vector<tesseract_collision::ContactResultMap>& contacts,
-                                 tesseract_collision::DiscreteContactManager& manager,
-                                 const tesseract_environment::EnvState::Ptr& state,
-                                 tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
-                                 bool verbose = false)
+inline bool
+checkTrajectoryState(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                     tesseract_collision::DiscreteContactManager& manager,
+                     const tesseract_environment::EnvState::Ptr& state,
+                     tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
+                     bool verbose = false)
 {
   tesseract_collision::ContactResultMap collisions;
 

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/utils.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/utils.h
@@ -79,6 +79,7 @@ inline void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
  * @param manager A continuous contact manager
  * @param state0 First environment state
  * @param state1 Second environment state
+ * @param type The type of contact test to perform (FIRST, CLOSEST, ALL)
  * @param verbose Print out found collisions
  * @return True if collision was found, otherwise false.
  */
@@ -86,13 +87,14 @@ inline bool checkTrajectorySegment(std::vector<tesseract_collision::ContactResul
                                    tesseract_collision::ContinuousContactManager& manager,
                                    const tesseract_environment::EnvState::Ptr& state0,
                                    const tesseract_environment::EnvState::Ptr& state1,
+                                   tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
                                    bool verbose = false)
 {
   for (const auto& link_name : manager.getActiveCollisionObjects())
     manager.setCollisionObjectsTransform(link_name, state0->transforms[link_name], state1->transforms[link_name]);
 
   tesseract_collision::ContactResultMap collisions;
-  manager.contactTest(collisions, tesseract_collision::ContactTestType::FIRST);
+  manager.contactTest(collisions, type);
 
   if (!collisions.empty())
   {
@@ -120,12 +122,14 @@ inline bool checkTrajectorySegment(std::vector<tesseract_collision::ContactResul
  * @param contacts A vector of vector of ContactMap where each indicie corrisponds to a timestep
  * @param manager A discrete contact manager
  * @param state First environment state
+ * @param type The type of contact test to perform (FIRST, CLOSEST, ALL)
  * @param verbose Print out found collisions
  * @return True if collision was found, otherwise false.
  */
 inline bool checkTrajectoryState(std::vector<tesseract_collision::ContactResultMap>& contacts,
                                  tesseract_collision::DiscreteContactManager& manager,
                                  const tesseract_environment::EnvState::Ptr& state,
+                                 tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
                                  bool verbose = false)
 {
   tesseract_collision::ContactResultMap collisions;
@@ -133,7 +137,7 @@ inline bool checkTrajectoryState(std::vector<tesseract_collision::ContactResultM
   for (const auto& link_name : manager.getActiveCollisionObjects())
     manager.setCollisionObjectsTransform(link_name, state->transforms[link_name]);
 
-  manager.contactTest(collisions, tesseract_collision::ContactTestType::FIRST);
+  manager.contactTest(collisions, type);
 
   if (!collisions.empty())
   {
@@ -160,29 +164,29 @@ inline bool checkTrajectoryState(std::vector<tesseract_collision::ContactResultM
  * @brief Should perform a continuous collision check over the trajectory and stop on first collision.
  * @param contacts A vector of vector of ContactMap where each indicie corrisponds to a timestep
  * @param manager A continuous contact manager
- * @param env The environment
+ * @param state_solver The environment state solver
  * @param joint_names JointNames corresponding to the values in traj (must be in same order)
  * @param traj The joint values at each time step
- * @param first_only Indicates if it should return on first contact
+ * @param type The type of contact test to perform (FIRST, CLOSEST, ALL)
  * @return True if collision was found, otherwise false.
  */
 inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                             tesseract_collision::ContinuousContactManager& manager,
-                            const tesseract_environment::Environment& env,
+                            const tesseract_environment::StateSolver& state_solver,
                             const std::vector<std::string>& joint_names,
                             const tesseract_common::TrajArray& traj,
-                            const bool first_only = true,
-                            const bool verbose = false)
+                            tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
+                            bool verbose = false)
 {
   bool found = false;
 
   contacts.reserve(static_cast<size_t>(traj.rows() - 1));
   for (int iStep = 0; iStep < traj.rows() - 1; ++iStep)
   {
-    tesseract_environment::EnvState::Ptr state0 = env.getState(joint_names, traj.row(iStep));
-    tesseract_environment::EnvState::Ptr state1 = env.getState(joint_names, traj.row(iStep + 1));
+    tesseract_environment::EnvState::Ptr state0 = state_solver.getState(joint_names, traj.row(iStep));
+    tesseract_environment::EnvState::Ptr state1 = state_solver.getState(joint_names, traj.row(iStep + 1));
 
-    if (checkTrajectorySegment(contacts, manager, state0, state1, verbose))
+    if (checkTrajectorySegment(contacts, manager, state0, state1, type, verbose))
     {
       found = true;
       if (verbose)
@@ -202,7 +206,7 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
       }
     }
 
-    if (found && first_only)
+    if (found && (type == tesseract_collision::ContactTestType::FIRST))
       break;
   }
 
@@ -213,21 +217,21 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
  * @brief Should perform a continuous collision check over the trajectory and stop on first collision.
  * @param contacts A vector of vector of ContactMap where each indicie corrisponds to a timestep
  * @param manager A continuous contact manager
- * @param env The environment
+ * @param state_solver The environment state solver
  * @param joint_names JointNames corresponding to the values in traj (must be in same order)
  * @param traj The joint values at each time step
  * @param longest_valid_segment_length Used to check collisions between two state if norm(state0-state1) >
  * longest_valid_segment_length.
- * @param first_only Indicates if it should return on first contact
+ * @param type The type of contact test to perform (FIRST, CLOSEST, ALL)
  * @return True if collision was found, otherwise false.
  */
 inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                             tesseract_collision::ContinuousContactManager& manager,
-                            const tesseract_environment::Environment& env,
+                            const tesseract_environment::StateSolver& state_solver,
                             const std::vector<std::string>& joint_names,
                             const tesseract_common::TrajArray& traj,
                             double longest_valid_segment_length,
-                            bool first_only = true,
+                            tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
                             bool verbose = false)
 {
   bool found = false;
@@ -245,9 +249,9 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
 
       for (int iSubStep = 0; iSubStep < subtraj.rows() - 1; ++iSubStep)
       {
-        tesseract_environment::EnvState::Ptr state0 = env.getState(joint_names, subtraj.row(iSubStep));
-        tesseract_environment::EnvState::Ptr state1 = env.getState(joint_names, subtraj.row(iSubStep + 1));
-        if (checkTrajectorySegment(contacts, manager, state0, state1, verbose))
+        tesseract_environment::EnvState::Ptr state0 = state_solver.getState(joint_names, subtraj.row(iSubStep));
+        tesseract_environment::EnvState::Ptr state1 = state_solver.getState(joint_names, subtraj.row(iSubStep + 1));
+        if (checkTrajectorySegment(contacts, manager, state0, state1, type, verbose))
         {
           found = true;
           if (verbose)
@@ -268,18 +272,18 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
           }
         }
 
-        if (found && first_only)
+        if (found && (type == tesseract_collision::ContactTestType::FIRST))
           break;
       }
 
-      if (found && first_only)
+      if (found && (type == tesseract_collision::ContactTestType::FIRST))
         break;
     }
     else
     {
-      tesseract_environment::EnvState::Ptr state0 = env.getState(joint_names, traj.row(iStep));
-      tesseract_environment::EnvState::Ptr state1 = env.getState(joint_names, traj.row(iStep + 1));
-      if (checkTrajectorySegment(contacts, manager, state0, state1, verbose))
+      tesseract_environment::EnvState::Ptr state0 = state_solver.getState(joint_names, traj.row(iStep));
+      tesseract_environment::EnvState::Ptr state1 = state_solver.getState(joint_names, traj.row(iStep + 1));
+      if (checkTrajectorySegment(contacts, manager, state0, state1, type, verbose))
       {
         found = true;
         if (verbose)
@@ -299,7 +303,7 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
         }
       }
 
-      if (found && first_only)
+      if (found && (type == tesseract_collision::ContactTestType::FIRST))
         break;
     }
   }
@@ -311,27 +315,27 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
  * @brief Should perform a discrete collision check over the trajectory and stop on first collision.
  * @param contacts A vector of vector of ContactMap where each indicie corrisponds to a timestep
  * @param manager A continuous contact manager
- * @param env The environment
+ * @param state_solver The environment state solver
  * @param joint_names JointNames corresponding to the values in traj (must be in same order)
  * @param traj The joint values at each time step
- * @param first_only Indicates if it should return on first contact
+ * @param type The type of contact test to perform (FIRST, CLOSEST, ALL)
  * @return True if collision was found, otherwise false.
  */
 inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                             tesseract_collision::DiscreteContactManager& manager,
-                            const tesseract_environment::Environment& env,
+                            const tesseract_environment::StateSolver& state_solver,
                             const std::vector<std::string>& joint_names,
                             const tesseract_common::TrajArray& traj,
-                            const bool first_only = true,
-                            const bool verbose = false)
+                            tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
+                            bool verbose = false)
 {
   bool found = false;
 
   contacts.reserve(static_cast<size_t>(traj.rows()));
   for (int iStep = 0; iStep < traj.rows() - 1; ++iStep)
   {
-    tesseract_environment::EnvState::Ptr state = env.getState(joint_names, traj.row(iStep));
-    if (checkTrajectoryState(contacts, manager, state, verbose))
+    tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, traj.row(iStep));
+    if (checkTrajectoryState(contacts, manager, state, type, verbose))
     {
       found = true;
       if (verbose)
@@ -349,7 +353,7 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
       }
     }
 
-    if (found && first_only)
+    if (found && (type == tesseract_collision::ContactTestType::FIRST))
       break;
   }
 
@@ -360,22 +364,22 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
  * @brief Should perform a discrete collision check over the trajectory and stop on first collision.
  * @param contacts A vector of vector of ContactMap where each indicie corrisponds to a timestep
  * @param manager A continuous contact manager
- * @param env The environment
+ * @param state_solver The environment state solver
  * @param joint_names JointNames corresponding to the values in traj (must be in same order)
  * @param traj The joint values at each time step
  * @param longest_valid_segment_length Used to check collisions between two state if norm(state0-state1) >
  * longest_valid_segment_length.
- * @param first_only Indicates if it should return on first contact
+ * @param type The type of contact test to perform (FIRST, CLOSEST, ALL)
  * @return True if collision was found, otherwise false.
  */
 inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                             tesseract_collision::DiscreteContactManager& manager,
-                            const tesseract_environment::Environment& env,
+                            const tesseract_environment::StateSolver& state_solver,
                             const std::vector<std::string>& joint_names,
                             const tesseract_common::TrajArray& traj,
                             double longest_valid_segment_length,
-                            const bool first_only = true,
-                            const bool verbose = false)
+                            tesseract_collision::ContactTestType type = tesseract_collision::ContactTestType::FIRST,
+                            bool verbose = false)
 {
   bool found = false;
 
@@ -395,8 +399,8 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
 
       for (int iSubStep = 0; iSubStep < subtraj.rows() - 1; ++iSubStep)
       {
-        tesseract_environment::EnvState::Ptr state = env.getState(joint_names, subtraj.row(iSubStep));
-        if (checkTrajectoryState(contacts, manager, state, verbose))
+        tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, subtraj.row(iSubStep));
+        if (checkTrajectoryState(contacts, manager, state, type, verbose))
         {
           found = true;
           if (verbose)
@@ -415,17 +419,17 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
           }
         }
 
-        if (found && first_only)
+        if (found && (type == tesseract_collision::ContactTestType::FIRST))
           break;
       }
 
-      if (found && first_only)
+      if (found && (type == tesseract_collision::ContactTestType::FIRST))
         break;
     }
     else
     {
-      tesseract_environment::EnvState::Ptr state = env.getState(joint_names, traj.row(iStep));
-      if (checkTrajectoryState(contacts, manager, state, verbose))
+      tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, traj.row(iStep));
+      if (checkTrajectoryState(contacts, manager, state, type, verbose))
       {
         found = true;
         if (verbose)
@@ -443,7 +447,7 @@ inline bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& 
         }
       }
 
-      if (found && first_only)
+      if (found && (type == tesseract_collision::ContactTestType::FIRST))
         break;
     }
   }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/CMakeLists.txt
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/CMakeLists.txt
@@ -72,6 +72,7 @@ target_include_directories(${PROJECT_NAME}_ompl_trajopt_freespace PUBLIC
 add_library(${PROJECT_NAME}_descartes SHARED
   src/descartes/descartes_motion_planner.cpp
   src/descartes/descartes_collision.cpp
+  src/descartes/descartes_collision_edge_evaluator.cpp
   src/descartes/descartes_robot_sampler.cpp
   src/descartes/descartes_robot_positioner_sampler.cpp
   src/descartes/descartes_external_positioner_sampler.cpp

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
@@ -47,7 +47,7 @@ public:
    * @param joint_names The list of joint names in the order that the data will be provided to the validate function.
    * @param collision_safety_margin The minimum distance allowed from a collision object
    * @param longest_valid_segment_length Used to check collisions between two state if norm(state0-state1) >
-    * longest_valid_segment_length.
+   * longest_valid_segment_length.
    * @param debug If true, this print debug information to the terminal
    */
   DescartesCollision(const tesseract_environment::Environment::ConstPtr& collision_env,
@@ -103,7 +103,7 @@ private:
   std::vector<std::string> joint_names_;                             /**< @brief A vector of joint names */
   tesseract_collision::DiscreteContactManager::Ptr contact_manager_; /**< @brief The discrete contact manager */
   double collision_safety_margin_; /**< @brief The minimum allowed collision distance */
-  bool debug_; /**< @brief Enable debug information to be printed to the terminal */
+  bool debug_;                     /**< @brief Enable debug information to be printed to the terminal */
 };
 
 using DescartesCollisionF = DescartesCollision<float>;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
@@ -26,7 +26,7 @@
 #ifndef TESSERACT_MOTION_PLANNERS_DESCARTES_COLLISION_H
 #define TESSERACT_MOTION_PLANNERS_DESCARTES_COLLISION_H
 
-#include <tesseract/tesseract.h>
+#include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <descartes_light/interface/collision_interface.h>
@@ -45,12 +45,15 @@ public:
    * @param collision_env The collision Environment
    * @param active_links The list of active links
    * @param joint_names The list of joint names in the order that the data will be provided to the validate function.
+   * @param collision_safety_margin The minimum distance allowed from a collision object
+   * @param longest_valid_segment_length Used to check collisions between two state if norm(state0-state1) >
+    * longest_valid_segment_length.
    * @param debug If true, this print debug information to the terminal
    */
   DescartesCollision(const tesseract_environment::Environment::ConstPtr& collision_env,
                      std::vector<std::string> active_links,
                      std::vector<std::string> joint_names,
-                     double contact_dist_threshold = 0.025,
+                     double collision_safety_margin = 0.025,
                      bool debug = false);
   ~DescartesCollision() override = default;
 
@@ -99,8 +102,8 @@ private:
   std::vector<std::string> active_link_names_;                       /**< @brief A vector of active link names */
   std::vector<std::string> joint_names_;                             /**< @brief A vector of joint names */
   tesseract_collision::DiscreteContactManager::Ptr contact_manager_; /**< @brief The discrete contact manager */
-  double contact_dist_threshold_; /**< @brief Distance in meters for evaluating collisions */
-  bool debug_;                    /**< @brief Enable debug information to be printed to the terminal */
+  double collision_safety_margin_; /**< @brief The minimum allowed collision distance */
+  bool debug_; /**< @brief Enable debug information to be printed to the terminal */
 };
 
 using DescartesCollisionF = DescartesCollision<float>;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
@@ -91,6 +91,40 @@ protected:
    * @return True if allowed to be in collision, otherwise false
    */
   bool isContactAllowed(const std::string& a, const std::string& b) const;
+
+  // The member variables below are to cache the contact manager based on thread ID. Currently descartes is multi
+  // threaded but the methods used to implement collision checking are not thread safe. To prevent
+  // reconstructing the collision environment for every check this will cache a contact manager
+  // based on its thread ID.
+
+  /** @brief Contact manager caching mutex */
+  mutable std::mutex mutex_;
+
+  /** @brief The continuous contact manager cache */
+  mutable std::map<unsigned long int, tesseract_collision::ContinuousContactManager::Ptr> continuous_contact_managers_;
+
+  /** @brief The discrete contact manager cache */
+  mutable std::map<unsigned long int, tesseract_collision::DiscreteContactManager::Ptr> discrete_contact_managers_;
+
+  /**
+   * @brief Perform a continuous collision check between two states
+   * @param segment Trajectory containing two states
+   * @param results Store results from collision check.
+   * @return True if in collision otherwise false
+   */
+  bool continuousCollisionCheck(std::vector<tesseract_collision::ContactResultMap>& results,
+                                const tesseract_common::TrajArray& segment,
+                                bool find_best);
+
+  /**
+   * @brief Perform a continuous discrete check between two states
+   * @param segment Trajectory containing two states
+   * @param results Store results from collision check.
+   * @return True if in collision otherwise false
+   */
+  bool discreteCollisionCheck(std::vector<tesseract_collision::ContactResultMap>& results,
+                              const tesseract_common::TrajArray& segment,
+                              bool find_best);
 };
 
 using DescartesCollisionEdgeEvaluatorF = DescartesCollisionEdgeEvaluator<float>;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
@@ -3,11 +3,11 @@
  * @brief Tesseract Descartes Collision Edge Evaluator Implementation
  *
  * @author Levi Armstrong
- * @date April 18, 2018
+ * @date December 18, 2019
  * @version TODO
  * @bug No known bugs
  *
- * @copyright Copyright (c) 2017, Southwest Research Institute
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
  * @par License
  * Software License Agreement (Apache License)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
@@ -1,0 +1,97 @@
+/**
+ * @file descartes_collision_edge_evaluator.h
+ * @brief Tesseract Descartes Collision Edge Evaluator Implementation
+ *
+ * @author Levi Armstrong
+ * @date April 18, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_DESCARTES_COLLISION_EDGE_EVALUATOR_H
+#define TESSERACT_MOTION_PLANNERS_DESCARTES_COLLISION_EDGE_EVALUATOR_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <memory>
+#include <vector>
+#include <descartes_light/interface/edge_evaluator.h>
+#include <tesseract_environment/core/environment.h>
+#include <tesseract_collision/core/discrete_contact_manager.h>
+#include <tesseract_collision/core/continuous_contact_manager.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_motion_planners
+{
+template <typename FloatType>
+class DescartesCollisionEdgeEvaluator : public descartes_light::EdgeEvaluator<FloatType>
+{
+public:
+  DescartesCollisionEdgeEvaluator(const tesseract_environment::Environment::ConstPtr& collision_env,
+                                  std::vector<std::string> active_links,
+                                  std::vector<std::string> joint_names,
+                                  double collision_safety_margin = 0.025,
+                                  double longest_valid_segment_length = 0.5,
+                                  bool allow_collision = false,
+                                  bool debug = false);
+
+  bool evaluate(const descartes_light::Rung_<FloatType>& from,
+                const descartes_light::Rung_<FloatType>& to,
+                std::vector<typename descartes_light::LadderGraph<FloatType>::EdgeList>& edges) override;
+
+protected:
+  tesseract_environment::StateSolver::Ptr state_solver_;             /**< @brief The tesseract state solver */
+  tesseract_scene_graph::AllowedCollisionMatrix acm_;                /**< @brief The allowed collision matrix */
+  std::vector<std::string> active_link_names_;                       /**< @brief A vector of active link names */
+  std::vector<std::string> joint_names_;                             /**< @brief A vector of joint names */
+  tesseract_collision::DiscreteContactManager::Ptr discrete_contact_manager_; /**< @brief The discrete contact manager */
+  tesseract_collision::ContinuousContactManager::Ptr continuous_contact_manager_; /**< @brief The discrete contact manager */
+  double collision_safety_margin_; /**< @brief The minimum allowed collision distance */
+  double longest_valid_segment_length_; /**< @brief Used to check collisions between two state if norm(state0-state1) > longest_valid_segment_length. */
+  bool allow_collision_; /**< @brief If true and no valid edges are found it will return the one with the lowest cost */
+  bool debug_; /**< @brief Enable debug information to be printed to the terminal */
+  std::size_t dof_; /**< @brief The number of joints */
+
+  /**
+   * @brief Check continuous and discrete collision between two states
+   * @param out Output edge lists
+   * @param start Start state
+   * @param end End state
+   * @param next_idx Next idex
+   * @param find_best Indicate if best solution should be found
+   */
+  void considerEdge(typename descartes_light::LadderGraph<FloatType>::EdgeList& out,
+                    const FloatType* start,
+                    const FloatType* end,
+                    std::size_t next_idx,
+                    bool find_best);
+
+  /**
+   * @brief Check if two links are allowed to be in collision
+   * @param a The name of the first link
+   * @param b The name of the second link
+   * @return True if allowed to be in collision, otherwise false
+   */
+  bool isContactAllowed(const std::string& a, const std::string& b) const;
+};
+
+using DescartesCollisionEdgeEvaluatorF = DescartesCollisionEdgeEvaluator<float>;
+using DescartesCollisionEdgeEvaluatorD = DescartesCollisionEdgeEvaluator<double>;
+
+}  // namespace descartes_light
+#endif  // TESSERACT_MOTION_PLANNERS_DESCARTES_COLLISION_EDGE_EVALUATOR_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
@@ -55,17 +55,20 @@ public:
                 std::vector<typename descartes_light::LadderGraph<FloatType>::EdgeList>& edges) override;
 
 protected:
-  tesseract_environment::StateSolver::Ptr state_solver_;             /**< @brief The tesseract state solver */
-  tesseract_scene_graph::AllowedCollisionMatrix acm_;                /**< @brief The allowed collision matrix */
-  std::vector<std::string> active_link_names_;                       /**< @brief A vector of active link names */
-  std::vector<std::string> joint_names_;                             /**< @brief A vector of joint names */
-  tesseract_collision::DiscreteContactManager::Ptr discrete_contact_manager_; /**< @brief The discrete contact manager */
-  tesseract_collision::ContinuousContactManager::Ptr continuous_contact_manager_; /**< @brief The discrete contact manager */
-  double collision_safety_margin_; /**< @brief The minimum allowed collision distance */
-  double longest_valid_segment_length_; /**< @brief Used to check collisions between two state if norm(state0-state1) > longest_valid_segment_length. */
+  tesseract_environment::StateSolver::Ptr state_solver_; /**< @brief The tesseract state solver */
+  tesseract_scene_graph::AllowedCollisionMatrix acm_;    /**< @brief The allowed collision matrix */
+  std::vector<std::string> active_link_names_;           /**< @brief A vector of active link names */
+  std::vector<std::string> joint_names_;                 /**< @brief A vector of joint names */
+  tesseract_collision::DiscreteContactManager::Ptr discrete_contact_manager_; /**< @brief The discrete contact manager
+                                                                               */
+  tesseract_collision::ContinuousContactManager::Ptr continuous_contact_manager_; /**< @brief The discrete contact
+                                                                                     manager */
+  double collision_safety_margin_;      /**< @brief The minimum allowed collision distance */
+  double longest_valid_segment_length_; /**< @brief Used to check collisions between two state if norm(state0-state1) >
+                                           longest_valid_segment_length. */
   bool allow_collision_; /**< @brief If true and no valid edges are found it will return the one with the lowest cost */
-  bool debug_; /**< @brief Enable debug information to be printed to the terminal */
-  std::size_t dof_; /**< @brief The number of joints */
+  bool debug_;           /**< @brief Enable debug information to be printed to the terminal */
+  std::size_t dof_;      /**< @brief The number of joints */
 
   /**
    * @brief Check continuous and discrete collision between two states
@@ -93,5 +96,5 @@ protected:
 using DescartesCollisionEdgeEvaluatorF = DescartesCollisionEdgeEvaluator<float>;
 using DescartesCollisionEdgeEvaluatorD = DescartesCollisionEdgeEvaluator<double>;
 
-}  // namespace descartes_light
+}  // namespace tesseract_motion_planners
 #endif  // TESSERACT_MOTION_PLANNERS_DESCARTES_COLLISION_EDGE_EVALUATOR_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision.hpp
@@ -92,7 +92,8 @@ bool DescartesCollision<FloatType>::validate(const FloatType* pos, std::size_t s
   tesseract_environment::EnvState::Ptr env_state = state_solver_->getState(joint_names_, joint_angles);
 
   std::vector<tesseract_collision::ContactResultMap> results;
-  bool in_contact = checkTrajectoryState(results, *contact_manager_, env_state, tesseract_collision::ContactTestType::FIRST, debug_);
+  bool in_contact =
+      checkTrajectoryState(results, *contact_manager_, env_state, tesseract_collision::ContactTestType::FIRST, debug_);
   return (!in_contact);
 }
 
@@ -107,7 +108,8 @@ FloatType DescartesCollision<FloatType>::distance(const FloatType* pos, std::siz
   tesseract_environment::EnvState::Ptr env_state = state_solver_->getState(joint_names_, joint_angles);
 
   std::vector<tesseract_collision::ContactResultMap> results;
-  bool in_contact = checkTrajectoryState(results, *contact_manager_, env_state, tesseract_collision::ContactTestType::CLOSEST, debug_);
+  bool in_contact = checkTrajectoryState(
+      results, *contact_manager_, env_state, tesseract_collision::ContactTestType::CLOSEST, debug_);
 
   if (!in_contact)
     return static_cast<FloatType>(contact_manager_->getContactDistanceThreshold());

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
@@ -3,7 +3,7 @@
  * @brief Tesseract Descartes Collision Edge Evaluator Implementation
  *
  * @author Levi Armstrong
- * @date April 18, 2018
+ * @date December 18, 2019
  * @version TODO
  * @bug No known bugs
  *
@@ -80,6 +80,8 @@ bool DescartesCollisionEdgeEvaluator<FloatType>::evaluate(
     const descartes_light::Rung_<FloatType>& to,
     std::vector<typename descartes_light::LadderGraph<FloatType>::EdgeList>& edges)
 {
+  assert(from.data.size() % dof_ == 0);
+  assert(to.data.size() % dof_ == 0);
   const auto n_start = from.data.size() / dof_;
   const auto n_end = to.data.size() / dof_;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
@@ -1,0 +1,166 @@
+/**
+ * @file descartes_collision_edge_evaluator.hpp
+ * @brief Tesseract Descartes Collision Edge Evaluator Implementation
+ *
+ * @author Levi Armstrong
+ * @date April 18, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_IMPL_DESCARTES_COLLISION_EDGE_EVALUATOR_HPP
+#define TESSERACT_MOTION_PLANNERS_IMPL_DESCARTES_COLLISION_EDGE_EVALUATOR_HPP
+
+#include <tesseract/tesseract.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <numeric>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h>
+#include <tesseract_environment/core/utils.h>
+
+namespace tesseract_motion_planners
+{
+
+template <typename FloatType>
+DescartesCollisionEdgeEvaluator<FloatType>::DescartesCollisionEdgeEvaluator(const tesseract_environment::Environment::ConstPtr& collision_env,
+                                                                            std::vector<std::string> active_links,
+                                                                            std::vector<std::string> joint_names,
+                                                                            double collision_safety_margin,
+                                                                            double longest_valid_segment_length,
+                                                                            bool allow_collision,
+                                                                            bool debug)
+  : state_solver_(collision_env->getStateSolver())
+  , acm_(*(collision_env->getAllowedCollisionMatrix()))
+  , active_link_names_(std::move(active_links))
+  , joint_names_(std::move(joint_names))
+  , discrete_contact_manager_(collision_env->getDiscreteContactManager())
+  , continuous_contact_manager_(collision_env->getContinuousContactManager())
+  , collision_safety_margin_(collision_safety_margin)
+  , longest_valid_segment_length_(longest_valid_segment_length)
+  , allow_collision_(allow_collision)
+  , debug_(debug)
+  , dof_(joint_names_.size())
+{
+  discrete_contact_manager_->setActiveCollisionObjects(active_link_names_);
+  discrete_contact_manager_->setContactDistanceThreshold(collision_safety_margin_);
+  discrete_contact_manager_->setIsContactAllowedFn(
+      std::bind(&tesseract_motion_planners::DescartesCollisionEdgeEvaluator<FloatType>::isContactAllowed,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
+
+  continuous_contact_manager_->setActiveCollisionObjects(active_link_names_);
+  continuous_contact_manager_->setContactDistanceThreshold(collision_safety_margin_);
+  continuous_contact_manager_->setIsContactAllowedFn(
+      std::bind(&tesseract_motion_planners::DescartesCollisionEdgeEvaluator<FloatType>::isContactAllowed,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
+}
+
+template <typename FloatType>
+bool DescartesCollisionEdgeEvaluator<FloatType>::evaluate(const descartes_light::Rung_<FloatType>& from,
+                                                          const descartes_light::Rung_<FloatType>& to,
+                                                          std::vector<typename descartes_light::LadderGraph<FloatType>::EdgeList>& edges)
+{
+  const auto n_start = from.data.size() / dof_;
+  const auto n_end = to.data.size() / dof_;
+
+  // Allocate
+  edges.resize(n_start);
+
+  for (std::size_t i = 0; i < n_start; ++i)
+  {
+    const auto* start_vertex = from.data.data() + dof_ * i;
+    for (std::size_t j = 0; j < n_end; ++j)
+    {
+      const auto* end_vertex = to.data.data() + dof_ * j;
+
+      // Consider the edge:
+      considerEdge(edges[i], start_vertex, end_vertex, j, allow_collision_);
+    }
+  }
+
+  for (const auto& rung : edges)
+    if (!rung.empty())
+      return true;
+
+  return false;
+}
+
+template <typename FloatType>
+void DescartesCollisionEdgeEvaluator<FloatType>::considerEdge(typename descartes_light::LadderGraph<FloatType>::EdgeList& out,
+                                                              const FloatType* start,
+                                                              const FloatType* end,
+                                                              std::size_t next_idx,
+                                                              bool find_best)
+{
+  // Happens in two phases:
+  // 1. Compute the transform of all objects
+  tesseract_common::TrajArray segment(2, dof_);
+  for (size_t i = 0; i < dof_; ++i)
+  {
+    segment(0, static_cast<long>(i)) = start[i];
+    segment(1, static_cast<long>(i)) = end[i];
+  }
+
+  std::vector<tesseract_collision::ContactResultMap> discrete_results;
+  std::vector<tesseract_collision::ContactResultMap> continuous_results;
+  bool discrete_in_contact = tesseract_environment::checkTrajectory(discrete_results,
+                                              *discrete_contact_manager_,
+                                              *state_solver_,
+                                              joint_names_,
+                                              segment,
+                                              longest_valid_segment_length_,
+                                              (find_best) ? tesseract_collision::ContactTestType::CLOSEST : tesseract_collision::ContactTestType::FIRST,
+                                              debug_);
+
+  bool continuous_in_contact = tesseract_environment::checkTrajectory(continuous_results,
+                                              *continuous_contact_manager_,
+                                              *state_solver_,
+                                              joint_names_,
+                                              segment,
+                                              longest_valid_segment_length_,
+                                              (find_best) ? tesseract_collision::ContactTestType::CLOSEST : tesseract_collision::ContactTestType::FIRST,
+                                              debug_);
+
+  if (!discrete_in_contact && !continuous_in_contact)
+    out.emplace_back(0, next_idx);
+  else if (!discrete_in_contact && continuous_in_contact && find_best)
+    out.emplace_back(collision_safety_margin_ - continuous_results.begin()->begin()->second[0].distance, next_idx);
+  else if (discrete_in_contact && !continuous_in_contact && find_best)
+    out.emplace_back(collision_safety_margin_ - discrete_results.begin()->begin()->second[0].distance, next_idx);
+  else if (discrete_in_contact && continuous_in_contact && find_best)
+  {
+    double d = collision_safety_margin_ - discrete_results.begin()->begin()->second[0].distance;
+    double c = collision_safety_margin_ - continuous_results.begin()->begin()->second[0].distance;
+    out.emplace_back(std::max(d, c), next_idx);
+  }
+
+}
+
+template <typename FloatType>
+bool DescartesCollisionEdgeEvaluator<FloatType>::isContactAllowed(const std::string& a, const std::string& b) const
+{
+  return acm_.isCollisionAllowed(a, b);
+}
+
+}  // namespace descartes_light
+
+#endif // TESSERACT_MOTION_PLANNERS_IMPL_DESCARTES_COLLISION_EDGE_EVALUATOR_HPP

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
@@ -36,15 +36,15 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_motion_planners
 {
-
 template <typename FloatType>
-DescartesCollisionEdgeEvaluator<FloatType>::DescartesCollisionEdgeEvaluator(const tesseract_environment::Environment::ConstPtr& collision_env,
-                                                                            std::vector<std::string> active_links,
-                                                                            std::vector<std::string> joint_names,
-                                                                            double collision_safety_margin,
-                                                                            double longest_valid_segment_length,
-                                                                            bool allow_collision,
-                                                                            bool debug)
+DescartesCollisionEdgeEvaluator<FloatType>::DescartesCollisionEdgeEvaluator(
+    const tesseract_environment::Environment::ConstPtr& collision_env,
+    std::vector<std::string> active_links,
+    std::vector<std::string> joint_names,
+    double collision_safety_margin,
+    double longest_valid_segment_length,
+    bool allow_collision,
+    bool debug)
   : state_solver_(collision_env->getStateSolver())
   , acm_(*(collision_env->getAllowedCollisionMatrix()))
   , active_link_names_(std::move(active_links))
@@ -75,9 +75,10 @@ DescartesCollisionEdgeEvaluator<FloatType>::DescartesCollisionEdgeEvaluator(cons
 }
 
 template <typename FloatType>
-bool DescartesCollisionEdgeEvaluator<FloatType>::evaluate(const descartes_light::Rung_<FloatType>& from,
-                                                          const descartes_light::Rung_<FloatType>& to,
-                                                          std::vector<typename descartes_light::LadderGraph<FloatType>::EdgeList>& edges)
+bool DescartesCollisionEdgeEvaluator<FloatType>::evaluate(
+    const descartes_light::Rung_<FloatType>& from,
+    const descartes_light::Rung_<FloatType>& to,
+    std::vector<typename descartes_light::LadderGraph<FloatType>::EdgeList>& edges)
 {
   const auto n_start = from.data.size() / dof_;
   const auto n_end = to.data.size() / dof_;
@@ -105,11 +106,12 @@ bool DescartesCollisionEdgeEvaluator<FloatType>::evaluate(const descartes_light:
 }
 
 template <typename FloatType>
-void DescartesCollisionEdgeEvaluator<FloatType>::considerEdge(typename descartes_light::LadderGraph<FloatType>::EdgeList& out,
-                                                              const FloatType* start,
-                                                              const FloatType* end,
-                                                              std::size_t next_idx,
-                                                              bool find_best)
+void DescartesCollisionEdgeEvaluator<FloatType>::considerEdge(
+    typename descartes_light::LadderGraph<FloatType>::EdgeList& out,
+    const FloatType* start,
+    const FloatType* end,
+    std::size_t next_idx,
+    bool find_best)
 {
   // Happens in two phases:
   // 1. Compute the transform of all objects
@@ -122,23 +124,25 @@ void DescartesCollisionEdgeEvaluator<FloatType>::considerEdge(typename descartes
 
   std::vector<tesseract_collision::ContactResultMap> discrete_results;
   std::vector<tesseract_collision::ContactResultMap> continuous_results;
-  bool discrete_in_contact = tesseract_environment::checkTrajectory(discrete_results,
-                                              *discrete_contact_manager_,
-                                              *state_solver_,
-                                              joint_names_,
-                                              segment,
-                                              longest_valid_segment_length_,
-                                              (find_best) ? tesseract_collision::ContactTestType::CLOSEST : tesseract_collision::ContactTestType::FIRST,
-                                              debug_);
+  bool discrete_in_contact = tesseract_environment::checkTrajectory(
+      discrete_results,
+      *discrete_contact_manager_,
+      *state_solver_,
+      joint_names_,
+      segment,
+      longest_valid_segment_length_,
+      (find_best) ? tesseract_collision::ContactTestType::CLOSEST : tesseract_collision::ContactTestType::FIRST,
+      debug_);
 
-  bool continuous_in_contact = tesseract_environment::checkTrajectory(continuous_results,
-                                              *continuous_contact_manager_,
-                                              *state_solver_,
-                                              joint_names_,
-                                              segment,
-                                              longest_valid_segment_length_,
-                                              (find_best) ? tesseract_collision::ContactTestType::CLOSEST : tesseract_collision::ContactTestType::FIRST,
-                                              debug_);
+  bool continuous_in_contact = tesseract_environment::checkTrajectory(
+      continuous_results,
+      *continuous_contact_manager_,
+      *state_solver_,
+      joint_names_,
+      segment,
+      longest_valid_segment_length_,
+      (find_best) ? tesseract_collision::ContactTestType::CLOSEST : tesseract_collision::ContactTestType::FIRST,
+      debug_);
 
   if (!discrete_in_contact && !continuous_in_contact)
     out.emplace_back(0, next_idx);
@@ -152,7 +156,6 @@ void DescartesCollisionEdgeEvaluator<FloatType>::considerEdge(typename descartes
     double c = collision_safety_margin_ - continuous_results.begin()->begin()->second[0].distance;
     out.emplace_back(std::max(d, c), next_idx);
   }
-
 }
 
 template <typename FloatType>
@@ -161,6 +164,6 @@ bool DescartesCollisionEdgeEvaluator<FloatType>::isContactAllowed(const std::str
   return acm_.isCollisionAllowed(a, b);
 }
 
-}  // namespace descartes_light
+}  // namespace tesseract_motion_planners
 
-#endif // TESSERACT_MOTION_PLANNERS_IMPL_DESCARTES_COLLISION_EDGE_EVALUATOR_HPP
+#endif  // TESSERACT_MOTION_PLANNERS_IMPL_DESCARTES_COLLISION_EDGE_EVALUATOR_HPP

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -165,10 +165,10 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(PlannerRes
   collisions.clear();
   bool found = tesseract_environment::checkTrajectory(collisions,
                                                       *manager,
-                                                      *config_->tesseract->getEnvironmentConst(),
+                                                      *config_->tesseract->getEnvironmentConst()->getStateSolver(),
                                                       response.joint_trajectory.joint_names,
                                                       response.joint_trajectory.trajectory,
-                                                      true,
+                                                      tesseract_collision::ContactTestType::FIRST,
                                                       verbose);
 
   CONSOLE_BRIDGE_logInform("Descartes planning time: %.3f",

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_freespace_planner.hpp
@@ -116,15 +116,16 @@ tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::solve(PlannerRes
 
   // Check and report collisions
   std::vector<tesseract_collision::ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = config_->tesseract->getEnvironmentConst()->getStateSolver();
   continuous_contact_manager_->setContactDistanceThreshold(0);
   collisions.clear();
   bool found = tesseract_environment::checkTrajectory(collisions,
                                                       *continuous_contact_manager_,
-                                                      *(config_->tesseract->getEnvironmentConst()),
+                                                      *state_solver,
                                                       kin_->getJointNames(),
                                                       traj,
                                                       config_->longest_valid_segment_length,
-                                                      true,
+                                                      tesseract_collision::ContactTestType::FIRST,
                                                       verbose);
 
   // Do a discrete check until continuous collision checking is updated to do dynamic-dynamic checking
@@ -133,11 +134,11 @@ tesseract_common::StatusCode OMPLFreespacePlanner<PlannerType>::solve(PlannerRes
 
   found = found || tesseract_environment::checkTrajectory(collisions,
                                                           *discrete_contact_manager_,
-                                                          *(config_->tesseract->getEnvironmentConst()),
+                                                          *state_solver,
                                                           kin_->getJointNames(),
                                                           traj,
                                                           config_->longest_valid_segment_length,
-                                                          true,
+                                                          tesseract_collision::ContactTestType::FIRST,
                                                           verbose);
 
   // Set the contact distance back to original incase solve was called again.

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/descartes/descartes_collision_edge_evaluator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/descartes/descartes_collision_edge_evaluator.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file descartes_collision_edge_evaluator.cpp
+ * @brief Tesseract Descartes Collision Edge Evaluator Implementation
+ *
+ * @author Levi Armstrong
+ * @date April 18, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp>
+
+namespace tesseract_motion_planners
+{
+// Explicit template instantiation
+template class DescartesCollisionEdgeEvaluator<float>;
+template class DescartesCollisionEdgeEvaluator<double>;
+
+}  // namespace tesseract_motion_planners

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -154,6 +154,7 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(PlannerResponse& respon
     length = LONGEST_VALID_SEGMENT_FRACTION_DEFAULT * extent;
   }
   std::vector<tesseract_collision::ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = config_->prob->GetEnv()->getStateSolver();
   tesseract_collision::ContinuousContactManager::Ptr continuous_manager =
       config_->prob->GetEnv()->getContinuousContactManager();
   tesseract_environment::AdjacencyMap::Ptr adjacency_map =
@@ -166,11 +167,11 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(PlannerResponse& respon
   collisions.clear();
   bool found = checkTrajectory(collisions,
                                *continuous_manager,
-                               *(config_->prob->GetEnv()),
+                               *state_solver,
                                config_->prob->GetKin()->getJointNames(),
                                getTraj(opt.x(), config_->prob->GetVars()),
                                length,
-                               true,
+                               tesseract_collision::ContactTestType::FIRST,
                                verbose);
 
   // Do a discrete check until continuous collision checking is updated to do dynamic-dynamic checking
@@ -182,11 +183,11 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(PlannerResponse& respon
 
   found = found || checkTrajectory(collisions,
                                    *discrete_manager,
-                                   *(config_->prob->GetEnv()),
+                                   *state_solver,
                                    config_->prob->GetKin()->getJointNames(),
                                    getTraj(opt.x(), config_->prob->GetVars()),
                                    length,
-                                   true,
+                                   tesseract_collision::ContactTestType::FIRST,
                                    verbose);
 
   // Send response

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
@@ -250,6 +250,7 @@ bool BasicCartesianExample::run()
   ROS_INFO("basic cartesian plan example");
 
   std::vector<ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = prob->GetEnv()->getStateSolver();
   ContinuousContactManager::Ptr manager = prob->GetEnv()->getContinuousContactManager();
   AdjacencyMap::Ptr adjacency_map =
       std::make_shared<tesseract_environment::AdjacencyMap>(prob->GetEnv()->getSceneGraph(),
@@ -260,7 +261,7 @@ bool BasicCartesianExample::run()
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   bool found =
-      checkTrajectory(collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), prob->GetInitTraj());
+      checkTrajectory(collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), prob->GetInitTraj());
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
@@ -280,7 +281,7 @@ bool BasicCartesianExample::run()
 
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
 

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
@@ -388,6 +388,7 @@ bool CarSeatExample::run()
   plotter->plotTrajectory(prob->GetKin()->getJointNames(), getTraj(pick1_opt.x(), prob->GetVars()));
 
   std::vector<ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = prob->GetEnv()->getStateSolver();
   ContinuousContactManager::Ptr manager = prob->GetEnv()->getContinuousContactManager();
   AdjacencyMap::Ptr adjacency_map =
       std::make_shared<tesseract_environment::AdjacencyMap>(prob->GetEnv()->getSceneGraph(),
@@ -398,7 +399,7 @@ bool CarSeatExample::run()
   manager->setContactDistanceThreshold(0);
 
   bool found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(pick1_opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(pick1_opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Pick seat #1 trajectory is in collision") : ("Pick seat #1 trajectory is collision free"));
 
@@ -458,7 +459,7 @@ bool CarSeatExample::run()
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(place1_opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(place1_opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Place seat #1 trajectory is in collision") : ("Place seat #1 trajectory is collision free"));
 
@@ -511,7 +512,7 @@ bool CarSeatExample::run()
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(pick2_opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(pick2_opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Pick seat #2 trajectory is in collision") : ("Pick seat #2 trajectory is collision free"));
 

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_up_right_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_up_right_example.cpp
@@ -244,6 +244,7 @@ bool GlassUpRightExample::run()
   ROS_INFO("glass upright plan example");
 
   std::vector<ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = prob->GetEnv()->getStateSolver();
   ContinuousContactManager::Ptr manager = prob->GetEnv()->getContinuousContactManager();
   AdjacencyMap::Ptr adjacency_map =
       std::make_shared<tesseract_environment::AdjacencyMap>(prob->GetEnv()->getSceneGraph(),
@@ -254,7 +255,7 @@ bool GlassUpRightExample::run()
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   bool found =
-      checkTrajectory(collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), prob->GetInitTraj());
+      checkTrajectory(collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), prob->GetInitTraj());
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
@@ -303,7 +304,7 @@ bool GlassUpRightExample::run()
 
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
 

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
@@ -254,6 +254,7 @@ bool PuzzlePieceAuxillaryAxesExample::run()
   ROS_INFO("puzzle piece plan");
 
   std::vector<ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = prob->GetEnv()->getStateSolver();
   ContinuousContactManager::Ptr manager = prob->GetEnv()->getContinuousContactManager();
   AdjacencyMap::Ptr adjacency_map =
       std::make_shared<tesseract_environment::AdjacencyMap>(prob->GetEnv()->getSceneGraph(),
@@ -264,7 +265,7 @@ bool PuzzlePieceAuxillaryAxesExample::run()
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   bool found =
-      checkTrajectory(collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), prob->GetInitTraj());
+      checkTrajectory(collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), prob->GetInitTraj());
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
@@ -285,7 +286,7 @@ bool PuzzlePieceAuxillaryAxesExample::run()
 
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
 

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
@@ -270,6 +270,7 @@ bool PuzzlePieceExample::run()
   ROS_INFO("puzzle piece plan");
 
   std::vector<ContactResultMap> collisions;
+  tesseract_environment::StateSolver::Ptr state_solver = prob->GetEnv()->getStateSolver();
   ContinuousContactManager::Ptr manager = prob->GetEnv()->getContinuousContactManager();
   AdjacencyMap::Ptr adjacency_map =
       std::make_shared<tesseract_environment::AdjacencyMap>(prob->GetEnv()->getSceneGraph(),
@@ -280,7 +281,7 @@ bool PuzzlePieceExample::run()
   manager->setContactDistanceThreshold(0);
   collisions.clear();
   bool found =
-      checkTrajectory(collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), prob->GetInitTraj());
+      checkTrajectory(collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), prob->GetInitTraj());
 
   ROS_INFO((found) ? ("Initial trajectory is in collision") : ("Initial trajectory is collision free"));
 
@@ -303,7 +304,7 @@ bool PuzzlePieceExample::run()
 
   collisions.clear();
   found = checkTrajectory(
-      collisions, *manager, *prob->GetEnv(), prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
+      collisions, *manager, *state_solver, prob->GetKin()->getJointNames(), getTraj(opt.x(), prob->GetVars()));
 
   ROS_INFO((found) ? ("Final trajectory is in collision") : ("Final trajectory is collision free"));
 

--- a/tesseract_ros/tesseract_rviz/src/render_tools/manipulation_widget.cpp
+++ b/tesseract_ros/tesseract_rviz/src/render_tools/manipulation_widget.cpp
@@ -279,8 +279,8 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
     {
       inv_seed_[i] = joints_[j];
       const auto& joint = scene_graph->getJoint(j);
-      QString joint_description = QString("Limits: [%1, %2]")
-                                .arg(QString("%1").arg(limits(i, 0)), QString("%1").arg(limits(i, 1)));
+      QString joint_description =
+          QString("Limits: [%1, %2]").arg(QString("%1").arg(limits(i, 0)), QString("%1").arg(limits(i, 1)));
 
       rviz::FloatProperty* joint_value_property = new rviz::FloatProperty(QString::fromStdString(j),
                                                                           static_cast<float>(joints_[j]),
@@ -288,7 +288,6 @@ bool ManipulationWidget::changeManipulator(const QString& manipulator)
                                                                           nullptr,
                                                                           SLOT(userInputJointValuesChanged()),
                                                                           this);
-
 
       joint_value_property->setMin(static_cast<float>(limits(i, 0)));
       joint_value_property->setMax(static_cast<float>(limits(i, 1)));


### PR DESCRIPTION
This PR includes:

- Fixed manipulation widget to handle continuous joints
- Update checkTrajectory and supporting function to leverage state solver and contact test type
- Add a descartes collision edge evaluator