### PR TITLE
TrajOpt Config Update: Avoid Singularity 

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -110,6 +110,10 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
   bool smooth_jerks = true;
   /** @brief This default to all ones, but allows you to weight different joints */
   Eigen::VectorXd jerk_coeff;
+  /** @brief If true, applies a cost to avoid kinematic singularities */
+  bool avoid_singularity = true;
+  /** @brief Optimization weight associated with kinematic singularity avoidance */
+  double avoid_singularity_coeff = 5.0;
 
   /** @brief Error function that is set as a constraint for each timestep.
    *

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -111,7 +111,7 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
   /** @brief This default to all ones, but allows you to weight different joints */
   Eigen::VectorXd jerk_coeff;
   /** @brief If true, applies a cost to avoid kinematic singularities */
-  bool avoid_singularity = true;
+  bool avoid_singularity = false;
   /** @brief Optimization weight associated with kinematic singularity avoidance */
   double avoid_singularity_coeff = 5.0;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
@@ -35,26 +35,26 @@ trajopt::TermInfo::Ptr createJointWaypointTermInfo(const JointWaypoint::ConstPtr
                                                    int ind,
                                                    const std::vector<std::string>& joint_names,
                                                    double coeff = 1.0,
-                                                   const std::string& name = "joint_position");
+                                                   const std::string& name = "joint_waypoint");
 
 trajopt::TermInfo::Ptr createJointTolerancedWaypointTermInfo(const JointTolerancedWaypoint::ConstPtr& waypoint,
                                                              int ind,
                                                              const std::vector<std::string>& joint_names,
                                                              double coeff = 0.1,
-                                                             const std::string& name = "joint_toleranced_position");
+                                                             const std::string& name = "joint_tol_waypoint");
 
 trajopt::TermInfo::Ptr createCartesianWaypointTermInfo(const CartesianWaypoint::ConstPtr& waypoint,
                                                        int ind,
                                                        const std::string& link,
                                                        const Eigen::Isometry3d& tcp = Eigen::Isometry3d::Identity(),
-                                                       const std::string& name = "cartesian_position_position");
+                                                       const std::string& name = "cart_waypoint");
 
 trajopt::TermInfo::Ptr
 createDynamicCartesianWaypointTermInfo(const CartesianWaypoint::ConstPtr& waypoint,
                                        int ind,
                                        const std::string& link,
                                        const Eigen::Isometry3d& tcp = Eigen::Isometry3d::Identity(),
-                                       const std::string& name = "dynamic_cartesian_position");
+                                       const std::string& name = "dyn_cart_waypoint");
 
 struct WaypointTermInfo
 {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
@@ -114,6 +114,11 @@ trajopt::TermInfo::Ptr createUserDefinedTermInfo(int n_steps,
                                                  sco::MatrixOfVector::func jacobian_function,
                                                  const std::string& name = "user_defined");
 
+trajopt::TermInfo::Ptr createAvoidSingularityTermInfo(const int n_steps,
+                                                      const std::string& link,
+                                                      const double coeff = 5.0,
+                                                      const std::string& name = "avoid_singularity");
+
 }  // namespace tesseract_motion_planners
 
 #endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_UTILS_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
@@ -114,9 +114,9 @@ trajopt::TermInfo::Ptr createUserDefinedTermInfo(int n_steps,
                                                  sco::MatrixOfVector::func jacobian_function,
                                                  const std::string& name = "user_defined");
 
-trajopt::TermInfo::Ptr createAvoidSingularityTermInfo(const int n_steps,
+trajopt::TermInfo::Ptr createAvoidSingularityTermInfo(int n_steps,
                                                       const std::string& link,
-                                                      const double coeff = 5.0,
+                                                      double coeff = 5.0,
                                                       const std::string& name = "avoid_singularity");
 
 }  // namespace tesseract_motion_planners

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -258,6 +258,13 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerDefaultConfig::g
     }
   }
 
+  // Avoid singularity
+  if (avoid_singularity)
+  {
+    trajopt::TermInfo::Ptr ti = createAvoidSingularityTermInfo(pci.basic_info.n_steps, link, avoid_singularity_coeff);
+    pci.cost_infos.push_back(ti);
+  }
+
   return std::make_shared<trajopt::ProblemConstructionInfo>(pci);
 }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
@@ -335,7 +335,7 @@ trajopt::TermInfo::Ptr createUserDefinedTermInfo(int n_steps,
 }
 
 trajopt::TermInfo::Ptr
-createAvoidSingularityTermInfo(const int n_steps, const std::string& link, const double coeff, const std::string& name)
+createAvoidSingularityTermInfo(int n_steps, const std::string& link, double coeff, const std::string& name)
 {
   auto as = std::make_shared<trajopt::AvoidSingularityTermInfo>();
   as->term_type = trajopt::TT_COST;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
@@ -334,4 +334,18 @@ trajopt::TermInfo::Ptr createUserDefinedTermInfo(int n_steps,
   return ef;
 }
 
+trajopt::TermInfo::Ptr
+createAvoidSingularityTermInfo(const int n_steps, const std::string& link, const double coeff, const std::string& name)
+{
+  auto as = std::make_shared<trajopt::AvoidSingularityTermInfo>();
+  as->term_type = trajopt::TT_COST;
+  as->link = link;
+  as->first_step = 0;
+  as->last_step = n_steps - 1;
+  as->coeffs = std::vector<double>(1, coeff);
+  as->name = name;
+
+  return as;
+}
+
 }  // namespace tesseract_motion_planners

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -113,7 +113,7 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(PlannerResponse& respon
 
   // Set Log Level
   if (verbose)
-    util::gLogLevel = util::LevelDebug;
+    util::gLogLevel = util::LevelInfo;
   else
     util::gLogLevel = util::LevelWarn;
 


### PR DESCRIPTION
This PR updates the TrajOpt Default Configuration class with a boolean and coefficient value for using the new TrajOpt avoid singularity cost