### PR TITLE
Explictly look for libccd

### DIFF
--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -10,6 +10,9 @@ find_package(tesseract_common REQUIRED)
 find_package(Bullet REQUIRED)
 find_package(fcl REQUIRED)
 
+# We need to find ccd ourselves because FCL doesn't do it in their fclConfig.cmake
+find_package(ccd REQUIRED)
+
 # Create interface for core
 add_library(${PROJECT_NAME}_core INTERFACE)
 target_link_libraries(${PROJECT_NAME}_core INTERFACE tesseract::tesseract_geometry ${Boost_LIBRARIES} ${BULLET_LIBRARIES})

--- a/tesseract/tesseract_collision/cmake/tesseract_collision-config.cmake.in
+++ b/tesseract/tesseract_collision/cmake/tesseract_collision-config.cmake.in
@@ -17,5 +17,6 @@ find_dependency(tesseract_geometry)
 find_dependency(tesseract_common)
 find_dependency(Bullet)
 find_dependency(fcl)
+find_dependency(ccd)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")


### PR DESCRIPTION
As FCL doesn't do it in their config file, we need to do it ourselves

This would fix #191 , but is suboptimal as FCL actually uses a more complex logic to fallback on pkg-config if they can't find the CMake package.