### PR TITLE
Update trajopt planner handling of fixed start and end states for collision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - ROSINSTALL_FILENAME=dependencies.rosinstall
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
-    - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_RUN_TESTING=OFF -DSWIG_EXECUTABLE=/usr/local/bin/swig"
+    - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_RUN_TESTING=OFF"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
     - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
@@ -28,7 +28,7 @@ env:
 jobs:
   include:
     - os: linux
-      dist: xenial
+      dist: bionic
       language: cpp
       env:
       - ROS_DISTRO="melodic"
@@ -41,35 +41,24 @@ jobs:
         directories:
           - $HOME/.ccache
     - os: linux
-      dist: trusty
+      dist: xenial
       language: cpp
       env:
       - ROS_DISTRO="kinetic"
       - DOCKER_IMAGE=lharmstrong/tesseract:kinetic
-      - BADGE=trusty
-      cache:
-        directories:
-          - $HOME/.ccache
-    - os: linux
-      dist: xenial
-      language: cpp
-      env:
-      - ROS_DISTRO="melodic"
-      - DOCKER_IMAGE=lharmstrong/tesseract:melodic
-      - ROS_PARALLEL_JOBS=-j4
-      - ROS_PARALLEL_TEST_JOBS=-j4
       - BADGE=xenial
       cache:
         directories:
           - $HOME/.ccache
     - os: linux
-      dist: trusty
+      dist: bionic
       language: cpp
       env:
-      - ROS_DISTRO="kinetic"
-      - ROS_REPO=ros-shadow-fixed
-      - DOCKER_IMAGE=lharmstrong/tesseract:kinetic
-      - BADGE=trusty-shadow
+      - ROS_DISTRO="melodic"
+      - DOCKER_IMAGE=lharmstrong/tesseract:melodic
+      - ROS_PARALLEL_JOBS=-j4
+      - ROS_PARALLEL_TEST_JOBS=-j4
+      - BADGE=bionic
       cache:
         directories:
           - $HOME/.ccache
@@ -77,18 +66,29 @@ jobs:
       dist: xenial
       language: cpp
       env:
+      - ROS_DISTRO="kinetic"
+      - ROS_REPO=ros-shadow-fixed
+      - DOCKER_IMAGE=lharmstrong/tesseract:kinetic
+      - BADGE=xenial-shadow
+      cache:
+        directories:
+          - $HOME/.ccache
+    - os: linux
+      dist: bionic
+      language: cpp
+      env:
       - ROS_DISTRO="melodic"
       - ROS_REPO=ros-shadow-fixed
       - DOCKER_IMAGE=lharmstrong/tesseract:melodic
       - ROS_PARALLEL_JOBS=-j4
       - ROS_PARALLEL_TEST_JOBS=-j4
-      - BADGE=xenial-shadow
+      - BADGE=bionic-shadow
       cache:
         directories:
           - $HOME/.ccache
   allow_failures:
-    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic BADGE=trusty-shadow
-    - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4 BADGE=xenial-shadow
+    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic BADGE=xenial-shadow
+    - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4 BADGE=bionic-shadow
 
 install:
   - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -290,11 +290,11 @@ public:
 };
 
 inline void
-GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, float& outsupport, btVector3& outpt)
+GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, btScalar& outsupport, btVector3& outpt)
 {
   btVector3 ptSum(0, 0, 0);
-  float ptCount = 0;
-  float maxSupport = -1000;
+  btScalar ptCount = 0;
+  btScalar maxSupport = -1000;
 
   const auto* pshape = dynamic_cast<const btPolyhedralConvexShape*>(shape);
   if (pshape)
@@ -306,7 +306,7 @@ GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, floa
       btVector3 pt;
       pshape->getVertex(i, pt);
 
-      float sup = pt.dot(localNormal);
+      btScalar sup = pt.dot(localNormal);
       if (sup > maxSupport + BULLET_EPSILON)
       {
         ptCount = 1;
@@ -460,18 +460,18 @@ inline void calculateContinuousData(ContactResult* col,
 
   // Calculate the contact point at the start location using the casted normal vector in thapes local coordinate system
   btVector3 shape_ptLocal0;
-  float shape_localsup0;
+  btScalar shape_localsup0;
   GetAverageSupport(shape->m_shape, shape_normalLocal0, shape_localsup0, shape_ptLocal0);
   btVector3 shape_ptWorld0 = shape_tfWorld0 * shape_ptLocal0;
 
   // Calculate the contact point at the final location using the casted normal vector in thapes local coordinate system
   btVector3 shape_ptLocal1;
-  float shape_localsup1;
+  btScalar shape_localsup1;
   GetAverageSupport(shape->m_shape, shape_normalLocal1, shape_localsup1, shape_ptLocal1);
   btVector3 shape_ptWorld1 = shape_tfWorld1 * shape_ptLocal1;
 
-  float shape_sup0 = normal_world.dot(shape_ptWorld0);
-  float shape_sup1 = normal_world.dot(shape_ptWorld1);
+  btScalar shape_sup0 = normal_world.dot(shape_ptWorld0);
+  btScalar shape_sup1 = normal_world.dot(shape_ptWorld1);
 
   // TODO: this section is potentially problematic. think hard about the math
   if (shape_sup0 - shape_sup1 > BULLET_SUPPORT_FUNC_TOLERANCE)
@@ -488,8 +488,8 @@ inline void calculateContinuousData(ContactResult* col,
   {
     // Given the contact point at the start and final location along with the casted contact point
     // the time between 0 and 1 can be calculated along the path between the start and final location contact occurs.
-    float l0c = (pt_world - shape_ptWorld0).length();
-    float l1c = (pt_world - shape_ptWorld1).length();
+    btScalar l0c = (pt_world - shape_ptWorld0).length();
+    btScalar l1c = (pt_world - shape_ptWorld1).length();
 
     col->nearest_points_local[link_index] =
         convertBtToEigen(link_tf_inv * (shape_tfWorld0 * ((shape_ptLocal0 + shape_ptLocal1) / 2.0)));

--- a/tesseract/tesseract_collision/src/bullet/bullet_utils.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_utils.cpp
@@ -178,7 +178,7 @@ btCollisionShape* createShapePrimitive(const tesseract_geometry::Octree::ConstPt
           geomTrans.setIdentity();
           geomTrans.setOrigin(btVector3(
               static_cast<btScalar>(it.getX()), static_cast<btScalar>(it.getY()), static_cast<btScalar>(it.getZ())));
-          auto l = static_cast<btScalar>(size / 2);
+          auto l = static_cast<btScalar>(size / 2.0);
           auto* childshape = new btBoxShape(btVector3(l, l, l));
           childshape->setUserIndex(shape_index);
           childshape->setMargin(BULLET_MARGIN);
@@ -203,7 +203,7 @@ btCollisionShape* createShapePrimitive(const tesseract_geometry::Octree::ConstPt
               static_cast<btScalar>(it.getX()), static_cast<btScalar>(it.getY()), static_cast<btScalar>(it.getZ())));
           auto* childshape = new btSphereShape(static_cast<btScalar>((size / 2)));
           childshape->setUserIndex(shape_index);
-          childshape->setMargin(BULLET_MARGIN);
+          // Sphere is a special case where you do not modify the margin which is internally set to the radius
           cow->manage(childshape);
 
           subshape->addChildShape(geomTrans, childshape);
@@ -225,7 +225,7 @@ btCollisionShape* createShapePrimitive(const tesseract_geometry::Octree::ConstPt
               static_cast<btScalar>(it.getX()), static_cast<btScalar>(it.getY()), static_cast<btScalar>(it.getZ())));
           auto* childshape = new btSphereShape(static_cast<btScalar>(std::sqrt(2 * ((size / 2) * (size / 2)))));
           childshape->setUserIndex(shape_index);
-          childshape->setMargin(BULLET_MARGIN);
+          // Sphere is a special case where you do not modify the margin which is internally set to the radius
           cow->manage(childshape);
 
           subshape->addChildShape(geomTrans, childshape);
@@ -250,48 +250,56 @@ btCollisionShape* createShapePrimitive(const CollisionShapeConstPtr& geom, Colli
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Box>(geom));
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     case tesseract_geometry::GeometryType::SPHERE:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Sphere>(geom));
       shape->setUserIndex(shape_index);
+      // Sphere is a special case where you do not modify the margin which is internally set to the radius
       break;
     }
     case tesseract_geometry::GeometryType::CYLINDER:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Cylinder>(geom));
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     case tesseract_geometry::GeometryType::CONE:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Cone>(geom));
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     case tesseract_geometry::GeometryType::CAPSULE:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Capsule>(geom));
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     case tesseract_geometry::GeometryType::MESH:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Mesh>(geom), cow, shape_index);
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     case tesseract_geometry::GeometryType::CONVEX_MESH:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::ConvexMesh>(geom));
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     case tesseract_geometry::GeometryType::OCTREE:
     {
       shape = createShapePrimitive(std::static_pointer_cast<const tesseract_geometry::Octree>(geom), cow, shape_index);
       shape->setUserIndex(shape_index);
+      shape->setMargin(BULLET_MARGIN);
       break;
     }
     default:
@@ -322,7 +330,6 @@ CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
   if (m_shapes.size() == 1 && m_shape_poses[0].matrix().isIdentity())
   {
     btCollisionShape* shape = createShapePrimitive(m_shapes[0], this, 0);
-    shape->setMargin(BULLET_MARGIN);
     manage(shape);
     setCollisionShape(shape);
   }
@@ -341,7 +348,6 @@ CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
       if (subshape != nullptr)
       {
         manage(subshape);
-        subshape->setMargin(BULLET_MARGIN);
         btTransform geomTrans = convertEigenToBt(m_shape_poses[j]);
         compound->addChildShape(geomTrans, subshape);
       }

--- a/tesseract/tesseract_collision/test/collision_sphere_sphere_cast_unit.cpp
+++ b/tesseract/tesseract_collision/test/collision_sphere_sphere_cast_unit.cpp
@@ -259,7 +259,7 @@ void runConvexTest(ContinuousContactManager& checker)
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
-  EXPECT_NEAR(result_vector[0].distance, -0.0754, 0.0001);
+  EXPECT_NEAR(result_vector[0].distance, -0.0754, 0.001);
 
   std::vector<int> idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "sphere_link")
@@ -327,7 +327,7 @@ void runConvexTest(ContinuousContactManager& checker)
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
-  EXPECT_NEAR(result_vector[0].distance, -0.0754, 0.0001);
+  EXPECT_NEAR(result_vector[0].distance, -0.0754, 0.001);
 
   idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "sphere_link")

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/continuous_motion_validator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/continuous_motion_validator.h
@@ -61,13 +61,6 @@ private:
    */
   bool continuousCollisionCheck(const ompl::base::State* s1, const ompl::base::State* s2) const;
 
-  /**
-   * @brief Perform a discrete collision for a given ompl state
-   * @param s2 OMPL State
-   * @return True if not in collision, otherwise false.
-   */
-  bool discreteCollisionCheck(const ompl::base::State* s2) const;
-
   /** @brief The Tesseract Environment */
   tesseract_environment::Environment::ConstPtr env_;
 
@@ -79,9 +72,6 @@ private:
 
   /** @brief The continuous contact manager used for creating cached continuous contact managers. */
   tesseract_collision::ContinuousContactManager::Ptr continuous_contact_manager_;
-
-  /** @brief The discrete contact manager used for creating cached discrete contact managers. */
-  tesseract_collision::DiscreteContactManager::Ptr discrete_contact_manager_;
 
   /** @brief A list of active links */
   std::vector<std::string> links_;
@@ -99,9 +89,6 @@ private:
 
   /** @brief The continuous contact manager cache */
   mutable std::map<unsigned long int, tesseract_collision::ContinuousContactManager::Ptr> continuous_contact_managers_;
-
-  /** @brief The discrete contact manager cache */
-  mutable std::map<unsigned long int, tesseract_collision::DiscreteContactManager::Ptr> discrete_contact_managers_;
 
   /** @brief The state solver manager cache */
   mutable std::map<unsigned long int, tesseract_environment::StateSolver::Ptr> state_solver_managers_;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_freespace_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_freespace_planner.h
@@ -30,6 +30,7 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <ompl/geometric/SimpleSetup.h>
 #include <ompl/base/OptimizationObjective.h>
+#include <ompl/tools/multiplan/ParallelPlan.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/core/planner.h>
@@ -142,6 +143,10 @@ public:
    * @brief Sets up the OMPL problem then solves. It is intended to simplify setting up
    * and solving freespace motion problems.
    *
+   * This planner leverages OMPL ParallelPlan which supports being called multiple times. So you are able to
+   * setConfiguration and keep calling solve and with each solve it will continue to build the existing planner graph.
+   * If you want to start with a clean graph you must call setConfiguration() before calling solve again.
+   *
    * This planner (and the associated config passed to the setConfiguration) does not expose all of the available
    * configuration data in OMPL. This is done to simplify the interface. However, many problems may require more
    * specific setups. In that case, the source code for this planner may be used as an example.
@@ -173,6 +178,9 @@ protected:
   /** @brief The planners status codes */
   std::shared_ptr<const OMPLFreespacePlannerStatusCategory> status_category_;
 
+  /** @brief OMPL Parallel planner */
+  std::shared_ptr<ompl::tools::ParallelPlan> parallel_plan_;
+
   /** @brief The ompl planner motion validator */
   ompl::base::MotionValidatorPtr motion_validator_;
 
@@ -184,9 +192,6 @@ protected:
 
   /** @brief The mapping of environment links to kinematics links */
   tesseract_environment::AdjacencyMap::ConstPtr adj_map_;
-
-  /** @brief The discrete contact manager */
-  tesseract_collision::DiscreteContactManager::Ptr discrete_contact_manager_;
 
   /** @brief The continuous contact manager */
   tesseract_collision::ContinuousContactManager::Ptr continuous_contact_manager_;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -141,7 +141,7 @@ protected:
   bool addBasicInfo(trajopt::ProblemConstructionInfo& pci) const;
   bool addInitTrajectory(trajopt::ProblemConstructionInfo& pci) const;
   void addWaypoints(trajopt::ProblemConstructionInfo& pci, std::vector<int>& fixed_steps) const;
-  void addConfiguration(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addKinematicConfiguration(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
   void addCollision(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
   void addVelocitySmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
   void addAccelerationSmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -93,7 +93,7 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
   /** @brief If true, collision checking will be enabled. Default: true*/
   bool collision_check = true;
   /** @brief If true, use continuous collision checking */
-  bool collision_continuous = true;
+  trajopt::CollisionEvaluatorType collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   /** @brief Max distance over which collisions are checked */
   double collision_safety_margin = 0.025;
   /** @brief The collision coeff/weight */

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -135,6 +135,19 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
    */
   std::vector<std::tuple<sco::VectorOfVector::func, sco::MatrixOfVector::func, sco::ConstraintType, Eigen::VectorXd>>
       constraint_error_functions;
+
+protected:
+  bool checkUserInput() const;
+  bool addBasicInfo(trajopt::ProblemConstructionInfo& pci) const;
+  bool addInitTrajectory(trajopt::ProblemConstructionInfo& pci) const;
+  void addWaypoints(trajopt::ProblemConstructionInfo& pci, std::vector<int>& fixed_steps) const;
+  void addConfiguration(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addCollision(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addVelocitySmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addAccelerationSmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addJerkSmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addConstraintErrorFunctions(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addAvoidSingularity(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
 };
 
 }  // namespace tesseract_motion_planners

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
@@ -80,7 +80,7 @@ trajopt::TermInfo::Ptr createConfigurationTermInfo(const JointWaypoint::ConstPtr
 trajopt::TermInfo::Ptr createCollisionTermInfo(
     int n_steps,
     double collision_safety_margin,
-    bool collision_continuous = true,
+    trajopt::CollisionEvaluatorType evaluator_type,
     double coeff = 20.0,
     tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL,
     double longest_valid_segment_length = 0.5,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerDefaultConfig::g
     addJerkSmoothing(pci, fixed_steps);
 
   if (configuration != nullptr)
-    addConfiguration(pci, fixed_steps);
+    addKinematicConfiguration(pci, fixed_steps);
 
   if (!constraint_error_functions.empty())
     addConstraintErrorFunctions(pci, fixed_steps);
@@ -219,8 +219,8 @@ void TrajOptPlannerDefaultConfig::addWaypoints(trajopt::ProblemConstructionInfo&
   }
 }
 
-void TrajOptPlannerDefaultConfig::addConfiguration(trajopt::ProblemConstructionInfo& pci,
-                                                   const std::vector<int>& fixed_steps) const
+void TrajOptPlannerDefaultConfig::addKinematicConfiguration(trajopt::ProblemConstructionInfo& pci,
+                                                            const std::vector<int>& fixed_steps) const
 {
   // Update the term info with the (possibly) new start and end state indices for which to apply this cost
   if (fixed_steps.empty())

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -319,12 +319,8 @@ void TrajOptPlannerDefaultConfig::addCollision(trajopt::ProblemConstructionInfo&
   }
 
   // Create a default collision term info
-  trajopt::TermInfo::Ptr ti = createCollisionTermInfo(pci.basic_info.n_steps,
-                                                      collision_safety_margin,
-                                                      collision_continuous,
-                                                      collision_coeff,
-                                                      contact_test_type,
-                                                      length);
+  trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
+      pci.basic_info.n_steps, collision_safety_margin, collision_type, collision_coeff, contact_test_type, length);
 
   // Update the term info with the (possibly) new start and end state indices for which to apply this cost
   std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
@@ -113,7 +113,7 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig:
     addJerkSmoothing(pci, fixed_steps);
 
   if (configuration != nullptr)
-    addConfiguration(pci, fixed_steps);
+    addKinematicConfiguration(pci, fixed_steps);
 
   if (!constraint_error_functions.empty())
     addConstraintErrorFunctions(pci, fixed_steps);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
@@ -26,88 +26,31 @@
 #include <tesseract_motion_planners/trajopt/config/trajopt_planner_freespace_config.h>
 #include <tesseract_motion_planners/trajopt/config/utils.h>
 
-static const double LONGEST_VALID_SEGMENT_FRACTION_DEFAULT = 0.01;
-
 namespace tesseract_motion_planners
 {
 std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig::generatePCI() const
 {
-  using namespace trajopt;
-
-  // Check that parameters are valid
-  if (tesseract == nullptr)
-  {
-    CONSOLE_BRIDGE_logError("In trajopt_array_planner: tesseract_ is a required parameter and has not been set");
+  if (!checkUserInput())
     return nullptr;
-  }
-
-  if (target_waypoints.size() < 2)
-  {
-    CONSOLE_BRIDGE_logError("TrajOpt Planner Config requires at least 2 waypoints");
-    return nullptr;
-  }
-
-  if (tcp.size() != target_waypoints.size() && tcp.size() != 1)
-  {
-    std::stringstream ss;
-    ss << "Number of TCP transforms (" << tcp.size() << ") does not match the number of waypoints ("
-       << target_waypoints.size() << ") and is also not 1";
-    CONSOLE_BRIDGE_logError(ss.str().c_str());
-    return nullptr;
-  }
 
   // -------- Construct the problem ------------
   // -------------------------------------------
-  ProblemConstructionInfo pci(tesseract);
-  pci.kin = pci.getManipulator(manipulator);
-
-  if (pci.kin == nullptr)
-  {
-    CONSOLE_BRIDGE_logError("In trajopt_array_planner: manipulator_ does not exist in kin_map_");
-    return nullptr;
-  }
+  trajopt::ProblemConstructionInfo pci(tesseract);
 
   // Populate Basic Info
-  pci.basic_info.n_steps = num_steps;  // static_cast<int>(target_waypoints.size());
-  pci.basic_info.manip = manipulator;
-  pci.basic_info.start_fixed = false;
-  pci.basic_info.use_time = false;
-  pci.basic_info.convex_solver = optimizer;
+  if (!addBasicInfo(pci))
+    return nullptr;
+
+  pci.basic_info.n_steps = num_steps;
+
+  if (!addInitTrajectory(pci))
+    return nullptr;
 
   // Get kinematics information
   tesseract_environment::Environment::ConstPtr env = tesseract->getEnvironmentConst();
-  tesseract_kinematics::ForwardKinematics::ConstPtr kin =
-      tesseract->getFwdKinematicsManagerConst()->getFwdKinematicSolver(manipulator);
   tesseract_environment::AdjacencyMap map(
-      env->getSceneGraph(), kin->getActiveLinkNames(), env->getCurrentState()->transforms);
+      env->getSceneGraph(), pci.kin->getActiveLinkNames(), env->getCurrentState()->transforms);
   const std::vector<std::string>& adjacency_links = map.getActiveLinkNames();
-
-  // Populate Init Info
-  pci.init_info.type = init_type;
-  if (init_type == trajopt::InitInfo::GIVEN_TRAJ)
-  {
-    pci.init_info.data = seed_trajectory;
-
-    // Add check to make sure if starts with joint waypoint that the seed trajectory also starts at this waypoint
-    // If it does not start this causes issues in trajopt and it will never converge.
-    if (isJointWaypointType(target_waypoints.front()->getType()))
-    {
-      const auto jwp = std::static_pointer_cast<JointWaypoint>(target_waypoints.front());
-      const Eigen::VectorXd position = jwp->getPositions(kin->getJointNames());
-      for (int i = 0; i < static_cast<int>(kin->numJoints()); ++i)
-      {
-        if (std::abs(position[i] - seed_trajectory(0, i)) > static_cast<double>(std::numeric_limits<float>::epsilon()))
-        {
-          std::stringstream ss;
-          ss << "Seed trajectory start position does not match starting joint waypoint position!";
-          ss << "    waypoint: " << position.transpose().matrix() << std::endl;
-          ss << "  seed start: " << seed_trajectory.row(0).transpose().matrix() << std::endl;
-          CONSOLE_BRIDGE_logError(ss.str().c_str());
-          return nullptr;
-        }
-      }
-    }
-  }
 
   // Add the first waypoint
   {
@@ -145,114 +88,35 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig:
    * that are incapable of changing (i.e. joint positions). Therefore, the first and last indices of these
    * costs (which equal 0 and num_steps-1 by default) should be changed to exclude those states
    */
-  int cost_first_step = 0;
-  int cost_last_step = num_steps - 1;
+  std::vector<int> fixed_steps;
   if (target_waypoints.front()->getType() == WaypointType::JOINT_WAYPOINT ||
       target_waypoints.front()->getType() == WaypointType::JOINT_TOLERANCED_WAYPOINT)
   {
-    ++cost_first_step;
+    fixed_steps.push_back(0);
   }
   if (target_waypoints.back()->getType() == WaypointType::JOINT_WAYPOINT ||
       target_waypoints.back()->getType() == WaypointType::JOINT_TOLERANCED_WAYPOINT)
   {
-    --cost_last_step;
+    fixed_steps.push_back(num_steps - 1);
   }
 
-  // Set costs for the rest of the points
   if (collision_check)
-  {
-    // Calculate longest valid segment length
-    const Eigen::MatrixX2d& limits = kin->getLimits();
-    double length = 0;
-    double extent = (limits.col(1) - limits.col(0)).norm();
-    if (longest_valid_segment_fraction > 0 && longest_valid_segment_length > 0)
-    {
-      length = std::min(longest_valid_segment_fraction * extent, longest_valid_segment_length);
-    }
-    else if (longest_valid_segment_fraction > 0)
-    {
-      length = longest_valid_segment_fraction * extent;
-    }
-    else if (longest_valid_segment_length > 0)
-    {
-      length = longest_valid_segment_length;
-    }
-    else
-    {
-      length = LONGEST_VALID_SEGMENT_FRACTION_DEFAULT * extent;
-    }
+    addCollision(pci, fixed_steps);
 
-    // Create a default collision term info
-    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(pci.basic_info.n_steps,
-                                                        collision_safety_margin,
-                                                        collision_continuous,
-                                                        collision_coeff,
-                                                        contact_test_type,
-                                                        length);
-
-    // Update the term info with the (possibly) new start and end state indices for which to apply this cost
-    std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
-    ct->first_step = cost_first_step;
-    ct->last_step = cost_last_step;
-
-    pci.cost_infos.push_back(ct);
-  }
   if (smooth_velocities)
-  {
-    if (velocity_coeff.size() == 0)
-      pci.cost_infos.push_back(
-          createSmoothVelocityTermInfo(pci.basic_info.n_steps, static_cast<int>(pci.kin->numJoints())));
-    else
-      pci.cost_infos.push_back(createSmoothVelocityTermInfo(pci.basic_info.n_steps, velocity_coeff));
-  }
+    addVelocitySmoothing(pci, fixed_steps);
+
   if (smooth_accelerations)
-  {
-    if (acceleration_coeff.size() == 0)
-      pci.cost_infos.push_back(
-          createSmoothAccelerationTermInfo(pci.basic_info.n_steps, static_cast<int>(pci.kin->numJoints())));
-    else
-      pci.cost_infos.push_back(createSmoothAccelerationTermInfo(pci.basic_info.n_steps, acceleration_coeff));
-  }
+    addAccelerationSmoothing(pci, fixed_steps);
+
   if (smooth_jerks)
-  {
-    if (jerk_coeff.size() == 0)
-      pci.cost_infos.push_back(
-          createSmoothJerkTermInfo(pci.basic_info.n_steps, static_cast<int>(pci.kin->numJoints())));
-    else
-      pci.cost_infos.push_back(createSmoothJerkTermInfo(pci.basic_info.n_steps, jerk_coeff));
-  }
+    addJerkSmoothing(pci, fixed_steps);
+
   if (configuration != nullptr)
-  {
-    trajopt::TermInfo::Ptr ti =
-        createConfigurationTermInfo(configuration, pci.kin->getJointNames(), pci.basic_info.n_steps);
-
-    // Update the term info with the (possibly) new start and end state indices for which to apply this cost
-    std::shared_ptr<trajopt::JointPosTermInfo> jp = std::static_pointer_cast<trajopt::JointPosTermInfo>(ti);
-    jp->first_step = cost_first_step;
-    jp->last_step = cost_last_step;
-
-    pci.cost_infos.push_back(jp);
-  }
+    addConfiguration(pci, fixed_steps);
 
   if (!constraint_error_functions.empty())
-  {
-    for (std::size_t i = 0; i < constraint_error_functions.size(); ++i)
-    {
-      auto& c = constraint_error_functions[i];
-      trajopt::TermInfo::Ptr ti = createUserDefinedTermInfo(
-          pci.basic_info.n_steps, std::get<0>(c), std::get<1>(c), "user_defined_" + std::to_string(i));
-
-      // Update the term info with the (possibly) new start and end state indices for which to apply this cost
-      std::shared_ptr<trajopt::UserDefinedTermInfo> ef = std::static_pointer_cast<trajopt::UserDefinedTermInfo>(ti);
-      ef->term_type = trajopt::TT_CNT;
-      ef->constraint_type = std::get<2>(c);
-      ef->coeff = std::get<3>(c);
-      ef->first_step = cost_first_step;
-      ef->last_step = cost_last_step;
-
-      pci.cnt_infos.push_back(ef);
-    }
-  }
+    addConstraintErrorFunctions(pci, fixed_steps);
 
   return std::make_shared<trajopt::ProblemConstructionInfo>(pci);
 }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
@@ -216,7 +216,7 @@ trajopt::TermInfo::Ptr createConfigurationTermInfo(const JointWaypoint::ConstPtr
 
 trajopt::TermInfo::Ptr createCollisionTermInfo(int n_steps,
                                                double collision_safety_margin,
-                                               bool collision_continuous,
+                                               trajopt::CollisionEvaluatorType evaluator_type,
                                                double coeff,
                                                tesseract_collision::ContactTestType contact_test_type,
                                                double longest_valid_segment_length,
@@ -225,7 +225,7 @@ trajopt::TermInfo::Ptr createCollisionTermInfo(int n_steps,
   std::shared_ptr<trajopt::CollisionTermInfo> collision = std::make_shared<trajopt::CollisionTermInfo>();
   collision->name = name;
   collision->term_type = trajopt::TT_COST;
-  collision->continuous = collision_continuous;
+  collision->evaluator_type = evaluator_type;
   collision->first_step = 0;
   collision->last_step = n_steps - 1;
   collision->contact_test_type = contact_test_type;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_trajopt_planner_test.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_trajopt_planner_test.cpp
@@ -194,7 +194,7 @@ TYPED_TEST(OMPLTrajOptTestFixture, OMPLTrajOptFreespacePlannerUnit)  // NOLINT
     trajopt_config.target_waypoints.push_back(end);
 
     trajopt_config.collision_check = true;
-    trajopt_config.collision_continuous = true;
+    trajopt_config.collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
     trajopt_config.collision_safety_margin = 0.02;
 
     trajopt_config.smooth_velocities = true;

--- a/tesseract_python/tesseract_python/CMakeLists.txt
+++ b/tesseract_python/tesseract_python/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.0)
 project(tesseract_python)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 # Read version
 FILE (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/package.xml" tesseract_python_version1 REGEX "<version>[0-9]+\\.[0-9]+\\.[0-9]+</version>")
@@ -51,7 +53,7 @@ message(STATUS "NumPy Include Directory: ${NUMPY_INCLUDE_DIR}")
 # End Find NumPy
 
 include(FindSWIG)
-find_package(SWIG 4.0.0 REQUIRED)
+find_package(SWIG 4.0 REQUIRED)
 include(UseSWIG)
 
 # Primary tesseract_python library

--- a/tesseract_python/tesseract_python/cmake/FindSWIG.cmake
+++ b/tesseract_python/tesseract_python/cmake/FindSWIG.cmake
@@ -1,0 +1,66 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindSWIG
+# --------
+#
+# Find SWIG
+#
+# This module finds an installed SWIG.  It sets the following variables:
+#
+# ::
+#
+#   SWIG_FOUND - set to true if SWIG is found
+#   SWIG_DIR - the directory where swig is installed
+#   SWIG_EXECUTABLE - the path to the swig executable
+#   SWIG_VERSION   - the version number of the swig executable
+#
+#
+#
+# The minimum required version of SWIG can be specified using the
+# standard syntax, e.g.  find_package(SWIG 1.1)
+#
+# All information is collected from the SWIG_EXECUTABLE so the version
+# to be found can be changed from the command line by means of setting
+# SWIG_EXECUTABLE
+
+find_program(SWIG_EXECUTABLE NAMES swig4.0 swig3.0 swig2.0 swig)
+
+if(SWIG_EXECUTABLE)
+  execute_process(COMMAND ${SWIG_EXECUTABLE} -swiglib
+    OUTPUT_VARIABLE SWIG_swiglib_output
+    ERROR_VARIABLE SWIG_swiglib_error
+    RESULT_VARIABLE SWIG_swiglib_result)
+
+  if(SWIG_swiglib_result)
+    if(SWIG_FIND_REQUIRED)
+      message(SEND_ERROR "Command \"${SWIG_EXECUTABLE} -swiglib\" failed with output:\n${SWIG_swiglib_error}")
+    else()
+      message(STATUS "Command \"${SWIG_EXECUTABLE} -swiglib\" failed with output:\n${SWIG_swiglib_error}")
+    endif()
+  else()
+    string(REGEX REPLACE "[\n\r]+" ";" SWIG_swiglib_output ${SWIG_swiglib_output})
+    find_path(SWIG_DIR swig.swg PATHS ${SWIG_swiglib_output} NO_CMAKE_FIND_ROOT_PATH)
+    if(SWIG_DIR)
+      set(SWIG_USE_FILE ${CMAKE_CURRENT_LIST_DIR}/UseSWIG.cmake)
+      execute_process(COMMAND ${SWIG_EXECUTABLE} -version
+        OUTPUT_VARIABLE SWIG_version_output
+        ERROR_VARIABLE SWIG_version_output
+        RESULT_VARIABLE SWIG_version_result)
+      if(SWIG_version_result)
+        message(SEND_ERROR "Command \"${SWIG_EXECUTABLE} -version\" failed with output:\n${SWIG_version_output}")
+      else()
+        string(REGEX REPLACE ".*SWIG Version[^0-9.]*\([0-9.]+\).*" "\\1"
+          SWIG_version_output "${SWIG_version_output}")
+        set(SWIG_VERSION ${SWIG_version_output} CACHE STRING "Swig version" FORCE)
+      endif()
+    endif()
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SWIG  REQUIRED_VARS SWIG_EXECUTABLE SWIG_DIR
+                                        VERSION_VAR SWIG_VERSION )
+
+mark_as_advanced(SWIG_DIR SWIG_VERSION)

--- a/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_planner_config.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_planner_config.i
@@ -43,13 +43,16 @@ struct TrajOptPlannerConfig
 
   virtual bool generate();
 
-  //TODO: ?
-  //sco::BasicTrustRegionSQPParameters params;
+  sco::BasicTrustRegionSQPParameters params;
 
   //TODO: ?
   //std::vector<sco::Optimizer::Callback> callbacks;
   
   trajopt::TrajOptProb::Ptr prob;
+
+  double longest_valid_segment_fraction = 0.01;
+
+  double longest_valid_segment_length = 0.5;
 };
 
 }  // namespace tesseract_motion_planners

--- a/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.i
@@ -67,9 +67,11 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
   
   JointWaypoint::ConstPtr configuration;
 
+  tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL;
+
   bool collision_check = true;
   
-  bool collision_continuous = true;
+  trajopt::CollisionEvaluatorType collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   
   double collision_safety_margin = 0.025;
   
@@ -84,6 +86,10 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
   bool smooth_jerks = true;
   
   Eigen::VectorXd jerk_coeff;
+
+  bool avoid_singularity = false;
+
+  double avoid_singularity_coeff = 5.0;
 
   // std::vector<std::pair<sco::VectorOfVector::func, sco::MatrixOfVector::func>> constraint_error_functions;
 };

--- a/tesseract_python/tesseract_python/swig/trajopt/problem_description.i
+++ b/tesseract_python/tesseract_python/swig/trajopt/problem_description.i
@@ -346,11 +346,19 @@ std::vector<std::shared_ptr<SafetyMarginData> > createSafetyMarginDataVector(int
                                                                 const double& default_safety_margin,
                                                                 const double& default_safety_margin_coeff);
 
+enum class CollisionEvaluatorType
+{
+  SINGLE_TIMESTEP = 0,
+  DISCRETE_CONTINUOUS = 1,
+  CAST_CONTINUOUS = 2,
+};
+
 class CollisionTermInfo : public TermInfo
 {
 public:
   int first_step, last_step;
-  bool continuous;
+  CollisionEvaluatorType evaluator_type;
+  std::vector<int> fixed_steps;
   double longest_valid_segment_length = 0.5;
   std::vector<std::shared_ptr<SafetyMarginData> > info;
   tesseract_collision::ContactTestType contact_test_type;

--- a/tesseract_python/tesseract_python/tests/test_trajopt_motion_planner.py
+++ b/tesseract_python/tesseract_python/tests/test_trajopt_motion_planner.py
@@ -8,6 +8,8 @@ def test_trajopt_motion_planner_default_config():
 
     config = tesseract.TrajOptPlannerDefaultConfig(t,"manipulator", "tool0", np.eye(4))
 
+    config.params.cnt_tolerance = 1e-5
+
     for ind in range(10):
         tcp_pose = np.array([[0,0,1,0],[0,1,0,0],[-1,0,0, 0],[0,0,0,1]],dtype=np.float64)
         tcp_pose[0,3] = 0.5

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/basic_cartesian_plan.json
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/basic_cartesian_plan.json
@@ -21,7 +21,7 @@
       {
         "coeffs" : [20],
         "dist_pen" : [0.025],
-        "continuous" : false
+        "evaluator_type" : 0
       }
     }
   ],

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/glass_up_right_plan.json
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/glass_up_right_plan.json
@@ -21,7 +21,7 @@
       {
         "coeffs" : [20],
         "dist_pen" : [0.025],
-        "continuous" : true,
+        "evaluator_type" : 2,
         "longest_valid_segment_length" : 0.1,
         "pairs" :
         [

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
@@ -162,7 +162,7 @@ TrajOptProb::Ptr BasicCartesianExample::cppMethod()
   auto collision = std::make_shared<CollisionTermInfo>();
   collision->name = "collision";
   collision->term_type = TT_COST;
-  collision->continuous = false;
+  collision->evaluator_type = trajopt::CollisionEvaluatorType::SINGLE_TIMESTEP;
   collision->first_step = 0;
   collision->last_step = pci.basic_info.n_steps - 1;
   collision->info = createSafetyMarginDataVector(pci.basic_info.n_steps, 0.025, 20);

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
@@ -292,7 +292,7 @@ std::shared_ptr<ProblemConstructionInfo> CarSeatExample::cppMethod(const std::st
   auto collision = std::make_shared<CollisionTermInfo>();
   collision->name = "collision";
   collision->term_type = TT_CNT;
-  collision->continuous = true;
+  collision->evaluator_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   collision->first_step = 0;
   collision->last_step = pci->basic_info.n_steps - 2;
   collision->info = createSafetyMarginDataVector(pci->basic_info.n_steps, 0.0001, 40);

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_up_right_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_up_right_example.cpp
@@ -122,7 +122,7 @@ TrajOptProb::Ptr GlassUpRightExample::cppMethod()
   auto collision = std::make_shared<CollisionTermInfo>();
   collision->name = "collision";
   collision->term_type = TT_COST;
-  collision->continuous = false;
+  collision->evaluator_type = trajopt::CollisionEvaluatorType::SINGLE_TIMESTEP;
   collision->first_step = 0;
   collision->last_step = pci.basic_info.n_steps - 1;
   collision->info = createSafetyMarginDataVector(pci.basic_info.n_steps, 0.025, 20);

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
@@ -186,7 +186,7 @@ bool PickAndPlaceExample::run()
     auto collision = std::make_shared<trajopt::CollisionTermInfo>();
     collision->name = "collision";
     collision->term_type = trajopt::TT_COST;
-    collision->continuous = true;
+    collision->evaluator_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
     collision->first_step = 1;
     collision->last_step = pci.basic_info.n_steps - 1;
     collision->info = trajopt::createSafetyMarginDataVector(pci.basic_info.n_steps, 0.005, 50);
@@ -396,7 +396,7 @@ bool PickAndPlaceExample::run()
     auto collision = std::make_shared<trajopt::CollisionTermInfo>();
     collision->name = "collision";
     collision->term_type = trajopt::TT_COST;
-    collision->continuous = true;
+    collision->evaluator_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
     collision->first_step = 1;
     collision->last_step = pci_place.basic_info.n_steps - 1;
     collision->info = trajopt::createSafetyMarginDataVector(pci_place.basic_info.n_steps, 0.005, 50);

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
@@ -171,7 +171,7 @@ ProblemConstructionInfo PuzzlePieceAuxillaryAxesExample::cppMethod()
   auto collision = std::make_shared<CollisionTermInfo>();
   collision->name = "collision";
   collision->term_type = TT_COST;
-  collision->continuous = false;
+  collision->evaluator_type = trajopt::CollisionEvaluatorType::SINGLE_TIMESTEP;
   collision->first_step = 0;
   collision->last_step = pci.basic_info.n_steps - 1;
   collision->info = createSafetyMarginDataVector(pci.basic_info.n_steps, 0.025, 1);

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
@@ -179,7 +179,7 @@ ProblemConstructionInfo PuzzlePieceExample::cppMethod()
   auto collision = std::make_shared<CollisionTermInfo>();
   collision->name = "collision";
   collision->term_type = TT_COST;
-  collision->continuous = false;
+  collision->evaluator_type = trajopt::CollisionEvaluatorType::SINGLE_TIMESTEP;
   collision->first_step = 0;
   collision->last_step = pci.basic_info.n_steps - 1;
   collision->info = createSafetyMarginDataVector(pci.basic_info.n_steps, 0.025, 20);

--- a/tesseract_ros/tesseract_rviz/include/tesseract_rviz/render_tools/link_widget.h
+++ b/tesseract_ros/tesseract_rviz/include/tesseract_rviz/render_tools/link_widget.h
@@ -301,6 +301,7 @@ private:
     rviz::PointCloud* point_cloud;
     std::vector<rviz::PointCloud::Point> points;
     float size;
+    tesseract_geometry::Octree::SubType shape_type;
 
     rviz::PointCloud* clone();
   };


### PR DESCRIPTION
This add ability to handle fixed states throughout the provided trajectory for collision. It also simplifies the trajopt configs to reduce code duplication. 

Update:
Noticed that there is an intermittent bug in OMPL hybridization which will return a plan that starts at the end and finishes at the end. Need to create issue on OMPL. 

Updated tesseract to support bullet being built using double precision.

Update rviz link_widget to support tesseract octree sub shape type SPHERE_INSIDE and SPHERE_OUTSIDE visualization.