### PR TITLE
Add initial support for Groups and GroupStates

### DIFF
--- a/tesseract_python/tesseract_python/swig/tesseract/tesseract.i
+++ b/tesseract_python/tesseract_python/swig/tesseract/tesseract.i
@@ -54,7 +54,7 @@ public:
   //          const boost::filesystem::path& srdf_path,
   //          tesseract_scene_graph::ResourceLocator::Ptr locator);
 
-  //const tesseract_scene_graph::SRDFModel::ConstPtr& getSRDFModel() const;
+  const tesseract_scene_graph::SRDFModel::ConstPtr& getSRDFModel() const;
 
   const tesseract_environment::Environment::Ptr getEnvironment();
   const tesseract_environment::Environment::ConstPtr getEnvironmentConst() const;

--- a/tesseract_python/tesseract_python/swig/tesseract_python.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_python.i
@@ -78,6 +78,7 @@
 %include "tesseract_geometry/geometry_loaders.i"
 %include "tesseract_scene_graph/graph.i"
 %include "tesseract_scene_graph/resource_locator.i"
+%include "tesseract_scene_graph/srdf_parser.i"
 %include "tesseract_kinematics/core/forward_kinematics.i"
 %include "tesseract_kinematics/core/forward_kinematics_factory.i"
 %include "tesseract_kinematics/core/inverse_kinematics.i"

--- a/tesseract_python/tesseract_python/swig/tesseract_python.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_python.i
@@ -69,6 +69,11 @@
 %include "eigen_types.i"
 
 %template(vector_string) std::vector<std::string>;
+%template(pair_string) std::pair<std::string, std::string>;
+%template(vector_pair_string) std::vector<std::pair<std::string, std::string> >;
+
+%template(vector_double) std::vector<double>;
+%template(map_string_vector_double) std::map<std::string, std::vector<double> >;
 
 %include "tesseract_common/types.i"
 %include "tesseract_common/status_code.i"

--- a/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_parser.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_parser.i
@@ -35,6 +35,8 @@
 %template(GroupStateVector) std::vector<tesseract_scene_graph::SRDFModel::GroupState>;
 %template(DoubleVector) std::vector<double>;
 %template(StringDoubleVectorMap) std::map<std::string, std::vector<double> >;
+%template(PairString) std::pair<std::string, std::string>;
+%template(PairStringVector) std::vector<std::pair<std::string, std::string> >;
 
 namespace tesseract_scene_graph
 {

--- a/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_parser.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_parser.i
@@ -33,10 +33,6 @@
 %shared_ptr(tesseract_scene_graph::SRDFModel)
 %template(GroupVector) std::vector<tesseract_scene_graph::SRDFModel::Group>;
 %template(GroupStateVector) std::vector<tesseract_scene_graph::SRDFModel::GroupState>;
-%template(DoubleVector) std::vector<double>;
-%template(StringDoubleVectorMap) std::map<std::string, std::vector<double> >;
-%template(PairString) std::pair<std::string, std::string>;
-%template(PairStringVector) std::vector<std::pair<std::string, std::string> >;
 
 namespace tesseract_scene_graph
 {

--- a/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_parser.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_parser.i
@@ -1,0 +1,68 @@
+/**
+ * @file srdf_parser.i
+ * @brief SWIG interface file for tesseract_scene_graph/parser/srdf_parser.h
+ *
+ * @author Hervé Audren
+ * @date January 20, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Ascent Robotics Inc.
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+%feature(flatnested)
+
+%{
+#include <tesseract_scene_graph/parser/srdf_parser.h>
+%}
+
+%shared_ptr(tesseract_scene_graph::SRDFModel)
+%template(GroupVector) std::vector<tesseract_scene_graph::SRDFModel::Group>;
+%template(GroupStateVector) std::vector<tesseract_scene_graph::SRDFModel::GroupState>;
+%template(DoubleVector) std::vector<double>;
+%template(StringDoubleVectorMap) std::map<std::string, std::vector<double> >;
+
+namespace tesseract_scene_graph
+{
+class SRDFModel
+{
+public:
+  using Ptr = std::shared_ptr<SRDFModel>;
+  using ConstPtr = std::shared_ptr<const SRDFModel>;
+
+  struct Group {
+    std::string name_;
+    std::vector<std::string> joints_;
+    std::vector<std::string> links_;
+    std::vector<std::pair<std::string, std::string> > chains_;
+    std::vector<std::string> subgroups_;
+  };
+
+  struct GroupState {
+    std::string name_;
+    std::string group_;
+    std::map<std::string, std::vector<double> > joint_values_;
+  };
+
+  const std::string& getName() const;
+
+  const std::vector<Group>& getGroups() const;
+
+  const std::vector<GroupState>& getGroupStates() const;
+};
+
+}  // namespace tesseract_scene_graph

--- a/tesseract_python/tesseract_python/tests/test_srdf_parser.py
+++ b/tesseract_python/tesseract_python/tests/test_srdf_parser.py
@@ -1,0 +1,63 @@
+import tesseract
+import os
+import re
+import numpy as np
+
+
+def test_environment():
+
+    TESSERACT_SUPPORT_DIR = os.environ["TESSERACT_SUPPORT_DIR"]
+
+    with open(os.path.join(TESSERACT_SUPPORT_DIR, "urdf", "abb_irb2400.urdf"), "r") as f:
+        abb_irb2400_urdf = f.read()
+
+    with open(os.path.join(TESSERACT_SUPPORT_DIR, "urdf", "abb_irb2400.srdf"), "r") as f:
+        abb_irb2400_srdf = f.read()
+
+    t = tesseract.Tesseract()
+
+    t.init(abb_irb2400_urdf, abb_irb2400_srdf, TesseractSupportResourceLocator())
+
+    t_srdf = t.getSRDFModel()
+
+    assert t_srdf.getName() == "abb_irb2400"
+
+    groups = t_srdf.getGroups()
+    assert len(groups) == 1
+    group = groups[0]
+    assert group.name_ == "manipulator"
+    # Group definition contains no joints, no links, no subgroups,  only a chain
+    assert not group.joints_
+    assert not group.links_
+    assert not group.subgroups_
+    assert len(group.chains_) == 1
+    assert group.chains_[0] == ("base_link", "tool0")
+
+    # Group state now
+    group_states = t_srdf.getGroupStates()
+    assert len(group_states) == 1
+    group_state = group_states[0]
+    assert group_state.name_ == "all-zeros"
+    assert group_state.group_ == "manipulator"
+    for i in range(1, 7):
+        assert group_state.joint_values_["joint_{}".format(i)] == (0.0,)
+
+
+class TesseractSupportResourceLocator(tesseract.ResourceLocator):
+    def __init__(self):
+        super(TesseractSupportResourceLocator, self).__init__()
+        self.TESSERACT_SUPPORT_DIR = os.environ["TESSERACT_SUPPORT_DIR"]
+
+    def locateResource(self, url):
+
+        url_match = re.match(r"^package:\/\/tesseract_support\/(.*)$", url)
+        if url_match is None:
+            return None
+
+        fname = os.path.join(self.TESSERACT_SUPPORT_DIR, os.path.normpath(url_match.group(1)))
+        with open(fname, "rb") as f:
+            resource_bytes = f.read()
+
+        resource = tesseract.BytesResource(url, resource_bytes)
+
+        return resource

--- a/tesseract_python/tesseract_python/tests/test_srdf_parser.py
+++ b/tesseract_python/tesseract_python/tests/test_srdf_parser.py
@@ -61,3 +61,7 @@ class TesseractSupportResourceLocator(tesseract.ResourceLocator):
         resource = tesseract.BytesResource(url, resource_bytes)
 
         return resource
+
+
+if __name__ == "__main__":
+    test_environment()


### PR DESCRIPTION
This commit adds a new binding for srdf_parser.h
Current support is:
- Retrieving Groups and GroupStates
- Accessing their members
Note that due to SWIG's lack of support of nested classes, they end up
flattened, at the root of the module.

This PR still lacks a few things, namely tests but I'd like to get a few comments on this code first.