### PR TITLE
Allow adding TrajOpt collision terms as both constraints and costs

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -59,6 +59,6 @@ struct CollisionConstraintConfig
   /** @brief The collision coeff/weight */
   double coeff = 20;
 };
-}
+}  // namespace tesseract_motion_planners
 
-#endif // TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H
+#endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -1,5 +1,5 @@
 /**
- * @file trajopt_collision_config_base.h
+ * @file trajopt_collision_config.h
  * @brief TrajOpt collision configuration settings
  *
  * @author Joseph Schornak

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -11,7 +11,7 @@ namespace tesseract_motion_planners
 struct CollisionCostConfig
 {
   /** @brief If true, a collision cost term will be added to the problem. Default: true*/
-  bool check = true;
+  bool enabled = true;
   /** @brief The evaluator type that will be used for collision checking. */
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   /** @brief Max distance in which collision costs will be evaluated. */
@@ -26,7 +26,7 @@ struct CollisionCostConfig
 struct CollisionConstraintConfig
 {
   /** @brief If true, a collision cost term will be added to the problem. Default: true*/
-  bool check = true;
+  bool enabled = true;
   /** @brief The evaluator type that will be used for collision checking. */
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   /** @brief Max distance in which collision constraints will be evaluated. */

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -1,0 +1,39 @@
+#ifndef TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H
+#define TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H
+
+#include <trajopt/problem_description.hpp>
+
+namespace tesseract_motion_planners
+{
+/**
+ * @brief Config settings for collision cost terms.
+ */
+struct CollisionCostConfig
+{
+  /** @brief If true, a collision cost term will be added to the problem. Default: true*/
+  bool check = true;
+  /** @brief The evaluator type that will be used for collision checking. */
+  trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
+  /** @brief Max distance in which collision costs will be evaluated. */
+  double buffer_margin = 0.025;
+  /** @brief The collision coeff/weight */
+  double coeff = 20;
+};
+
+/**
+ * @brief Config settings for collision constraint terms.
+ */
+struct CollisionConstraintConfig
+{
+  /** @brief If true, a collision cost term will be added to the problem. Default: true*/
+  bool check = true;
+  /** @brief The evaluator type that will be used for collision checking. */
+  trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
+  /** @brief Max distance in which collision constraints will be evaluated. */
+  double safety_margin = 0.01;
+  /** @brief The collision coeff/weight */
+  double coeff = 20;
+};
+}
+
+#endif // TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -1,3 +1,28 @@
+/**
+ * @file trajopt_collision_config_base.h
+ * @brief TrajOpt collision configuration settings
+ *
+ * @author Joseph Schornak
+ * @date January 22, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H
 #define TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_COLLISION_CONFIG_H
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -90,12 +90,16 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
 
   /** @brief The type of contact test to perform: FIRST, CLOSEST, ALL */
   tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL;
-  /** @brief If true, collision checking will be enabled. Default: true*/
+  /** @brief If true, collision checking will be enabled and a collision constraint term will be added to the problem. Default: true*/
   bool collision_check = true;
+  /** @brief If true, a collision cost term will be added to the problem. Default: false*/
+  bool use_collision_cost_term = false;
   /** @brief If true, use continuous collision checking */
   trajopt::CollisionEvaluatorType collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
-  /** @brief Max distance over which collisions are checked */
+  /** @brief Max distance in which collisions will be evaluated as constraints */
   double collision_safety_margin = 0.025;
+  /** @brief Max distance in which collisions will be evaluated as costs if use_collision_cost_term is true */
+  double collision_buffer_margin = 0.05;
   /** @brief The collision coeff/weight */
   double collision_coeff = 20;
   /** @brief If true, a joint velocity cost with a target of 0 will be applied for all timesteps Default: true*/
@@ -142,7 +146,8 @@ protected:
   bool addInitTrajectory(trajopt::ProblemConstructionInfo& pci) const;
   void addWaypoints(trajopt::ProblemConstructionInfo& pci, std::vector<int>& fixed_steps) const;
   void addKinematicConfiguration(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
-  void addCollision(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addCollisionCost(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
+  void addCollisionConstraint(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
   void addVelocitySmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
   void addAccelerationSmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;
   void addJerkSmoothing(trajopt::ProblemConstructionInfo& pci, const std::vector<int>& fixed_steps) const;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.h
@@ -27,6 +27,7 @@
 #define TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_PLANNER_DEFAULT_CONFIG_H
 
 #include <tesseract_motion_planners/trajopt/config/trajopt_planner_config.h>
+#include <tesseract_motion_planners/trajopt/config/trajopt_collision_config.h>
 
 namespace tesseract_motion_planners
 {
@@ -90,18 +91,10 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
 
   /** @brief The type of contact test to perform: FIRST, CLOSEST, ALL */
   tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL;
-  /** @brief If true, collision checking will be enabled and a collision constraint term will be added to the problem. Default: true*/
-  bool collision_check = true;
-  /** @brief If true, a collision cost term will be added to the problem. Default: false*/
-  bool use_collision_cost_term = false;
-  /** @brief If true, use continuous collision checking */
-  trajopt::CollisionEvaluatorType collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
-  /** @brief Max distance in which collisions will be evaluated as constraints */
-  double collision_safety_margin = 0.025;
-  /** @brief Max distance in which collisions will be evaluated as costs if use_collision_cost_term is true */
-  double collision_buffer_margin = 0.05;
-  /** @brief The collision coeff/weight */
-  double collision_coeff = 20;
+  /** @brief Configuration info for collisions that are modeled as costs */
+  tesseract_motion_planners::CollisionCostConfig collision_cost_config;
+  /** @brief Configuration info for collisions that are modeled as constraints */
+  tesseract_motion_planners::CollisionConstraintConfig collision_constraint_config;
   /** @brief If true, a joint velocity cost with a target of 0 will be applied for all timesteps Default: true*/
   bool smooth_velocities = true;
   /** @brief This default to all ones, but allows you to weight different joints */

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
@@ -84,7 +84,8 @@ trajopt::TermInfo::Ptr createCollisionTermInfo(
     double coeff = 20.0,
     tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL,
     double longest_valid_segment_length = 0.5,
-    const std::string& name = "collision_cost");
+    const std::string& name = "collision_cost",
+    bool is_constraint = false);
 
 trajopt::TermInfo::Ptr
 createSmoothVelocityTermInfo(int n_steps, int n_joints, double coeff = 5.0, const std::string& name = "joint_vel_cost");

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -64,10 +64,10 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerDefaultConfig::g
   std::vector<int> fixed_steps;
   addWaypoints(pci, fixed_steps);
 
-  if (collision_constraint_config.check)
+  if (collision_constraint_config.enabled)
     addCollisionConstraint(pci, fixed_steps);
 
-  if (collision_cost_config.check)
+  if (collision_cost_config.enabled)
     addCollisionCost(pci, fixed_steps);
 
   if (smooth_velocities)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -64,10 +64,10 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerDefaultConfig::g
   std::vector<int> fixed_steps;
   addWaypoints(pci, fixed_steps);
 
-  if (collision_check)
+  if (collision_constraint_config.check)
     addCollisionConstraint(pci, fixed_steps);
 
-  if (collision_check && use_collision_cost_term)
+  if (collision_cost_config.check)
     addCollisionCost(pci, fixed_steps);
 
   if (smooth_velocities)
@@ -324,7 +324,7 @@ void TrajOptPlannerDefaultConfig::addCollisionCost(trajopt::ProblemConstructionI
 
   // Create a default collision term info
   trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
-      pci.basic_info.n_steps, collision_buffer_margin, collision_type, collision_coeff, contact_test_type, length, "collision_cost", false);
+      pci.basic_info.n_steps, collision_cost_config.buffer_margin, collision_cost_config.type, collision_cost_config.coeff, contact_test_type, length, "collision_cost", false);
 
   // Update the term info with the (possibly) new start and end state indices for which to apply this cost
   std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
@@ -359,7 +359,7 @@ void TrajOptPlannerDefaultConfig::addCollisionConstraint(trajopt::ProblemConstru
 
   // Create a default collision term info
   trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
-      pci.basic_info.n_steps, collision_safety_margin, collision_type, collision_coeff, contact_test_type, length, "collision_cnt", true);
+      pci.basic_info.n_steps, collision_constraint_config.safety_margin, collision_constraint_config.type, collision_constraint_config.coeff, contact_test_type, length, "collision_cnt", true);
 
   // Update the term info with the (possibly) new start and end state indices for which to apply this cost
   std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -323,8 +323,14 @@ void TrajOptPlannerDefaultConfig::addCollisionCost(trajopt::ProblemConstructionI
   }
 
   // Create a default collision term info
-  trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
-      pci.basic_info.n_steps, collision_cost_config.buffer_margin, collision_cost_config.type, collision_cost_config.coeff, contact_test_type, length, "collision_cost", false);
+  trajopt::TermInfo::Ptr ti = createCollisionTermInfo(pci.basic_info.n_steps,
+                                                      collision_cost_config.buffer_margin,
+                                                      collision_cost_config.type,
+                                                      collision_cost_config.coeff,
+                                                      contact_test_type,
+                                                      length,
+                                                      "collision_cost",
+                                                      false);
 
   // Update the term info with the (possibly) new start and end state indices for which to apply this cost
   std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
@@ -358,8 +364,14 @@ void TrajOptPlannerDefaultConfig::addCollisionConstraint(trajopt::ProblemConstru
   }
 
   // Create a default collision term info
-  trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
-      pci.basic_info.n_steps, collision_constraint_config.safety_margin, collision_constraint_config.type, collision_constraint_config.coeff, contact_test_type, length, "collision_cnt", true);
+  trajopt::TermInfo::Ptr ti = createCollisionTermInfo(pci.basic_info.n_steps,
+                                                      collision_constraint_config.safety_margin,
+                                                      collision_constraint_config.type,
+                                                      collision_constraint_config.coeff,
+                                                      contact_test_type,
+                                                      length,
+                                                      "collision_cnt",
+                                                      true);
 
   // Update the term info with the (possibly) new start and end state indices for which to apply this cost
   std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
@@ -100,10 +100,10 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig:
     fixed_steps.push_back(num_steps - 1);
   }
 
-  if (collision_constraint_config.check)
+  if (collision_constraint_config.enabled)
     addCollisionConstraint(pci, fixed_steps);
 
-  if (collision_cost_config.check)
+  if (collision_cost_config.enabled)
     addCollisionCost(pci, fixed_steps);
 
   if (smooth_velocities)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
@@ -100,10 +100,10 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig:
     fixed_steps.push_back(num_steps - 1);
   }
 
-  if (collision_check)
+  if (collision_constraint_config.check)
     addCollisionConstraint(pci, fixed_steps);
 
-  if (collision_check && use_collision_cost_term)
+  if (collision_cost_config.check)
     addCollisionCost(pci, fixed_steps);
 
   if (smooth_velocities)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_freespace_config.cpp
@@ -101,7 +101,10 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerFreespaceConfig:
   }
 
   if (collision_check)
-    addCollision(pci, fixed_steps);
+    addCollisionConstraint(pci, fixed_steps);
+
+  if (collision_check && use_collision_cost_term)
+    addCollisionCost(pci, fixed_steps);
 
   if (smooth_velocities)
     addVelocitySmoothing(pci, fixed_steps);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
@@ -220,11 +220,12 @@ trajopt::TermInfo::Ptr createCollisionTermInfo(int n_steps,
                                                double coeff,
                                                tesseract_collision::ContactTestType contact_test_type,
                                                double longest_valid_segment_length,
-                                               const std::string& name)
+                                               const std::string& name,
+                                               bool is_constraint)
 {
   std::shared_ptr<trajopt::CollisionTermInfo> collision = std::make_shared<trajopt::CollisionTermInfo>();
   collision->name = name;
-  collision->term_type = trajopt::TT_COST;
+  collision->term_type = is_constraint ? trajopt::TT_CNT : trajopt::TT_COST;
   collision->evaluator_type = evaluator_type;
   collision->first_step = 0;
   collision->last_step = n_steps - 1;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_trajopt_planner_test.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_trajopt_planner_test.cpp
@@ -193,9 +193,11 @@ TYPED_TEST(OMPLTrajOptTestFixture, OMPLTrajOptFreespacePlannerUnit)  // NOLINT
     trajopt_config.target_waypoints.push_back(start);
     trajopt_config.target_waypoints.push_back(end);
 
-    trajopt_config.collision_check = true;
-    trajopt_config.collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
-    trajopt_config.collision_safety_margin = 0.02;
+    tesseract_motion_planners::CollisionConstraintConfig collision_constraint_cfg;
+    collision_constraint_cfg.enabled = true;
+    collision_constraint_cfg.safety_margin = 0.02;
+    collision_constraint_cfg.type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
+    trajopt_config.collision_constraint_config = collision_constraint_cfg;
 
     trajopt_config.smooth_velocities = true;
     trajopt_config.smooth_jerks = true;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
@@ -147,7 +147,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespacePlanner0)  // NOLINT
     config->smooth_velocities = t1;
     config->smooth_accelerations = t2;
     config->smooth_jerks = t3;
-    config->collision_check = t4;
+    config->collision_constraint_config.enabled = t4;
+    config->collision_cost_config.enabled = t4;
     test_planner.setConfiguration(config);
 
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointVelEqCost>(config->prob->getCosts())),
@@ -366,7 +367,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayPlanner0)  // NOLINT
     config->smooth_velocities = t1;
     config->smooth_accelerations = t2;
     config->smooth_jerks = t3;
-    config->collision_check = t4;
+    config->collision_constraint_config.enabled = t4;
+    config->collision_cost_config.enabled = t4;
     test_planner.setConfiguration(config);
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointVelEqCost>(config->prob->getCosts())),
               t1);

--- a/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_collision_config.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_collision_config.i
@@ -1,0 +1,57 @@
+/**
+ * @file trajopt_collision_config.i
+ * @brief SWIG interface file for tesseract_planning/trajopt/config/trajopt_collision_config.h
+ *
+ * @author Joseph Schornak
+ * @date January 22, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+%{
+#include <tesseract_motion_planners/trajopt/config/trajopt_collision_config.h>
+%}
+
+namespace tesseract_motion_planners
+{
+struct CollisionCostConfig
+{
+
+  bool enabled = true;
+
+  trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
+
+  double buffer_margin = 0.025;
+
+  double coeff = 20;
+};
+
+struct CollisionConstraintConfig
+{
+
+  bool enabled = true;
+
+  trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
+
+  double safety_margin = 0.01;
+
+  double coeff = 20;
+};
+
+}  // namespace tesseract_motion_planners

--- a/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_planner_default_config.i
@@ -69,12 +69,10 @@ struct TrajOptPlannerDefaultConfig : public TrajOptPlannerConfig
 
   tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL;
 
-  bool collision_check = true;
-  
-  trajopt::CollisionEvaluatorType collision_type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
-  
-  double collision_safety_margin = 0.025;
-  
+  tesseract_motion_planners::CollisionCostConfig collision_cost_config;
+
+  tesseract_motion_planners::CollisionConstraintConfig collision_constraint_config;
+
   bool smooth_velocities = true;
   
   Eigen::VectorXd velocity_coeff;


### PR DESCRIPTION
Add separate collisions terms for constraint and cost and expose them in the TrajOpt planner configs. It's important for collisions to be represented as constraints to ensure that the resulting trajectory is collision-free. In certain cases it is desirable for collisions to also be modeled as costs to drive the solution further away from nearby collisions if possible.

- Add new functions to allow adding collision terms as either costs or constraints.
- ~~Added new parameters in the TrajOpt planner configs to set if collisions will be disabled, modeled as constraints, or modeled as both costs and constraints.~~
- ~~If collisions are enabled they will be modeled as constraints. If `collision_check = true`, a collision constraint term will be added with a safety margin of `collision_safety_margin`.~~
- ~~Add a new flag to the TrajOpt planner config to enable a separate collision cost term. If `use_collision_cost_term = true`, an additional collision cost term will be added with a safety margin of `collision_buffer_margin`.~~
- Add new config structs to represent settings for collision costs and constraints. This allows collision costs and collision constraints to be independently enabled or disabled.