### PR TITLE
Add double precision flag to tesseract_collision target compile definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ env:
     - ROSINSTALL_FILENAME=dependencies.rosinstall
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
-    - CATKIN_CONFIG="--make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=2"
+    - CATKIN_CONFIG="--make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=1"
     - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
     - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
-    - ROS_PARALLEL_JOBS=-j2
-    - ROS_PARALLEL_TEST_JOBS=-j2
+    - ROS_PARALLEL_JOBS=-j1
+    - ROS_PARALLEL_TEST_JOBS=-j1
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
     - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
+    - ROS_PARALLEL_JOBS=-j2
+    - ROS_PARALLEL_TEST_JOBS=-j2
 
 jobs:
   include:
@@ -56,8 +58,6 @@ jobs:
       env:
       - ROS_DISTRO="melodic"
       - DOCKER_IMAGE=lharmstrong/tesseract:melodic
-      - ROS_PARALLEL_JOBS=-j4
-      - ROS_PARALLEL_TEST_JOBS=-j4
       - BADGE=bionic
       cache:
         directories:
@@ -69,8 +69,6 @@ jobs:
       - ROS_DISTRO="kinetic"
       - ROS_REPO=ros-shadow-fixed
       - DOCKER_IMAGE=lharmstrong/tesseract:kinetic
-      - ROS_PARALLEL_JOBS=-j4
-      - ROS_PARALLEL_TEST_JOBS=-j4
       - BADGE=xenial-shadow
       cache:
         directories:
@@ -82,15 +80,13 @@ jobs:
       - ROS_DISTRO="melodic"
       - ROS_REPO=ros-shadow-fixed
       - DOCKER_IMAGE=lharmstrong/tesseract:melodic
-      - ROS_PARALLEL_JOBS=-j2
-      - ROS_PARALLEL_TEST_JOBS=-j2
       - BADGE=bionic-shadow
       cache:
         directories:
           - $HOME/.ccache
   allow_failures:
-    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic BADGE=xenial-shadow
-    - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j4 ROS_PARALLEL_TEST_JOBS=-j4 BADGE=bionic-shadow
+    - env: ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:kinetic ROS_PARALLEL_JOBS=-j2 ROS_PARALLEL_TEST_JOBS=-j2 BADGE=xenial-shadow
+    - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed DOCKER_IMAGE=lharmstrong/tesseract:melodic ROS_PARALLEL_JOBS=-j2 ROS_PARALLEL_TEST_JOBS=-j2 BADGE=bionic-shadow
 
 install:
   - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - NOT_TEST_INSTALL=true
     - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
-    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=2 CTEST_PROGRESS_OUTPUT=TRUE'
+    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=2'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
     - ROS_PARALLEL_JOBS=-j2
     - ROS_PARALLEL_TEST_JOBS=-j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ jobs:
       - ROS_DISTRO="kinetic"
       - ROS_REPO=ros-shadow-fixed
       - DOCKER_IMAGE=lharmstrong/tesseract:kinetic
+      - ROS_PARALLEL_JOBS=-j4
+      - ROS_PARALLEL_TEST_JOBS=-j4
       - BADGE=xenial-shadow
       cache:
         directories:
@@ -80,8 +82,8 @@ jobs:
       - ROS_DISTRO="melodic"
       - ROS_REPO=ros-shadow-fixed
       - DOCKER_IMAGE=lharmstrong/tesseract:melodic
-      - ROS_PARALLEL_JOBS=-j4
-      - ROS_PARALLEL_TEST_JOBS=-j4
+      - ROS_PARALLEL_JOBS=-j2
+      - ROS_PARALLEL_TEST_JOBS=-j2
       - BADGE=bionic-shadow
       cache:
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
   include:
     - os: linux
       dist: bionic
-      language: cpp
+      language: minimal
       env:
       - ROS_DISTRO="melodic"
       - CLANG_FORMAT_CHECK=file
@@ -44,7 +44,7 @@ jobs:
           - $HOME/.ccache
     - os: linux
       dist: xenial
-      language: cpp
+      language: minimal
       env:
       - ROS_DISTRO="kinetic"
       - DOCKER_IMAGE=lharmstrong/tesseract:kinetic
@@ -54,7 +54,7 @@ jobs:
           - $HOME/.ccache
     - os: linux
       dist: bionic
-      language: cpp
+      language: minimal
       env:
       - ROS_DISTRO="melodic"
       - DOCKER_IMAGE=lharmstrong/tesseract:melodic
@@ -64,7 +64,7 @@ jobs:
           - $HOME/.ccache
     - os: linux
       dist: xenial
-      language: cpp
+      language: minimal
       env:
       - ROS_DISTRO="kinetic"
       - ROS_REPO=ros-shadow-fixed
@@ -75,7 +75,7 @@ jobs:
           - $HOME/.ccache
     - os: linux
       dist: bionic
-      language: cpp
+      language: minimal
       env:
       - ROS_DISTRO="melodic"
       - ROS_REPO=ros-shadow-fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ env:
     - ROSINSTALL_FILENAME=dependencies.rosinstall
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
+    - CATKIN_CONFIG="--make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=2"
     - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
-    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=2'
+    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
     - ROS_PARALLEL_JOBS=-j2
     - ROS_PARALLEL_TEST_JOBS=-j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - NOT_TEST_INSTALL=true
     - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
-    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE'
+    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE CTEST_PARALLEL_LEVEL=2 CTEST_PROGRESS_OUTPUT=TRUE'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
     - ROS_PARALLEL_JOBS=-j2
     - ROS_PARALLEL_TEST_JOBS=-j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
     - ROSINSTALL_FILENAME=dependencies.rosinstall
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
-    - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_RUN_TESTING=OFF"
+    - CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
     - ROSDEP_SKIP_KEYS="bullet3 fcl"
-    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE'
+    - AFTER_SCRIPT='catkin test -w $CATKIN_WORKSPACE --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_planners tesseract_scene_graph tesseract_urdf tesseract_python --make-args CTEST_OUTPUT_ON_FAILURE=TRUE'
     - PKGS_DOWNSTREAM='tesseract_ros_examples tesseract_rosutils'
     - ROS_PARALLEL_JOBS=-j2
     - ROS_PARALLEL_TEST_JOBS=-j2

--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(${PROJECT_NAME}_core INTERFACE)
 target_link_libraries(${PROJECT_NAME}_core INTERFACE tesseract::tesseract_geometry ${Boost_LIBRARIES} ${BULLET_LIBRARIES})
 tesseract_target_compile_options(${PROJECT_NAME}_core INTERFACE)
 tesseract_clang_tidy(${PROJECT_NAME}_core)
+target_compile_definitions(${PROJECT_NAME}_core INTERFACE "-DBT_USE_DOUBLE_PRECISION")
 target_include_directories(${PROJECT_NAME}_core INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
@@ -66,6 +67,7 @@ add_executable(create_convex_hull src/create_convex_hull.cpp)
 target_link_libraries(create_convex_hull PUBLIC tesseract::tesseract_geometry console_bridge ${BULLET_LIBRARIES} ${Boost_LIBRARIES} ${OCTOMAP_LIBRARIES})
 tesseract_target_compile_options(create_convex_hull PUBLIC)
 tesseract_clang_tidy(create_convex_hull)
+target_compile_definitions(create_convex_hull PRIVATE "-DBT_USE_DOUBLE_PRECISION")
 target_include_directories(create_convex_hull PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_include_directories(create_convex_hull SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIRS}


### PR DESCRIPTION
Supports [this `tesseract_ext` issue](https://github.com/ros-industrial-consortium/tesseract_ext/issues/10) and [this PR](https://github.com/ros-industrial-consortium/tesseract_ext/pull/11). Workaround for [a bullet3 issue](https://github.com/bulletphysics/bullet3/issues/2582) where it doesn't correctly export some compiler definitions.