### PR TITLE
Use Trajopt safety_margin_buffer parameter

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -41,6 +41,8 @@ struct CollisionCostConfig
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   /** @brief Max distance in which collision costs will be evaluated. */
   double buffer_margin = 0.025;
+  /** @brief Distance beyond buffer_margin in which collision optimization will be evaluated. */
+  double safety_margin_buffer = 0.05;
   /** @brief The collision coeff/weight */
   double coeff = 20;
 };
@@ -56,6 +58,8 @@ struct CollisionConstraintConfig
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   /** @brief Max distance in which collision constraints will be evaluated. */
   double safety_margin = 0.01;
+  /** @brief Distance beyond safety_margin in which collision optimization will be evaluated. */
+  double safety_margin_buffer = 0.05;
   /** @brief The collision coeff/weight */
   double coeff = 20;
 };

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/trajopt_collision_config.h
@@ -41,8 +41,9 @@ struct CollisionCostConfig
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
   /** @brief Max distance in which collision costs will be evaluated. */
   double buffer_margin = 0.025;
-  /** @brief Distance beyond buffer_margin in which collision optimization will be evaluated. */
-  double safety_margin_buffer = 0.05;
+  /** @brief Distance beyond buffer_margin in which collision optimization will be evaluated.
+      This is set to 0 by default (effectively disabled) for collision costs.*/
+  double safety_margin_buffer = 0.0;
   /** @brief The collision coeff/weight */
   double coeff = 20;
 };

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/config/utils.h
@@ -80,6 +80,7 @@ trajopt::TermInfo::Ptr createConfigurationTermInfo(const JointWaypoint::ConstPtr
 trajopt::TermInfo::Ptr createCollisionTermInfo(
     int n_steps,
     double collision_safety_margin,
+    double collision_safety_margin_buffer,
     trajopt::CollisionEvaluatorType evaluator_type,
     double coeff = 20.0,
     tesseract_collision::ContactTestType contact_test_type = tesseract_collision::ContactTestType::ALL,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -325,6 +325,7 @@ void TrajOptPlannerDefaultConfig::addCollisionCost(trajopt::ProblemConstructionI
   // Create a default collision term info
   trajopt::TermInfo::Ptr ti = createCollisionTermInfo(pci.basic_info.n_steps,
                                                       collision_cost_config.buffer_margin,
+                                                      collision_constraint_config.safety_margin_buffer,
                                                       collision_cost_config.type,
                                                       collision_cost_config.coeff,
                                                       contact_test_type,
@@ -366,6 +367,7 @@ void TrajOptPlannerDefaultConfig::addCollisionConstraint(trajopt::ProblemConstru
   // Create a default collision term info
   trajopt::TermInfo::Ptr ti = createCollisionTermInfo(pci.basic_info.n_steps,
                                                       collision_constraint_config.safety_margin,
+                                                      collision_constraint_config.safety_margin_buffer,
                                                       collision_constraint_config.type,
                                                       collision_constraint_config.coeff,
                                                       contact_test_type,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/utils.cpp
@@ -216,6 +216,7 @@ trajopt::TermInfo::Ptr createConfigurationTermInfo(const JointWaypoint::ConstPtr
 
 trajopt::TermInfo::Ptr createCollisionTermInfo(int n_steps,
                                                double collision_safety_margin,
+                                               double collision_safety_margin_buffer,
                                                trajopt::CollisionEvaluatorType evaluator_type,
                                                double coeff,
                                                tesseract_collision::ContactTestType contact_test_type,
@@ -232,6 +233,7 @@ trajopt::TermInfo::Ptr createCollisionTermInfo(int n_steps,
   collision->contact_test_type = contact_test_type;
   collision->longest_valid_segment_length = longest_valid_segment_length;
   collision->info = trajopt::createSafetyMarginDataVector(n_steps, collision_safety_margin, coeff);
+  collision->safety_margin_buffer = collision_safety_margin_buffer;
   return collision;
 }
 

--- a/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_collision_config.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_collision_config.i
@@ -39,6 +39,8 @@ struct CollisionCostConfig
 
   double buffer_margin = 0.025;
 
+  double safety_margin_buffer = 0.05;
+
   double coeff = 20;
 };
 
@@ -50,6 +52,8 @@ struct CollisionConstraintConfig
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
 
   double safety_margin = 0.01;
+
+  double safety_margin_buffer = 0.05;
 
   double coeff = 20;
 };

--- a/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_collision_config.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_planning/tesseract_motion_planners/trajopt/config/trajopt_collision_config.i
@@ -39,7 +39,7 @@ struct CollisionCostConfig
 
   double buffer_margin = 0.025;
 
-  double safety_margin_buffer = 0.05;
+  double safety_margin_buffer = 0.0;
 
   double coeff = 20;
 };


### PR DESCRIPTION
Depends on #210, as well as [#160 in `trajopt_ros`](https://github.com/ros-industrial-consortium/trajopt_ros/pull/160). ~~Should be rebased after #210 is merged.~~

Exposes the new `safety_margin_buffer` parameter, which helps keep the optimization away from collisions when the safety margin distance is very small.