### PR TITLE
Allow to merge a SceneGraph into another one

### DIFF
--- a/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -140,14 +140,14 @@ public:
    * @param link The link to be added to the graph
    * @return Return False if a link with the same name allready exists, otherwise true
    */
-  virtual bool addLink(const tesseract_scene_graph::Link& link);
+  virtual bool addLink(tesseract_scene_graph::Link link);
 
   /**
    * @brief Adds a link to the environment
    * @param link The link to be added to the graph
    * @return Return False if a link with the same name allready exists, otherwise true
    */
-  virtual bool addLink(const tesseract_scene_graph::Link& link, const tesseract_scene_graph::Joint& joint);
+  virtual bool addLink(tesseract_scene_graph::Link link, tesseract_scene_graph::Joint joint);
 
   /**
    * @brief Removes a link from the environment

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -399,10 +399,24 @@ public:
     return continuous_factory_.registar(name, std::move(create_function));
   }
 
-  /** Add a subgraph to the current environment. NB: the subgraph will be copied
-   * into the environment graph */
+  /** @brief Merge a graph into the current environment
+   * @param scene_graph Const ref to the graph to be merged (said graph will be copied)
+   * @param prefix string Will be prepended to every link and joint of the merged graph
+   * @return Return False if any link or joint name collides with current environment, otherwise True
+   * Merge a subgraph into the current environment, considering that the root of the merged graph is attached to the
+   * root of the environment by a fixed joint and no displacement. Every joint and link of the subgraph will be copied
+   * into the environment graph. The prefix argument is meant to allow adding multiple copies of the same subgraph with
+   * different names */
   virtual bool addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph, const std::string& prefix = "");
 
+  /** @brief Merge a graph into the current environment
+   * @param scene_graph Const ref to the graph to be merged (said graph will be copied)
+   * @param root_joint Const ptr to the joint that connects current environment with root of the merged graph
+   * @param prefix string Will be prepended to every link and joint of the merged graph
+   * @return Return False if any link or joint name collides with current environment, otherwise True
+   * Merge a subgraph into the current environment. Every joint and link of the subgraph will be copied into the
+   * environment graph. The prefix argument is meant to allow adding multiple copies of the same subgraph with different
+   * names */
   virtual bool addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph,
                              tesseract_scene_graph::Joint::ConstPtr root_joint,
                              const std::string& prefix = "");

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -399,6 +399,14 @@ public:
     return continuous_factory_.registar(name, std::move(create_function));
   }
 
+  /** Add a subgraph to the current environment. NB: the subgraph will be copied
+   * into the environment graph */
+  virtual bool addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph, const std::string& prefix = "");
+
+  virtual bool addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph,
+                             tesseract_scene_graph::Joint::ConstPtr root_joint,
+                             const std::string& prefix = "");
+
 protected:
   bool initialized_{ false }; /**< Identifies if the object has been initialized */
   int revision_{ 0 };         /**< This increments when the scene graph is modified */

--- a/tesseract/tesseract_environment/src/core/environment.cpp
+++ b/tesseract/tesseract_environment/src/core/environment.cpp
@@ -28,7 +28,9 @@
 #include <tesseract_environment/core/utils.h>
 #include <tesseract_collision/core/common.h>
 
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <queue>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {

--- a/tesseract/tesseract_environment/src/core/environment.cpp
+++ b/tesseract/tesseract_environment/src/core/environment.cpp
@@ -78,7 +78,7 @@ EnvState::Ptr Environment::getState(const std::vector<std::string>& joint_names,
   return state;
 }
 
-bool Environment::addLink(const tesseract_scene_graph::Link& link)
+bool Environment::addLink(tesseract_scene_graph::Link link)
 {
   std::string joint_name = "joint_" + link.getName();
   tesseract_scene_graph::Joint joint(joint_name);
@@ -86,10 +86,10 @@ bool Environment::addLink(const tesseract_scene_graph::Link& link)
   joint.child_link_name = link.getName();
   joint.parent_link_name = getRootLinkName();
 
-  return addLink(link, joint);
+  return addLink(std::move(link), std::move(joint));
 }
 
-bool Environment::addLink(const tesseract_scene_graph::Link& link, const tesseract_scene_graph::Joint& joint)
+bool Environment::addLink(tesseract_scene_graph::Link link, tesseract_scene_graph::Joint joint)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   if (scene_graph_->getLink(link.getName()) != nullptr)
@@ -104,27 +104,32 @@ bool Environment::addLink(const tesseract_scene_graph::Link& link, const tessera
     return false;
   }
 
-  if (!scene_graph_->addLink(link))
+  std::string link_name = link.getName();
+  std::string joint_name = joint.getName();
+
+  if (!scene_graph_->addLink(std::move(link)))
     return false;
 
-  if (!scene_graph_->addJoint(joint))
+  if (!scene_graph_->addJoint(std::move(joint)))
     return false;
 
-  if (!link.collision.empty())
+  // We have moved the original objects, get a pointer to them from scene_graph
+  auto link_ptr = scene_graph_->getLink(link_name);
+  auto joint_ptr = scene_graph_->getJoint(joint_name);
+  if (!link_ptr->collision.empty())
   {
     tesseract_collision::CollisionShapesConst shapes;
     tesseract_common::VectorIsometry3d shape_poses;
-    getCollisionObject(shapes, shape_poses, link);
+    getCollisionObject(shapes, shape_poses, *link_ptr);
 
     if (discrete_manager_ != nullptr)
-      discrete_manager_->addCollisionObject(link.getName(), 0, shapes, shape_poses, true);
+      discrete_manager_->addCollisionObject(link_name, 0, shapes, shape_poses, true);
     if (continuous_manager_ != nullptr)
-      continuous_manager_->addCollisionObject(link.getName(), 0, shapes, shape_poses, true);
+      continuous_manager_->addCollisionObject(link_name, 0, shapes, shape_poses, true);
   }
 
   ++revision_;
-  commands_.push_back(
-      std::make_shared<AddCommand>(scene_graph_->getLink(link.getName()), scene_graph_->getJoint(joint.getName())));
+  commands_.push_back(std::make_shared<AddCommand>(link_ptr, joint_ptr));
 
   environmentChanged();
 
@@ -153,11 +158,12 @@ bool Environment::moveLink(tesseract_scene_graph::Joint joint)
   if (!scene_graph_->removeJoint(joints[0]->getName()))
     return false;
 
-  if (!scene_graph_->addJoint(joint))
+  std::string joint_name = joint.getName();
+  if (!scene_graph_->addJoint(std::move(joint)))
     return false;
 
   ++revision_;
-  commands_.push_back(std::make_shared<MoveLinkCommand>(scene_graph_->getJoint(joint.getName())));
+  commands_.push_back(std::make_shared<MoveLinkCommand>(scene_graph_->getJoint(joint_name)));
 
   environmentChanged();
 
@@ -594,6 +600,22 @@ bool Environment::removeLinkHelper(const std::string& name)
   return true;
 }
 
+/** addSceneGraph needs a couple helpers to handle prefixing, we hide them in an anonymous namespace here **/
+namespace
+{
+tesseract_scene_graph::Link clone_prefix(tesseract_scene_graph::Link::ConstPtr link, const std::string& prefix)
+{
+  return link->clone(prefix + link->getName());
+}
+tesseract_scene_graph::Joint clone_prefix(tesseract_scene_graph::Joint::ConstPtr joint, const std::string& prefix)
+{
+  auto ret = joint->clone(prefix + joint->getName());
+  ret.child_link_name = prefix + joint->child_link_name;
+  ret.parent_link_name = prefix + joint->parent_link_name;
+  return ret;
+}
+}  // namespace
+
 bool Environment::addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_graph, const std::string& prefix)
 {
   // Connect root of subgraph to graph
@@ -616,13 +638,12 @@ bool Environment::addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_g
   {
     return true;
   }
-  auto new_link = std::make_shared<tesseract_scene_graph::Link>(link->prefix(prefix));
-
-  auto new_joint = std::make_shared<tesseract_scene_graph::Joint>(root_joint->prefix(prefix));
+  auto new_link = clone_prefix(link, prefix);
+  auto new_joint = clone_prefix(root_joint, prefix);
   // Preserve reference to common ancestor
-  new_joint->parent_link_name = root_joint->parent_link_name;
+  new_joint.parent_link_name = root_joint->parent_link_name;
 
-  bool res = addLink(*new_link, *new_joint);
+  bool res = addLink(std::move(new_link), std::move(new_joint));
   if (!res)
   {
     CONSOLE_BRIDGE_logError("Could not add the root joint");
@@ -637,13 +658,13 @@ bool Environment::addSceneGraph(const tesseract_scene_graph::SceneGraph& scene_g
     work_links.pop();
     for (const auto& joint : joints)
     {
-      auto new_joint = std::make_shared<tesseract_scene_graph::Joint>(joint->prefix(prefix));
+      auto new_joint = clone_prefix(joint, prefix);
       link = scene_graph.getLink(joint->child_link_name);
-      auto new_link = std::make_shared<tesseract_scene_graph::Link>(link->prefix(prefix));
-      res = addLink(*new_link, *new_joint);
+      auto new_link = clone_prefix(link, prefix);
+      res = addLink(std::move(new_link), std::move(new_joint));
       if (!res)
       {
-        CONSOLE_BRIDGE_logError("Could not add link (%s)", new_link->getName().c_str());
+        CONSOLE_BRIDGE_logError("Could not add link (%s) with prefix (%s)", link->getName().c_str(), prefix.c_str());
         return false;
       }
       work_links.push(link->getName());

--- a/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -66,110 +66,119 @@ void runContactManagerCloneTest(const tesseract_environment::Environment::Ptr& e
 
 void runAddandRemoveLinkTest(const tesseract_environment::Environment::Ptr& env)
 {
-  Link link_1("link_n1");
-  Link link_2("link_n2");
+  const std::string link_name1 = "link_n1";
+  const std::string link_name2 = "link_n2";
+  const std::string joint_name1 = "joint_n1";
+  Link link_1(link_name1);
+  Link link_2(link_name2);
 
-  Joint joint_1("joint_n1");
+  Joint joint_1(joint_name1);
   joint_1.parent_to_joint_origin_transform.translation()(0) = 1.25;
-  joint_1.parent_link_name = "link_n1";
-  joint_1.child_link_name = "link_n2";
+  joint_1.parent_link_name = link_name1;
+  joint_1.child_link_name = link_name2;
   joint_1.type = JointType::FIXED;
 
   EXPECT_TRUE(env->addLink(std::move(link_1)));
 
   std::vector<std::string> link_names = env->getLinkNames();
   std::vector<std::string> joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_link_n1") != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name1) != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_" + link_name1) != joint_names.end());
 
   env->addLink(std::move(link_2), std::move(joint_1));
   link_names = env->getLinkNames();
   joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name2) != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_name1) != joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/before_remove_link_unit.dot");
 
-  env->removeLink("link_n1");
+  env->removeLink(link_name1);
   link_names = env->getLinkNames();
   joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") == link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_link_n1") == joint_names.end());
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") == link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") == joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name1) == link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_" + link_name1) == joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name2) == link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_name1) == joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/after_remove_link_unit.dot");
 
   // Test against double removing
-  EXPECT_FALSE(env->removeLink("link_n1"));
-  EXPECT_FALSE(env->removeLink("link_n2"));
-  EXPECT_FALSE(env->removeJoint("joint_n1"));
-  EXPECT_FALSE(env->removeJoint("joint_link_n1"));
+  EXPECT_FALSE(env->removeLink(link_name1));
+  EXPECT_FALSE(env->removeLink(link_name2));
+  EXPECT_FALSE(env->removeJoint(joint_name1));
+  EXPECT_FALSE(env->removeJoint("joint_" + link_name1));
 }
 
 void runMoveLinkandJointTest(const tesseract_environment::Environment::Ptr& env)
 {
-  Link link_1("link_n1");
-  Link link_2("link_n2");
+  const std::string link_name1 = "link_n1";
+  const std::string link_name2 = "link_n2";
+  const std::string joint_name1 = "joint_n1";
+  const std::string joint_name2 = "joint_n2";
+  Link link_1(link_name1);
+  Link link_2(link_name2);
 
-  Joint joint_1("joint_n1");
+  Joint joint_1(joint_name1);
   joint_1.parent_link_name = env->getRootLinkName();
-  joint_1.child_link_name = "link_n1";
+  joint_1.child_link_name = link_name1;
   joint_1.type = JointType::FIXED;
 
-  Joint joint_2("joint_n2");
+  Joint joint_2(joint_name2);
   joint_2.parent_to_joint_origin_transform.translation()(0) = 1.25;
-  joint_2.parent_link_name = "link_n1";
-  joint_2.child_link_name = "link_n2";
+  joint_2.parent_link_name = link_name1;
+  joint_2.child_link_name = link_name2;
   joint_2.type = JointType::FIXED;
 
   env->addLink(std::move(link_1), std::move(joint_1));
   EnvState::ConstPtr state = env->getCurrentState();
-  EXPECT_TRUE(state->transforms.find("link_n1") != state->transforms.end());
+  EXPECT_TRUE(state->transforms.find(link_name1) != state->transforms.end());
 
   env->addLink(std::move(link_2), std::move(joint_2));
   std::vector<std::string> link_names = env->getLinkNames();
   std::vector<std::string> joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") != link_names.end());
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") != joint_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n2") != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name1) != link_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name2) != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_name1) != joint_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_name2) != joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/before_move_joint_unit.dot");
 
-  env->moveJoint("joint_n1", "tool0");
+  env->moveJoint(joint_name1, "tool0");
   link_names = env->getLinkNames();
   joint_names = env->getJointNames();
-  EXPECT_TRUE(env->getJoint("joint_n1")->parent_link_name == "tool0");
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") != link_names.end());
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") != joint_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n2") != joint_names.end());
+  EXPECT_TRUE(env->getJoint(joint_name1)->parent_link_name == "tool0");
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name1) != link_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_name2) != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_name1) != joint_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_name2) != joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/after_move_joint_unit.dot");
 }
 
 void runChangeJointOriginTest(const tesseract_environment::Environment::Ptr& env)
 {
-  Link link_1("link_n1");
+  const std::string link_name1 = "link_n1";
+  const std::string joint_name1 = "joint_n1";
+  Link link_1(link_name1);
 
-  Joint joint_1("joint_n1");
+  Joint joint_1(joint_name1);
   joint_1.parent_link_name = env->getRootLinkName();
-  joint_1.child_link_name = "link_n1";
+  joint_1.child_link_name = link_name1;
   joint_1.type = JointType::FIXED;
 
   env->addLink(std::move(link_1), std::move(joint_1));
   EnvState::ConstPtr state = env->getCurrentState();
-  ASSERT_TRUE(state->transforms.find("link_n1") != state->transforms.end());
+  ASSERT_TRUE(state->transforms.find(link_name1) != state->transforms.end());
 
   env->getSceneGraph()->saveDOT("/tmp/before_change_joint_origin_unit.dot");
 
   Eigen::Isometry3d new_origin = Eigen::Isometry3d::Identity();
   new_origin.translation()(0) += 1.234;
-  env->changeJointOrigin("joint_n1", new_origin);
+  env->changeJointOrigin(joint_name1, new_origin);
 
   // Check that the origin got updated
-  EXPECT_TRUE(env->getJoint("joint_n1")->parent_to_joint_origin_transform.isApprox(new_origin));
+  EXPECT_TRUE(env->getJoint(joint_name1)->parent_to_joint_origin_transform.isApprox(new_origin));
 
   env->getSceneGraph()->saveDOT("/tmp/after_change_joint_origin_unit.dot");
 }

--- a/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -75,8 +75,7 @@ void runAddandRemoveLinkTest(const tesseract_environment::Environment::Ptr& env)
   joint_1.child_link_name = "link_n2";
   joint_1.type = JointType::FIXED;
 
-  Link link_3 = std::move(link_1);
-  EXPECT_TRUE(env->addLink(std::move(link_3)));
+  EXPECT_TRUE(env->addLink(std::move(link_1)));
 
   std::vector<std::string> link_names = env->getLinkNames();
   std::vector<std::string> joint_names = env->getJointNames();

--- a/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -319,6 +319,38 @@ TEST(TesseractEnvironmentUnit, KDLEnvCurrentStatePreservedWhenEnvChanges)  // NO
   runCurrentStatePreservedWhenEnvChangesTest(env);
 }
 
+TEST(TesseractEnvironmentUnit, addSceneGraph)
+{
+  SceneGraph::Ptr scene_graph = getSceneGraph();
+  EXPECT_TRUE(scene_graph != nullptr);
+
+  SceneGraph::Ptr subgraph = std::make_shared<SceneGraph>();
+  subgraph->setName("subgraph");
+
+  KDLEnv env;
+
+  bool success = env.init(scene_graph);
+  EXPECT_TRUE(success);
+
+  // Adding an empty environment will work, however many times
+  EXPECT_TRUE(env.addSceneGraph(*subgraph));
+  EXPECT_TRUE(env.addSceneGraph(*subgraph));
+
+  // Now add a link to empty environment
+  Link link("subgraph_base_link");
+  subgraph->addLink(link);
+
+  EXPECT_TRUE(env.addSceneGraph(*subgraph));
+  EXPECT_TRUE(env.getJoint("subgraph_joint") != nullptr);
+  EXPECT_TRUE(env.getLink("subgraph_base_link") != nullptr);
+
+  // Adding twice with the same name should fail
+  EXPECT_FALSE(env.addSceneGraph(*subgraph));
+  EXPECT_TRUE(env.addSceneGraph(*subgraph, "prefix_"));
+  EXPECT_TRUE(env.getJoint("prefix_subgraph_joint") != nullptr);
+  EXPECT_TRUE(env.getLink("prefix_subgraph_base_link") != nullptr);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -75,36 +75,37 @@ void runAddandRemoveLinkTest(const tesseract_environment::Environment::Ptr& env)
   joint_1.child_link_name = "link_n2";
   joint_1.type = JointType::FIXED;
 
-  env->addLink(link_1);
+  Link link_3 = std::move(link_1);
+  EXPECT_TRUE(env->addLink(std::move(link_3)));
 
   std::vector<std::string> link_names = env->getLinkNames();
   std::vector<std::string> joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_1.getName()) != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_" + link_1.getName()) != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_link_n1") != joint_names.end());
 
-  env->addLink(link_2, joint_1);
+  env->addLink(std::move(link_2), std::move(joint_1));
   link_names = env->getLinkNames();
   joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_2.getName()) != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_1.getName()) != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") != joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/before_remove_link_unit.dot");
 
-  env->removeLink(link_1.getName());
+  env->removeLink("link_n1");
   link_names = env->getLinkNames();
   joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_1.getName()) == link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_" + link_1.getName()) == joint_names.end());
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_2.getName()) == link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_1.getName()) == joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") == link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_link_n1") == joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") == link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") == joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/after_remove_link_unit.dot");
 
   // Test against double removing
-  EXPECT_FALSE(env->removeLink(link_1.getName()));
-  EXPECT_FALSE(env->removeLink(link_2.getName()));
-  EXPECT_FALSE(env->removeJoint(joint_1.getName()));
-  EXPECT_FALSE(env->removeJoint("joint_" + link_1.getName()));
+  EXPECT_FALSE(env->removeLink("link_n1"));
+  EXPECT_FALSE(env->removeLink("link_n2"));
+  EXPECT_FALSE(env->removeJoint("joint_n1"));
+  EXPECT_FALSE(env->removeJoint("joint_link_n1"));
 }
 
 void runMoveLinkandJointTest(const tesseract_environment::Environment::Ptr& env)
@@ -123,17 +124,17 @@ void runMoveLinkandJointTest(const tesseract_environment::Environment::Ptr& env)
   joint_2.child_link_name = "link_n2";
   joint_2.type = JointType::FIXED;
 
-  env->addLink(link_1, joint_1);
+  env->addLink(std::move(link_1), std::move(joint_1));
   EnvState::ConstPtr state = env->getCurrentState();
-  EXPECT_TRUE(state->transforms.find(link_1.getName()) != state->transforms.end());
+  EXPECT_TRUE(state->transforms.find("link_n1") != state->transforms.end());
 
-  env->addLink(link_2, joint_2);
+  env->addLink(std::move(link_2), std::move(joint_2));
   std::vector<std::string> link_names = env->getLinkNames();
   std::vector<std::string> joint_names = env->getJointNames();
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_1.getName()) != link_names.end());
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_2.getName()) != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_1.getName()) != joint_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_2.getName()) != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") != link_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") != joint_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n2") != joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/before_move_joint_unit.dot");
 
@@ -141,10 +142,10 @@ void runMoveLinkandJointTest(const tesseract_environment::Environment::Ptr& env)
   link_names = env->getLinkNames();
   joint_names = env->getJointNames();
   EXPECT_TRUE(env->getJoint("joint_n1")->parent_link_name == "tool0");
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_1.getName()) != link_names.end());
-  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), link_2.getName()) != link_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_1.getName()) != joint_names.end());
-  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), joint_2.getName()) != joint_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n1") != link_names.end());
+  EXPECT_TRUE(std::find(link_names.begin(), link_names.end(), "link_n2") != link_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n1") != joint_names.end());
+  EXPECT_TRUE(std::find(joint_names.begin(), joint_names.end(), "joint_n2") != joint_names.end());
 
   env->getSceneGraph()->saveDOT("/tmp/after_move_joint_unit.dot");
 }
@@ -158,9 +159,9 @@ void runChangeJointOriginTest(const tesseract_environment::Environment::Ptr& env
   joint_1.child_link_name = "link_n1";
   joint_1.type = JointType::FIXED;
 
-  env->addLink(link_1, joint_1);
+  env->addLink(std::move(link_1), std::move(joint_1));
   EnvState::ConstPtr state = env->getCurrentState();
-  ASSERT_TRUE(state->transforms.find(link_1.getName()) != state->transforms.end());
+  ASSERT_TRUE(state->transforms.find("link_n1") != state->transforms.end());
 
   env->getSceneGraph()->saveDOT("/tmp/before_change_joint_origin_unit.dot");
 
@@ -200,7 +201,7 @@ void runCurrentStatePreservedWhenEnvChangesTest(const tesseract_environment::Env
   joint.child_link_name = "link_n1";
   joint.type = JointType::FIXED;
 
-  env->addLink(link, joint);
+  env->addLink(std::move(link), std::move(joint));
 
   current_state = env->getCurrentState();
   for (auto& joint_state : joint_states)
@@ -338,7 +339,7 @@ TEST(TesseractEnvironmentUnit, addSceneGraph)
 
   // Now add a link to empty environment
   Link link("subgraph_base_link");
-  subgraph->addLink(link);
+  subgraph->addLink(std::move(link));
 
   EXPECT_TRUE(env.addSceneGraph(*subgraph));
   EXPECT_TRUE(env.getJoint("subgraph_joint") != nullptr);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -112,7 +112,7 @@ static void addBox(tesseract_environment::Environment& env)
   joint_1.child_link_name = link_1.getName();
   joint_1.type = JointType::FIXED;
 
-  env.addLink(link_1, joint_1);
+  env.addLink(std::move(link_1), std::move(joint_1));
 }
 
 template <typename PlannerType>

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_trajopt_planner_test.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_trajopt_planner_test.cpp
@@ -115,7 +115,7 @@ static void addBox(tesseract_environment::Environment& env)
   joint_1.child_link_name = link_1.getName();
   joint_1.type = JointType::FIXED;
 
-  env.addLink(link_1, joint_1);
+  env.addLink(std::move(link_1), std::move(joint_1));
 }
 
 template <typename PlannerType>

--- a/tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+++ b/tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
@@ -28,11 +28,11 @@ int main(int /*argc*/, char** /*argv*/)
   Link link_5("link_5");
 
   // Add links
-  g.addLink(link_1);
-  g.addLink(link_2);
-  g.addLink(link_3);
-  g.addLink(link_4);
-  g.addLink(link_5);
+  g.addLink(std::move(link_1));
+  g.addLink(std::move(link_2));
+  g.addLink(std::move(link_3));
+  g.addLink(std::move(link_4));
+  g.addLink(std::move(link_5));
 
   // Create joints
   Joint joint_1("joint_1");
@@ -60,10 +60,10 @@ int main(int /*argc*/, char** /*argv*/)
   joint_4.type = JointType::REVOLUTE;
 
   // Add joints
-  g.addJoint(joint_1);
-  g.addJoint(joint_2);
-  g.addJoint(joint_3);
-  g.addJoint(joint_4);
+  g.addJoint(std::move(joint_1));
+  g.addJoint(std::move(joint_2));
+  g.addJoint(std::move(joint_3));
+  g.addJoint(std::move(joint_4));
 
   // Check getAdjacentLinkNames Method
   std::vector<std::string> adjacent_links = g.getAdjacentLinkNames("link_3");
@@ -98,12 +98,12 @@ int main(int /*argc*/, char** /*argv*/)
 
   // Test for unused links
   Link link_6("link_6");
-  g.addLink(link_6);
+  g.addLink(std::move(link_6));
   is_tree = g.isTree();
   CONSOLE_BRIDGE_logInform(toString(is_tree).c_str());
 
   // Remove unused link
-  g.removeLink(link_6.getName());
+  g.removeLink("link_6");
   is_tree = g.isTree();
   CONSOLE_BRIDGE_logInform(toString(is_tree).c_str());
 
@@ -113,7 +113,7 @@ int main(int /*argc*/, char** /*argv*/)
   joint_5.parent_link_name = "link_5";
   joint_5.child_link_name = "link_4";
   joint_5.type = JointType::CONTINUOUS;
-  g.addJoint(joint_5);
+  g.addJoint(std::move(joint_5));
 
   // Save new graph
   g.saveDOT("/tmp/graph_acyclic_not_tree_example.dot");

--- a/tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
+++ b/tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
@@ -64,68 +64,68 @@ int main(int /*argc*/, char** /*argv*/)
   Link link_7("link_7");
   Link tool0("tool0");
 
-  g.addLink(base_link);
-  g.addLink(link_1);
-  g.addLink(link_2);
-  g.addLink(link_3);
-  g.addLink(link_4);
-  g.addLink(link_5);
-  g.addLink(link_6);
-  g.addLink(link_7);
-  g.addLink(tool0);
+  g.addLink(std::move(base_link));
+  g.addLink(std::move(link_1));
+  g.addLink(std::move(link_2));
+  g.addLink(std::move(link_3));
+  g.addLink(std::move(link_4));
+  g.addLink(std::move(link_5));
+  g.addLink(std::move(link_6));
+  g.addLink(std::move(link_7));
+  g.addLink(std::move(tool0));
 
   Joint base_joint("base_joint");
   base_joint.parent_link_name = "base_link";
   base_joint.child_link_name = "link_1";
   base_joint.type = JointType::FIXED;
-  g.addJoint(base_joint);
+  g.addJoint(std::move(base_joint));
 
   Joint joint_1("joint_1");
   joint_1.parent_link_name = "link_1";
   joint_1.child_link_name = "link_2";
   joint_1.type = JointType::REVOLUTE;
-  g.addJoint(joint_1);
+  g.addJoint(std::move(joint_1));
 
   Joint joint_2("joint_2");
   joint_2.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_2.parent_link_name = "link_2";
   joint_2.child_link_name = "link_3";
   joint_2.type = JointType::REVOLUTE;
-  g.addJoint(joint_2);
+  g.addJoint(std::move(joint_2));
 
   Joint joint_3("joint_3");
   joint_3.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_3.parent_link_name = "link_3";
   joint_3.child_link_name = "link_4";
   joint_3.type = JointType::REVOLUTE;
-  g.addJoint(joint_3);
+  g.addJoint(std::move(joint_3));
 
   Joint joint_4("joint_4");
   joint_4.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_4.parent_link_name = "link_4";
   joint_4.child_link_name = "link_5";
   joint_4.type = JointType::REVOLUTE;
-  g.addJoint(joint_4);
+  g.addJoint(std::move(joint_4));
 
   Joint joint_5("joint_5");
   joint_5.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_5.parent_link_name = "link_5";
   joint_5.child_link_name = "link_6";
   joint_5.type = JointType::REVOLUTE;
-  g.addJoint(joint_5);
+  g.addJoint(std::move(joint_5));
 
   Joint joint_6("joint_6");
   joint_6.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_6.parent_link_name = "link_6";
   joint_6.child_link_name = "link_7";
   joint_6.type = JointType::REVOLUTE;
-  g.addJoint(joint_6);
+  g.addJoint(std::move(joint_6));
 
   Joint joint_tool0("joint_tool0");
   joint_tool0.parent_link_name = "link_7";
   joint_tool0.child_link_name = "tool0";
   joint_tool0.type = JointType::FIXED;
-  g.addJoint(joint_tool0);
+  g.addJoint(std::move(joint_tool0));
 
   // Parse the srdf
   SRDFModel srdf;

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
@@ -147,16 +147,6 @@ public:
   bool addLink(Link link);
 
   /**
-   * @brief Adds a link to the graph
-   *
-   * The first link added to the graph is set as the root by default. Use setRoot to change the root link of the graph.
-   *
-   * @param link_ptr Shared pointer to the link to be added to the graph
-   * @return Return False if a link with the same name allready exists, otherwise true
-   */
-  bool addLink(Link::Ptr link_ptr);
-
-  /**
    * @brief Get a link in the graph
    * @param name The name of the link
    * @return Return nullptr if link name does not exists, otherwise a pointer to the link
@@ -210,14 +200,6 @@ public:
    * otherwise true
    */
   bool addJoint(Joint joint);
-
-  /**
-   * @brief Adds joint to the graph
-   * @param joint_ptr Shared pointer to the joint to be added
-   * @return Return False if parent or child link does not exists and if joint name already exists in the graph,
-   * otherwise true
-   */
-  bool addJoint(Joint::Ptr joint_ptr);
 
   /**
    * @brief Get a joint in the graph
@@ -396,6 +378,25 @@ public:
    * @return Graph Edge
    */
   Edge getEdge(const std::string& name) const;
+
+protected:
+  /**
+   * @brief Adds a link to the graph
+   *
+   * The first link added to the graph is set as the root by default. Use setRoot to change the root link of the graph.
+   *
+   * @param link_ptr Shared pointer to the link to be added to the graph
+   * @return Return False if a link with the same name allready exists, otherwise true
+   */
+  bool addLink(Link::Ptr link_ptr);
+
+  /**
+   * @brief Adds joint to the graph
+   * @param joint_ptr Shared pointer to the joint to be added
+   * @return Return False if parent or child link does not exists and if joint name already exists in the graph,
+   * otherwise true
+   */
+  bool addJoint(Joint::Ptr joint_ptr);
 
 private:
   std::unordered_map<std::string, std::pair<Link::Ptr, Vertex>> link_map_;

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
@@ -147,6 +147,16 @@ public:
   bool addLink(Link link);
 
   /**
+   * @brief Adds a link to the graph
+   *
+   * The first link added to the graph is set as the root by default. Use setRoot to change the root link of the graph.
+   *
+   * @param link_ptr Shared pointer to the link to be added to the graph
+   * @return Return False if a link with the same name allready exists, otherwise true
+   */
+  bool addLink(Link::Ptr link);
+
+  /**
    * @brief Get a link in the graph
    * @param name The name of the link
    * @return Return nullptr if link name does not exists, otherwise a pointer to the link
@@ -200,6 +210,14 @@ public:
    * otherwise true
    */
   bool addJoint(Joint joint);
+
+  /**
+   * @brief Adds joint to the graph
+   * @param joint_ptr Shared pointer to the joint to be added
+   * @return Return False if parent or child link does not exists and if joint name already exists in the graph,
+   * otherwise true
+   */
+  bool addJoint(Joint::Ptr joint);
 
   /**
    * @brief Get a joint in the graph

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
@@ -154,7 +154,7 @@ public:
    * @param link_ptr Shared pointer to the link to be added to the graph
    * @return Return False if a link with the same name allready exists, otherwise true
    */
-  bool addLink(Link::Ptr link);
+  bool addLink(Link::Ptr link_ptr);
 
   /**
    * @brief Get a link in the graph
@@ -217,7 +217,7 @@ public:
    * @return Return False if parent or child link does not exists and if joint name already exists in the graph,
    * otherwise true
    */
-  bool addJoint(Joint::Ptr joint);
+  bool addJoint(Joint::Ptr joint_ptr);
 
   /**
    * @brief Get a joint in the graph

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/joint.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/joint.h
@@ -256,6 +256,24 @@ public:
     this->type = JointType::UNKNOWN;
   }
 
+  /* Create a shallow copy of current joint, with prefix prepended to its name, child link name and parent link name.
+   * Shallow means that underlying properties, such as dynamics, limits... are shared with the original object.*/
+  Joint prefix(const std::string& prefix) const
+  {
+    Joint ret(prefix + this->getName());
+    ret.axis = this->axis;
+    ret.child_link_name = prefix + this->child_link_name;
+    ret.parent_link_name = prefix + this->parent_link_name;
+    ret.parent_to_joint_origin_transform = this->parent_to_joint_origin_transform;
+    ret.dynamics = this->dynamics;
+    ret.limits = this->limits;
+    ret.safety = this->safety;
+    ret.calibration = this->calibration;
+    ret.mimic = this->mimic;
+    ret.type = this->type;
+    return ret;
+  }
+
 private:
   const std::string name_;
 };

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/joint.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/joint.h
@@ -200,12 +200,14 @@ public:
   using ConstPtr = std::shared_ptr<const Joint>;
 
   Joint(std::string name) : name_(std::move(name)) { this->clear(); }
+  ~Joint() = default;
   // Joints are non-copyable as their name must be unique
   Joint(const Joint& other) = delete;
   Joint& operator=(const Joint& other) = delete;
 
   Joint(Joint&& other) = default;
-  Joint& operator=(Joint&& other) = default;
+  // Joint has a const-member, so no move assignment operator
+  Joint& operator=(Joint&& other) = delete;
 
   const std::string& getName() const { return name_; }
 

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/joint.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/joint.h
@@ -206,8 +206,7 @@ public:
   Joint& operator=(const Joint& other) = delete;
 
   Joint(Joint&& other) = default;
-  // Joint has a const-member, so no move assignment operator
-  Joint& operator=(Joint&& other) = delete;
+  Joint& operator=(Joint&& other) = default;
 
   const std::string& getName() const { return name_; }
 
@@ -298,7 +297,7 @@ public:
   }
 
 private:
-  const std::string name_;
+  std::string name_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const JointType& type)

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -172,6 +172,16 @@ public:
     this->visual.clear();
   }
 
+  /** Perform a shallow copy of link, prepending prefix to the name **/
+  Link prefix(const std::string& prefix) const
+  {
+    Link ret(prefix + this->getName());
+    ret.inertial = this->inertial;
+    ret.collision = this->collision;
+    ret.visual = this->visual;
+    return ret;
+  }
+
 private:
   const std::string name_;
 };

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -159,8 +159,7 @@ public:
   Link& operator=(const Link& other) = delete;
 
   Link(Link&& other) = default;
-  // Link has a const member so can't have assignment operator
-  Link& operator=(Link&& other) = delete;
+  Link& operator=(Link&& other) = default;
 
   const std::string& getName() const { return name_; }
 
@@ -200,7 +199,7 @@ public:
   }
 
 private:
-  const std::string name_;
+  std::string name_;
 };
 
 }  // namespace tesseract_scene_graph

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -153,6 +153,12 @@ public:
   using ConstPtr = std::shared_ptr<const Link>;
 
   Link(std::string name) : name_(std::move(name)) { this->clear(); }
+  // Links are non-copyable as their name must be unique
+  Link(const Link& other) = delete;
+  Link& operator=(const Link& other) = delete;
+
+  Link(Link&& other) = default;
+  Link& operator=(Link&& other) = default;
 
   const std::string& getName() const { return name_; }
 
@@ -172,13 +178,22 @@ public:
     this->visual.clear();
   }
 
-  /** Perform a shallow copy of link, prepending prefix to the name **/
-  Link prefix(const std::string& prefix) const
+  /** Perform a copy of link, changing its name **/
+  Link clone(const std::string& name) const
   {
-    Link ret(prefix + this->getName());
-    ret.inertial = this->inertial;
-    ret.collision = this->collision;
-    ret.visual = this->visual;
+    Link ret(name);
+    if (this->inertial)
+    {
+      ret.inertial = std::make_shared<Inertial>(*(this->inertial));
+    }
+    for (const auto& c : this->collision)
+    {
+      ret.collision.push_back(std::make_shared<Collision>(*c));
+    }
+    for (const auto& v : this->visual)
+    {
+      ret.visual.push_back(std::make_shared<Visual>(*v));
+    }
     return ret;
   }
 

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -153,12 +153,14 @@ public:
   using ConstPtr = std::shared_ptr<const Link>;
 
   Link(std::string name) : name_(std::move(name)) { this->clear(); }
+  ~Link() = default;
   // Links are non-copyable as their name must be unique
   Link(const Link& other) = delete;
   Link& operator=(const Link& other) = delete;
 
   Link(Link&& other) = default;
-  Link& operator=(Link&& other) = default;
+  // Link has a const member so can't have assignment operator
+  Link& operator=(Link&& other) = delete;
 
   const std::string& getName() const { return name_; }
 

--- a/tesseract/tesseract_scene_graph/src/graph.cpp
+++ b/tesseract/tesseract_scene_graph/src/graph.cpp
@@ -67,6 +67,11 @@ const std::string& SceneGraph::getRoot() const
 bool SceneGraph::addLink(Link link)
 {
   auto link_ptr = std::make_shared<tesseract_scene_graph::Link>(std::move(link));
+  return addLink(link_ptr);
+}
+
+bool SceneGraph::addLink(Link::Ptr link_ptr)
+{
   auto found = link_map_.find(link_ptr->getName());
   if (found != link_map_.end())
     return false;
@@ -165,6 +170,11 @@ bool SceneGraph::getLinkCollisionEnabled(const std::string& name) const
 bool SceneGraph::addJoint(tesseract_scene_graph::Joint joint)
 {
   auto joint_ptr = std::make_shared<tesseract_scene_graph::Joint>(std::move(joint));
+  return addJoint(joint_ptr);
+}
+
+bool SceneGraph::addJoint(tesseract_scene_graph::Joint::Ptr joint_ptr)
+{
   auto parent = link_map_.find(joint_ptr->parent_link_name);
   auto child = link_map_.find(joint_ptr->child_link_name);
   auto found = joint_map_.find(joint_ptr->getName());
@@ -234,7 +244,7 @@ bool SceneGraph::moveJoint(const std::string& name, const std::string& parent_li
     return false;
 
   joint->parent_link_name = parent_link;
-  return addJoint(*joint);
+  return addJoint(std::move(joint));
 }
 
 std::vector<Joint::ConstPtr> SceneGraph::getJoints() const

--- a/tesseract/tesseract_scene_graph/test/tesseract_scene_graph_unit.cpp
+++ b/tesseract/tesseract_scene_graph/test/tesseract_scene_graph_unit.cpp
@@ -45,39 +45,39 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphUnit)  // NOLINT
   Link link_4("link_4");
   Link link_5("link_5");
 
-  g.addLink(link_1);
-  g.addLink(link_2);
-  g.addLink(link_3);
-  g.addLink(link_4);
-  g.addLink(link_5);
+  g.addLink(std::move(link_1));
+  g.addLink(std::move(link_2));
+  g.addLink(std::move(link_3));
+  g.addLink(std::move(link_4));
+  g.addLink(std::move(link_5));
 
   Joint joint_1("joint_1");
   joint_1.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_1.parent_link_name = "link_1";
   joint_1.child_link_name = "link_2";
   joint_1.type = JointType::FIXED;
-  g.addJoint(joint_1);
+  g.addJoint(std::move(joint_1));
 
   Joint joint_2("joint_2");
   joint_2.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_2.parent_link_name = "link_2";
   joint_2.child_link_name = "link_3";
   joint_2.type = JointType::PLANAR;
-  g.addJoint(joint_2);
+  g.addJoint(std::move(joint_2));
 
   Joint joint_3("joint_3");
   joint_3.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_3.parent_link_name = "link_3";
   joint_3.child_link_name = "link_4";
   joint_3.type = JointType::FLOATING;
-  g.addJoint(joint_3);
+  g.addJoint(std::move(joint_3));
 
   Joint joint_4("joint_4");
   joint_4.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_4.parent_link_name = "link_2";
   joint_4.child_link_name = "link_5";
   joint_4.type = JointType::REVOLUTE;
-  g.addJoint(joint_4);
+  g.addJoint(std::move(joint_4));
 
   // Check getAdjacentLinkNames Method
   std::vector<std::string> adjacent_links = g.getAdjacentLinkNames("link_3");
@@ -135,14 +135,14 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphUnit)  // NOLINT
 
   // Test for unused links
   Link link_6("link_6");
-  g.addLink(link_6);
+  g.addLink(std::move(link_6));
   std::cout << "Free Link, Is Tree: " << g.isTree() << std::endl;
   EXPECT_FALSE(g.isTree());
 
   // Check Graph
   checkSceneGraph(g);
 
-  g.removeLink(link_6.getName());
+  g.removeLink("link_6");
   std::cout << "Free Link Removed, Is Tree: " << g.isTree() << std::endl;
   EXPECT_TRUE(g.isTree());
 
@@ -154,7 +154,7 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphUnit)  // NOLINT
   joint_5.parent_link_name = "link_5";
   joint_5.child_link_name = "link_4";
   joint_5.type = JointType::CONTINUOUS;
-  g.addJoint(joint_5);
+  g.addJoint(std::move(joint_5));
 
   // Check Graph
   checkSceneGraph(g);
@@ -175,7 +175,7 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphUnit)  // NOLINT
   joint_6.parent_link_name = "link_5";
   joint_6.child_link_name = "link_1";
   joint_6.type = JointType::CONTINUOUS;
-  g.addJoint(joint_6);
+  g.addJoint(std::move(joint_6));
 
   // Check Graph
   checkSceneGraph(g);
@@ -259,68 +259,68 @@ TEST(TesseractSceneGraphUnit, LoadSRDFUnit)  // NOLINT
   Link link_7("link_7");
   Link tool0("tool0");
 
-  g.addLink(base_link);
-  g.addLink(link_1);
-  g.addLink(link_2);
-  g.addLink(link_3);
-  g.addLink(link_4);
-  g.addLink(link_5);
-  g.addLink(link_6);
-  g.addLink(link_7);
-  g.addLink(tool0);
+  g.addLink(std::move(base_link));
+  g.addLink(std::move(link_1));
+  g.addLink(std::move(link_2));
+  g.addLink(std::move(link_3));
+  g.addLink(std::move(link_4));
+  g.addLink(std::move(link_5));
+  g.addLink(std::move(link_6));
+  g.addLink(std::move(link_7));
+  g.addLink(std::move(tool0));
 
   Joint base_joint("base_joint");
   base_joint.parent_link_name = "base_link";
   base_joint.child_link_name = "link_1";
   base_joint.type = JointType::FIXED;
-  g.addJoint(base_joint);
+  g.addJoint(std::move(base_joint));
 
   Joint joint_1("joint_1");
   joint_1.parent_link_name = "link_1";
   joint_1.child_link_name = "link_2";
   joint_1.type = JointType::REVOLUTE;
-  g.addJoint(joint_1);
+  g.addJoint(std::move(joint_1));
 
   Joint joint_2("joint_2");
   joint_2.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_2.parent_link_name = "link_2";
   joint_2.child_link_name = "link_3";
   joint_2.type = JointType::REVOLUTE;
-  g.addJoint(joint_2);
+  g.addJoint(std::move(joint_2));
 
   Joint joint_3("joint_3");
   joint_3.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_3.parent_link_name = "link_3";
   joint_3.child_link_name = "link_4";
   joint_3.type = JointType::REVOLUTE;
-  g.addJoint(joint_3);
+  g.addJoint(std::move(joint_3));
 
   Joint joint_4("joint_4");
   joint_4.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_4.parent_link_name = "link_4";
   joint_4.child_link_name = "link_5";
   joint_4.type = JointType::REVOLUTE;
-  g.addJoint(joint_4);
+  g.addJoint(std::move(joint_4));
 
   Joint joint_5("joint_5");
   joint_5.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_5.parent_link_name = "link_5";
   joint_5.child_link_name = "link_6";
   joint_5.type = JointType::REVOLUTE;
-  g.addJoint(joint_5);
+  g.addJoint(std::move(joint_5));
 
   Joint joint_6("joint_6");
   joint_6.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_6.parent_link_name = "link_6";
   joint_6.child_link_name = "link_7";
   joint_6.type = JointType::REVOLUTE;
-  g.addJoint(joint_6);
+  g.addJoint(std::move(joint_6));
 
   Joint joint_tool0("joint_tool0");
   joint_tool0.parent_link_name = "link_7";
   joint_tool0.child_link_name = "tool0";
   joint_tool0.type = JointType::FIXED;
-  g.addJoint(joint_tool0);
+  g.addJoint(std::move(joint_tool0));
 
   SRDFModel srdf;
   EXPECT_TRUE(srdf.initFile(g, srdf_file));
@@ -364,45 +364,45 @@ TEST(TesseractSceneGraphUnit, LoadKDLUnit)  // NOLINT
   Link link_4("link_4");
   Link link_5("link_5");
 
-  g.addLink(base_link);
-  g.addLink(link_1);
-  g.addLink(link_2);
-  g.addLink(link_3);
-  g.addLink(link_4);
-  g.addLink(link_5);
+  g.addLink(std::move(base_link));
+  g.addLink(std::move(link_1));
+  g.addLink(std::move(link_2));
+  g.addLink(std::move(link_3));
+  g.addLink(std::move(link_4));
+  g.addLink(std::move(link_5));
 
   Joint base_joint("base_joint");
   base_joint.parent_link_name = "base_link";
   base_joint.child_link_name = "link_1";
   base_joint.type = JointType::FIXED;
-  g.addJoint(base_joint);
+  g.addJoint(std::move(base_joint));
 
   Joint joint_1("joint_1");
   joint_1.parent_link_name = "link_1";
   joint_1.child_link_name = "link_2";
   joint_1.type = JointType::REVOLUTE;
-  g.addJoint(joint_1);
+  g.addJoint(std::move(joint_1));
 
   Joint joint_2("joint_2");
   joint_2.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_2.parent_link_name = "link_2";
   joint_2.child_link_name = "link_3";
   joint_2.type = JointType::REVOLUTE;
-  g.addJoint(joint_2);
+  g.addJoint(std::move(joint_2));
 
   Joint joint_3("joint_3");
   joint_3.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_3.parent_link_name = "link_3";
   joint_3.child_link_name = "link_4";
   joint_3.type = JointType::REVOLUTE;
-  g.addJoint(joint_3);
+  g.addJoint(std::move(joint_3));
 
   Joint joint_4("joint_4");
   joint_4.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_4.parent_link_name = "link_2";
   joint_4.child_link_name = "link_5";
   joint_4.type = JointType::REVOLUTE;
-  g.addJoint(joint_4);
+  g.addJoint(std::move(joint_4));
 
   KDL::Tree tree;
   EXPECT_TRUE(parseSceneGraph(g, tree));
@@ -452,9 +452,9 @@ TEST(TesseractSceneGraphUnit, TestChangeJointOrigin)  // NOLINT
   joint_1.child_link_name = "link_n2";
   joint_1.type = JointType::FIXED;
 
-  g.addLink(link_1);
-  g.addLink(link_2);
-  g.addJoint(joint_1);
+  g.addLink(std::move(link_1));
+  g.addLink(std::move(link_2));
+  g.addJoint(std::move(joint_1));
 
   Eigen::Isometry3d new_origin = Eigen::Isometry3d::Identity();
   new_origin.translation()(0) += 1.234;

--- a/tesseract/tesseract_urdf/src/urdf_parser.cpp
+++ b/tesseract/tesseract_urdf/src/urdf_parser.cpp
@@ -84,7 +84,7 @@ tesseract_common::StatusCode::Ptr parseURDFString(tesseract_scene_graph::SceneGr
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorLinkNamesNotUnique, status_cat, status);
 
-    if (!sg->addLink(tesseract_scene_graph::Link(*l)))
+    if (!sg->addLink(std::move(l)))
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorAddingLinkToSceneGraph, status_cat, status);
   }
@@ -106,7 +106,7 @@ tesseract_common::StatusCode::Ptr parseURDFString(tesseract_scene_graph::SceneGr
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorJointNamesNotUnique, status_cat, status);
 
-    if (!sg->addJoint(tesseract_scene_graph::Joint(*j)))
+    if (!sg->addJoint(std::move(j)))
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorAddingJointToSceneGraph, status_cat, status);
   }

--- a/tesseract/tesseract_urdf/src/urdf_parser.cpp
+++ b/tesseract/tesseract_urdf/src/urdf_parser.cpp
@@ -84,7 +84,11 @@ tesseract_common::StatusCode::Ptr parseURDFString(tesseract_scene_graph::SceneGr
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorLinkNamesNotUnique, status_cat, status);
 
-    if (!sg->addLink(std::move(l)))
+    /** NB: Moving the pointed data is only ok here because we are the only owners
+     * of said link, and it's reset to nullptr at every loop iteration.
+     * TODO: Move to a unique_ptr interface?
+     */
+    if (!sg->addLink(std::move(*l)))
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorAddingLinkToSceneGraph, status_cat, status);
   }
@@ -106,7 +110,11 @@ tesseract_common::StatusCode::Ptr parseURDFString(tesseract_scene_graph::SceneGr
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorJointNamesNotUnique, status_cat, status);
 
-    if (!sg->addJoint(std::move(j)))
+    /** NB: Moving the pointed data is only ok here because we are the only owners
+     * of said link, and it's reset to nullptr at every loop iteration.
+     * TODO: Move to a unique_ptr interface?
+     */
+    if (!sg->addJoint(std::move(*j)))
       return std::make_shared<tesseract_common::StatusCode>(
           URDFStatusCategory::ErrorAddingJointToSceneGraph, status_cat, status);
   }

--- a/tesseract_python/tesseract_python/swig/ros/tesseract_rosutils/utils.i
+++ b/tesseract_python/tesseract_python/swig/ros/tesseract_rosutils/utils.i
@@ -144,6 +144,26 @@ tesseract_type name ## FromMsg(const msg_type& msg)
 %}
 %enddef
 
+// Macro to convert messages with move-only semantics
+%define CONVERT_MSG_TYPE7(name, tesseract_type, msg_type)
+%inline %{
+void name ## ToMsg(msg_type& msg, const tesseract_type& t)
+{
+  if (!tesseract_rosutils::toMsg(msg, t))
+  {
+    throw std::runtime_error(#name "ToMsg failed");
+  }
+}
+
+tesseract_type::Ptr name ## FromMsg(const msg_type& msg)
+{
+  tesseract_type::Ptr t = std::make_shared<tesseract_type>(std::move(tesseract_rosutils::fromMsg(msg)));
+  return t;
+}
+%}
+%enddef
+
+
 %define PROCESS_MSG(name, tesseract_type, msg_type)
 %inline %{
 void name ## ProcessMsg(tesseract_type& t, const msg_type& msg)
@@ -184,13 +204,13 @@ CONVERT_MSG_TYPE2(materials, tesseract_scene_graph::Material, tesseract_msgs::Ma
 CONVERT_MSG_TYPE2(inertial, tesseract_scene_graph::Inertial, tesseract_msgs::Inertial)
 CONVERT_MSG_TYPE(visualGeometry, tesseract_scene_graph::Visual, tesseract_msgs::VisualGeometry)
 CONVERT_MSG_TYPE(collisionGeometry, tesseract_scene_graph::Collision, tesseract_msgs::CollisionGeometry)
-CONVERT_MSG_TYPE3(link, tesseract_scene_graph::Link, tesseract_msgs::Link)
+CONVERT_MSG_TYPE7(link, tesseract_scene_graph::Link, tesseract_msgs::Link)
 CONVERT_MSG_TYPE2(jointCalibration, tesseract_scene_graph::JointCalibration, tesseract_msgs::JointCalibration)
 CONVERT_MSG_TYPE2(jointDynamics, tesseract_scene_graph::JointDynamics, tesseract_msgs::JointDynamics)
 CONVERT_MSG_TYPE2(jointLimits, tesseract_scene_graph::JointLimits, tesseract_msgs::JointLimits)
 CONVERT_MSG_TYPE2(jointMimic, tesseract_scene_graph::JointMimic, tesseract_msgs::JointMimic)
 CONVERT_MSG_TYPE2(jointSafety, tesseract_scene_graph::JointSafety, tesseract_msgs::JointSafety)
-CONVERT_MSG_TYPE3(joint, tesseract_scene_graph::Joint, tesseract_msgs::Joint)
+CONVERT_MSG_TYPE7(joint, tesseract_scene_graph::Joint, tesseract_msgs::Joint)
 
 // tesseract_environment
 CONVERT_MSG_TYPE5(tesseractEnvStateJoints, tesseract_environment::EnvState, sensor_msgs::JointState)

--- a/tesseract_python/tesseract_python/swig/tesseract_environment/core/environment.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_environment/core/environment.i
@@ -75,13 +75,8 @@ public:
 
   virtual EnvState::ConstPtr getCurrentState() const;
 
-  virtual bool addLink(tesseract_scene_graph::Link link);
-
-  virtual bool addLink(tesseract_scene_graph::Link link, tesseract_scene_graph::Joint joint);
 
    virtual bool removeLink(const std::string& name);
-
-  virtual bool moveLink(tesseract_scene_graph::Joint joint);
 
   virtual tesseract_scene_graph::Link::ConstPtr getLink(const std::string& name) const;
 
@@ -150,5 +145,28 @@ public:
   registerContinuousContactManager(const std::string& name,
                                    tesseract_collision::ContinuousContactManagerFactory::CreateMethod create_function);
 
+  %extend
+  {
+    // Links and joints are move-only, so the wrappers need to clone them!
+    bool addLink(tesseract_scene_graph::Link::ConstPtr link)
+    {
+      auto new_link = link->clone(link->getName());
+      return $self->addLink(std::move(new_link));
+    }
+
+    bool addLink(tesseract_scene_graph::Link::ConstPtr link,
+                 tesseract_scene_graph::Joint::ConstPtr joint)
+    {
+      auto new_joint = joint->clone(joint->getName());
+      auto new_link = link->clone(link->getName());
+      return $self->addLink(std::move(new_link), std::move(new_joint));
+    }
+
+    bool moveLink(tesseract_scene_graph::Joint::ConstPtr joint)
+    {
+      auto new_joint = joint->clone(joint->getName());
+      return $self->moveLink(std::move(new_joint));
+    }
+  }
 };
 }  // namespace tesseract_environment

--- a/tesseract_python/tesseract_python/swig/tesseract_scene_graph/graph.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_scene_graph/graph.i
@@ -59,7 +59,7 @@ bool setRoot(const std::string& name);
 
 const std::string& getRoot() const;
 
-bool addLink(Link link);
+bool addLink(Link::Ptr link);
 
 Link::ConstPtr getLink(const std::string& name) const;
 
@@ -75,7 +75,7 @@ void setLinkCollisionEnabled(const std::string& name, bool enabled);
 
 bool getLinkCollisionEnabled(const std::string& name) const;
 
-bool addJoint(Joint joint);
+bool addJoint(Joint::Ptr joint);
 
 Joint::ConstPtr getJoint(const std::string& name) const;
 

--- a/tesseract_python/tesseract_python/swig/tesseract_scene_graph/graph.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_scene_graph/graph.i
@@ -59,7 +59,6 @@ bool setRoot(const std::string& name);
 
 const std::string& getRoot() const;
 
-bool addLink(Link::Ptr link);
 
 Link::ConstPtr getLink(const std::string& name) const;
 
@@ -74,8 +73,6 @@ bool getLinkVisibility(const std::string& name) const;
 void setLinkCollisionEnabled(const std::string& name, bool enabled);
 
 bool getLinkCollisionEnabled(const std::string& name) const;
-
-bool addJoint(Joint::Ptr joint);
 
 Joint::ConstPtr getJoint(const std::string& name) const;
 
@@ -125,6 +122,21 @@ void saveDOT(const std::string& path) const;
 // Path getShortestPath(const std::string& root, const std::string& tip);
 // Vertex getVertex(const std::string& name) const;
 // Edge getEdge(const std::string& name) const;
+
+%extend {
+  bool addLink(Link::ConstPtr link)
+  {
+    auto new_link = link->clone(link->getName());
+    return $self->addLink(std::move(new_link));
+  }
+
+  bool addJoint(Joint::ConstPtr joint)
+  {
+    auto new_joint = joint->clone(joint->getName());
+    return $self->addJoint(std::move(new_joint));
+  }
+}
+
 };
 
 } // namespace tesseract_scene_graph

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/basic_cartesian_example.cpp
@@ -118,7 +118,7 @@ bool BasicCartesianExample::addPointCloud()
   joint_octomap.child_link_name = link_octomap.getName();
   joint_octomap.type = JointType::FIXED;
 
-  return tesseract_->getEnvironment()->addLink(link_octomap, joint_octomap);
+  return tesseract_->getEnvironment()->addLink(std::move(link_octomap), std::move(joint_octomap));
 }
 
 TrajOptProb::Ptr BasicCartesianExample::cppMethod()

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/car_seat_example.cpp
@@ -105,7 +105,7 @@ void CarSeatExample::addSeats()
                                                   Eigen::AngleAxisd(3.14159, Eigen::Vector3d::UnitZ());
     joint_seat.parent_to_joint_origin_transform.translation() = Eigen::Vector3d(0.5 + i, 2.15, 0.45);
 
-    tesseract_->getEnvironment()->addLink(link_seat, joint_seat);
+    tesseract_->getEnvironment()->addLink(std::move(link_seat), std::move(joint_seat));
   }
 }
 
@@ -414,7 +414,7 @@ bool CarSeatExample::run()
   joint_seat_1_robot.parent_to_joint_origin_transform =
       state->transforms["end_effector"].inverse() * state->transforms["seat_1"];
 
-  tesseract_->getEnvironment()->moveLink(joint_seat_1_robot);
+  tesseract_->getEnvironment()->moveLink(std::move(joint_seat_1_robot));
   tesseract_->getEnvironment()->addAllowedCollision("seat_1", "end_effector", "Adjacent");
   tesseract_->getEnvironment()->addAllowedCollision("seat_1", "cell_logo", "Never");
   tesseract_->getEnvironment()->addAllowedCollision("seat_1", "fence", "Never");
@@ -473,7 +473,7 @@ bool CarSeatExample::run()
   joint_seat_1_car.type = JointType::FIXED;
   joint_seat_1_car.parent_to_joint_origin_transform = state->transforms["car"].inverse() * state->transforms["seat_1"];
 
-  tesseract_->getEnvironment()->moveLink(joint_seat_1_car);
+  tesseract_->getEnvironment()->moveLink(std::move(joint_seat_1_car));
 
   if (rviz_)
   {
@@ -526,7 +526,7 @@ bool CarSeatExample::run()
   joint_seat_2_robot.parent_to_joint_origin_transform =
       state->transforms["end_effector"].inverse() * state->transforms["seat_2"];
 
-  tesseract_->getEnvironment()->moveLink(joint_seat_2_robot);
+  tesseract_->getEnvironment()->moveLink(std::move(joint_seat_2_robot));
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_up_right_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/glass_up_right_example.cpp
@@ -207,7 +207,7 @@ bool GlassUpRightExample::run()
   joint_sphere.child_link_name = link_sphere.getName();
   joint_sphere.type = JointType::FIXED;
 
-  tesseract_->getEnvironment()->addLink(link_sphere, joint_sphere);
+  tesseract_->getEnvironment()->addLink(std::move(link_sphere), std::move(joint_sphere));
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
@@ -132,7 +132,7 @@ bool PickAndPlaceExample::run()
   joint_box.parent_to_joint_origin_transform = Eigen::Isometry3d::Identity();
   joint_box.parent_to_joint_origin_transform.translation() += Eigen::Vector3d(box_x, box_y, (box_side / 2.0) + OFFSET);
 
-  tesseract_->getEnvironment()->addLink(link_box, joint_box);
+  tesseract_->getEnvironment()->addLink(std::move(link_box), std::move(joint_box));
 
   if (rviz_)
   {
@@ -332,7 +332,7 @@ bool PickAndPlaceExample::run()
   joint_box2.parent_to_joint_origin_transform = Eigen::Isometry3d::Identity();
   joint_box2.parent_to_joint_origin_transform.translation() += Eigen::Vector3d(0, 0, box_side / 2.0);
 
-  tesseract_->getEnvironment()->moveLink(joint_box2);
+  tesseract_->getEnvironment()->moveLink(std::move(joint_box2));
   tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), "iiwa_link_ee", "Never");
   tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), "iiwa_link_7", "Never");
   tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), "iiwa_link_6", "Never");

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/pick_and_place_example.cpp
@@ -113,7 +113,8 @@ bool PickAndPlaceExample::run()
   tesseract_->getEnvironment()->setState(joint_states);
 
   // Add simulated box to environment
-  Link link_box("box");
+  const std::string link_box_name = "box";
+  Link link_box(link_box_name);
 
   Visual::Ptr visual = std::make_shared<Visual>();
   visual->origin = Eigen::Isometry3d::Identity();
@@ -127,7 +128,7 @@ bool PickAndPlaceExample::run()
 
   Joint joint_box("joint_box");
   joint_box.parent_link_name = box_parent_link;
-  joint_box.child_link_name = link_box.getName();
+  joint_box.child_link_name = link_box_name;
   joint_box.type = JointType::FIXED;
   joint_box.parent_to_joint_origin_transform = Eigen::Isometry3d::Identity();
   joint_box.parent_to_joint_origin_transform.translation() += Eigen::Vector3d(box_x, box_y, (box_side / 2.0) + OFFSET);
@@ -327,16 +328,16 @@ bool PickAndPlaceExample::run()
   // Detach the simulated box from the world and attach to the end effector
   Joint joint_box2("joint_box2");
   joint_box2.parent_link_name = end_effector;
-  joint_box2.child_link_name = link_box.getName();
+  joint_box2.child_link_name = link_box_name;
   joint_box2.type = JointType::FIXED;
   joint_box2.parent_to_joint_origin_transform = Eigen::Isometry3d::Identity();
   joint_box2.parent_to_joint_origin_transform.translation() += Eigen::Vector3d(0, 0, box_side / 2.0);
 
   tesseract_->getEnvironment()->moveLink(std::move(joint_box2));
-  tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), "iiwa_link_ee", "Never");
-  tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), "iiwa_link_7", "Never");
-  tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), "iiwa_link_6", "Never");
-  tesseract_->getEnvironment()->addAllowedCollision(link_box.getName(), end_effector, "Adjacent");
+  tesseract_->getEnvironment()->addAllowedCollision(link_box_name, "iiwa_link_ee", "Never");
+  tesseract_->getEnvironment()->addAllowedCollision(link_box_name, "iiwa_link_7", "Never");
+  tesseract_->getEnvironment()->addAllowedCollision(link_box_name, "iiwa_link_6", "Never");
+  tesseract_->getEnvironment()->addAllowedCollision(link_box_name, end_effector, "Adjacent");
 
   if (rviz_)
   {

--- a/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
+++ b/tesseract_ros/tesseract_rosutils/include/tesseract_rosutils/utils.h
@@ -1287,13 +1287,13 @@ inline bool processMsg(tesseract_environment::Environment& env,
       {
         tesseract_scene_graph::Link link = tesseract_rosutils::fromMsg(command.add_link);
         tesseract_scene_graph::Joint joint = tesseract_rosutils::fromMsg(command.add_joint);
-        success &= env.addLink(link, joint);
+        success &= env.addLink(std::move(link), std::move(joint));
         break;
       }
       case tesseract_msgs::EnvironmentCommand::MOVE_LINK:
       {
         tesseract_scene_graph::Joint joint = tesseract_rosutils::fromMsg(command.move_link_joint);
-        success &= env.moveLink(joint);
+        success &= env.moveLink(std::move(joint));
         break;
       }
       case tesseract_msgs::EnvironmentCommand::MOVE_JOINT:

--- a/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
+++ b/tesseract_ros/tesseract_rviz/src/render_tools/environment_widget.cpp
@@ -281,7 +281,7 @@ bool EnvironmentWidget::applyEnvironmentCommands(const std::vector<tesseract_msg
         if (!visualization_->addLink(link) || !visualization_->addJoint(joint))
           return false;
 
-        if (!tesseract_->getEnvironment()->addLink(link, joint))
+        if (!tesseract_->getEnvironment()->addLink(std::move(link), std::move(joint)))
           return false;
 
         break;
@@ -297,7 +297,7 @@ bool EnvironmentWidget::applyEnvironmentCommands(const std::vector<tesseract_msg
         if (!visualization_->removeJoint(joints[0]->getName()) || !visualization_->addJoint(joint))
           return false;
 
-        if (!tesseract_->getEnvironment()->moveLink(joint))
+        if (!tesseract_->getEnvironment()->moveLink(std::move(joint)))
           return false;
 
         break;


### PR DESCRIPTION
This is a proposal to fix #142 

Basically introduce a new API to add a SceneGraph to another one, possibly with a prefix. This allows to `parseURDF` once, and add the same robot to the same scene multiple times with different names. Unfortunately, I needed to create prefixed copy operators for links and joints. As long as `name_` is a `const` member, I couldn't figure out a very good way to write them any other way.

The copying itself is done as breadth-first search over all links / joints, copying it into a prefixed version and adding to current Environment.

I also created a test that demonstrates usage and checks the following:
- Adding an empty scene graph always succeeds (nothing to do)
- Adding multiple times the same scene graph fails without prefix, succeeds with it