### PR TITLE
Fix missed disabling ompl planner hybirdization when config param optimize set to true

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/impl/ompl_motion_planner.hpp
@@ -87,6 +87,7 @@ tesseract_common::StatusCode OMPLMotionPlanner<PlannerType>::solve(PlannerRespon
       // and finishes at the end state.
       ompl::base::PlannerStatus localResult =
           parallel_plan_->solve(std::max(ompl::time::seconds(end - ompl::time::now()), 0.0),
+                                1,
                                 static_cast<unsigned>(config_->max_solutions),
                                 false);
       if (localResult)


### PR DESCRIPTION
The ompl solve call when optimize config param set to true had an issue so it was not disabling hybridization. 