### PR TITLE
Use BMPD solver for puzzle piece examples

### DIFF
--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_auxillary_axes_example.cpp
@@ -124,6 +124,7 @@ ProblemConstructionInfo PuzzlePieceAuxillaryAxesExample::cppMethod()
   pci.basic_info.manip = "manipulator_aux";
   pci.basic_info.start_fixed = false;
   pci.basic_info.use_time = false;
+  pci.basic_info.convex_solver = sco::ModelType::BPMPD;
 
   // Create Kinematic Object
   pci.kin = pci.getManipulator(pci.basic_info.manip);

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/puzzle_piece_example.cpp
@@ -124,6 +124,7 @@ ProblemConstructionInfo PuzzlePieceExample::cppMethod()
   pci.basic_info.manip = "manipulator";
   pci.basic_info.start_fixed = false;
   pci.basic_info.use_time = false;
+  pci.basic_info.convex_solver = sco::ModelType::BPMPD;
 
   pci.opt_info.max_iter = 200;
   pci.opt_info.min_approx_improve = 1e-3;


### PR DESCRIPTION
When the default solver was switched to OSQP the test takes longer to run causing the test to fail. I set the two puzzle piece test to use the BMPD solver which solve the issue.