### PR TITLE
Adjust Departure Generator

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/hybrid/descartes_trajopt_array_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/hybrid/descartes_trajopt_array_planner.h
@@ -1,6 +1,6 @@
 /**
  * @file descartes_trajopt_array_planner.h
- * @brief
+ * @brief a planner utilizing a descartes seed and trajopt optimization
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/hybrid/descartes_trajopt_array_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/hybrid/descartes_trajopt_array_planner.h
@@ -1,3 +1,28 @@
+/**
+ * @file descartes_trajopt_array_planner.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_MOTION_PLANNERS_DESCARTES_TRAJOPT_PLANNER_H
 #define TESSERACT_MOTION_PLANNERS_DESCARTES_TRAJOPT_PLANNER_H
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_tesseract_kinematics_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_tesseract_kinematics_tests.cpp
@@ -1,6 +1,6 @@
 /**
  * @file descartes_tesseract_kinematics.cpp
- * @brief
+ * @brief This contains unit test for the tesseract descartes kinematics
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_tesseract_kinematics_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_tesseract_kinematics_tests.cpp
@@ -1,3 +1,28 @@
+/**
+ * @file descartes_tesseract_kinematics.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_approach_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_approach_generator.h
@@ -1,6 +1,6 @@
 /**
  * @file axial_approach_generator.h
- * @brief
+ * @brief generator for an approach along the tool z direction
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_approach_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_approach_generator.h
@@ -1,3 +1,28 @@
+/**
+ * @file axial_approach_generator.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_AXIAL_APPROACH_GENERATOR_H
 #define TESSERACT_PLANNING_AXIAL_APPROACH_GENERATOR_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_departure_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_departure_generator.h
@@ -1,3 +1,28 @@
+/**
+ * @file axial_departure_generator.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_AXIAL_DEPARTURE_GENERATOR_H
 #define TESSERACT_PLANNING_AXIAL_DEPARTURE_GENERATOR_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_departure_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_departure_generator.h
@@ -1,6 +1,6 @@
 /**
  * @file axial_departure_generator.h
- * @brief
+ * @brief generator for a departure along the tool z direction
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_departure_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/axial_departure_generator.h
@@ -24,21 +24,43 @@ public:
            const ProcessDefinitionConfig& config) const override
   {
     assert(waypoints.back()->getType() == tesseract_motion_planners::WaypointType::CARTESIAN_WAYPOINT);
+    const tesseract_motion_planners::CartesianWaypoint::Ptr& cur_waypoint =
+        std::static_pointer_cast<tesseract_motion_planners::CartesianWaypoint>(waypoints.back());
+
+    Eigen::Isometry3d alt_departure = departure_;
+    // Ensure that negative x/y 'double back' and positive x/y move in the direction of the path
+    if (waypoints.size() >= 2)
+    {
+      assert(waypoints[waypoints.end() - 2].getType() == tesseract_motion_planners::WaypointType::CARTESIAN_WAYPOINT);
+      const tesseract_motion_planners::CartesianWaypoint::Ptr& prev_waypoint =
+          std::static_pointer_cast<tesseract_motion_planners::CartesianWaypoint>(*(waypoints.end() - 2));
+      Eigen::Isometry3d penultimate_in_final = cur_waypoint->getTransform().inverse() * prev_waypoint->getTransform();
+
+      // If the final waypoint x-axis is pointing 'towards' the previous waypoint,
+      // reverse the requested x-translation.  Likewise for y.
+
+      if (penultimate_in_final.translation().x() > 0)
+      {
+        alt_departure.translation().x() *= -1;
+      }
+      if (penultimate_in_final.translation().y() > 0)
+      {
+        alt_departure.translation().y() *= -1;
+      }
+    }
 
     std::vector<tesseract_motion_planners::Waypoint::Ptr> departure;
     departure.reserve(static_cast<size_t>(step_count_) + 1);
 
-    const tesseract_motion_planners::CartesianWaypoint::Ptr& cur_waypoint =
-        std::static_pointer_cast<tesseract_motion_planners::CartesianWaypoint>(waypoints.back());
     for (int i = 0; i < step_count_; i++)
     {
-      Eigen::Isometry3d scaled = departure_;
+      Eigen::Isometry3d scaled = alt_departure;
 
       // Interpolate the transform
       double progress = static_cast<double>(i + 1) / static_cast<double>(step_count_);
-      scaled.translation() = progress * departure_.translation();
+      scaled.translation() = progress * alt_departure.translation();
       scaled.linear() = Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0)
-                            .slerp(progress, Eigen::Quaterniond(departure_.rotation()))
+                            .slerp(progress, Eigen::Quaterniond(alt_departure.rotation()))
                             .toRotationMatrix();
 
       tesseract_motion_planners::CartesianWaypoint::Ptr new_waypoint =

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/extension_departure_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/extension_departure_generator.h
@@ -1,3 +1,29 @@
+/**
+ * @file extension_departure_generator.cpp
+ * @brief Tesseract process departure implementation
+ *
+ * @author David Merz, Jr.
+ * @date February 17, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_EXTENSION_DEPARTURE_GENERATOR_H
 #define TESSERACT_PLANNING_EXTENSION_DEPARTURE_GENERATOR_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/extension_departure_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/extension_departure_generator.h
@@ -6,7 +6,6 @@
 
 namespace tesseract_process_planners
 {
-
 /**
  * @brief The ExtensionDepartureGenerator class
  * For a series of waypoints that progresses along either the positive or

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/extension_departure_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/extension_departure_generator.h
@@ -1,0 +1,109 @@
+#ifndef TESSERACT_PLANNING_EXTENSION_DEPARTURE_GENERATOR_H
+#define TESSERACT_PLANNING_EXTENSION_DEPARTURE_GENERATOR_H
+
+#include <tesseract_process_planners/process_definition.h>
+#include <Eigen/Core>
+
+namespace tesseract_process_planners
+{
+
+/**
+ * @brief The ExtensionDepartureGenerator class
+ * For a series of waypoints that progresses along either the positive or
+ * negative x-axis of the waypoints, this class generates an extension at
+ * the end of that path.  A positive X-direction in the supplied vector
+ * will automatically be transformed to align with the direction the path
+ * was traveling, reducing complexity of calling code for alternating paths.
+ */
+class ExtensionDepartureGenerator : public ProcessStepGenerator
+{
+public:
+  /**
+   * @brief ExtensionDepartureGenerator - constructor. Supply a vector for
+   * the departure to follow along.
+   * @param departure - the vector along which the departure should be generated
+   * @param step_count - how many waypoints should be generated
+   */
+  ExtensionDepartureGenerator(const Eigen::Vector3d& departure, int step_count)
+    : departure_(Eigen::Isometry3d::Identity()), step_count_(step_count)
+  {
+    departure_.translation() = departure;
+  }
+  /**
+   * @brief ExtensionDepartureGenerator - alternate constructor to ease use with
+   * ProcessPlannerConfig, which uses Isometry3d for departure_direction.  Uses
+   * only the translation portion of a provided isometry.
+   * @param departure - the vector along which the departure should be generated
+   * @param step_count - how many waypoints should be generated
+   */
+  ExtensionDepartureGenerator(const Eigen::Isometry3d& departure, int step_count)
+    : departure_(Eigen::Isometry3d::Identity()), step_count_(step_count)
+  {
+    departure_.translation() = departure.translation();
+  }
+  ~ExtensionDepartureGenerator() override = default;
+  ExtensionDepartureGenerator(const ExtensionDepartureGenerator&) = default;
+  ExtensionDepartureGenerator& operator=(const ExtensionDepartureGenerator&) = default;
+  ExtensionDepartureGenerator(ExtensionDepartureGenerator&&) = default;
+  ExtensionDepartureGenerator& operator=(ExtensionDepartureGenerator&&) = default;
+
+  std::vector<tesseract_motion_planners::Waypoint::Ptr>
+  generate(const std::vector<tesseract_motion_planners::Waypoint::Ptr>& waypoints,
+           const ProcessDefinitionConfig& config) const override
+  {
+    assert(waypoints.back()->getType() == tesseract_motion_planners::WaypointType::CARTESIAN_WAYPOINT);
+    const tesseract_motion_planners::CartesianWaypoint::Ptr& cur_waypoint =
+        std::static_pointer_cast<tesseract_motion_planners::CartesianWaypoint>(waypoints.back());
+
+    Eigen::Isometry3d alt_departure = departure_;
+    // Ensure that negative x/y 'double back' and positive x/y move in the direction of the path
+    if (waypoints.size() >= 2)
+    {
+      assert(waypoints[waypoints.end() - 2].getType() == tesseract_motion_planners::WaypointType::CARTESIAN_WAYPOINT);
+      const tesseract_motion_planners::CartesianWaypoint::Ptr& prev_waypoint =
+          std::static_pointer_cast<tesseract_motion_planners::CartesianWaypoint>(*(waypoints.end() - 2));
+      Eigen::Isometry3d penultimate_in_final = cur_waypoint->getTransform().inverse() * prev_waypoint->getTransform();
+
+      // If the final waypoint x-axis is pointing 'towards' the previous waypoint,
+      // reverse the requested x-translation and y translation.  This assumes that
+      // the x-axis is the intended direction of travel.
+      if (penultimate_in_final.translation().x() > 0)
+      {
+        alt_departure.translation().x() *= -1;
+        alt_departure.translation().y() *= -1;
+      }
+    }
+
+    std::vector<tesseract_motion_planners::Waypoint::Ptr> departure;
+    departure.reserve(static_cast<size_t>(step_count_) + 1);
+
+    for (int i = 0; i < step_count_; i++)
+    {
+      Eigen::Isometry3d scaled = alt_departure;
+
+      // Interpolate the transform
+      double progress = static_cast<double>(i + 1) / static_cast<double>(step_count_);
+      scaled.translation() = progress * alt_departure.translation();
+      scaled.linear() = Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0)
+                            .slerp(progress, Eigen::Quaterniond(alt_departure.rotation()))
+                            .toRotationMatrix();
+
+      tesseract_motion_planners::CartesianWaypoint::Ptr new_waypoint =
+          std::make_shared<tesseract_motion_planners::CartesianWaypoint>(
+              config.world_offset_direction * cur_waypoint->getTransform() * config.local_offset_direction * scaled,
+              cur_waypoint->getParentLinkName());
+      new_waypoint->setCoefficients(cur_waypoint->getCoefficients());
+      new_waypoint->setIsCritical(cur_waypoint->isCritical());
+      departure.push_back(new_waypoint);
+    }
+    return departure;
+  }
+
+private:
+  Eigen::Isometry3d departure_;
+  int step_count_;
+};
+
+}  // namespace tesseract_process_planners
+
+#endif  // TESSERACT_PLANNING_EXTENSION_DEPARTURE_GENERATOR_H

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/linear_transition_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/linear_transition_generator.h
@@ -1,3 +1,28 @@
+/**
+ * @file linear_transition_generator.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_LINEAR_TRANSITION_GENERATOR_H
 #define TESSERACT_PLANNING_LINEAR_TRANSITION_GENERATOR_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/linear_transition_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/linear_transition_generator.h
@@ -1,6 +1,6 @@
 /**
  * @file linear_transition_generator.h
- * @brief
+ * @brief generator for a linear transition
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_process_generator.h
@@ -1,6 +1,7 @@
 /**
  * @file passthrough_process_generator.h
- * @brief
+ * @brief generator for processing strokes that pass through each of a
+ * list of supplied points
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_process_generator.h
@@ -1,3 +1,28 @@
+/**
+ * @file passthrough_process_generator.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_PASSTHROUGH_PROCESS_GENERATOR_H
 #define TESSERACT_PLANNING_PASSTHROUGH_PROCESS_GENERATOR_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_transition_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_transition_generator.h
@@ -1,6 +1,6 @@
 /**
  * @file passthrough_transition_generator.h
- * @brief
+ * @brief generator for transitions that pass through a list of supplied points
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_transition_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/generators/passthrough_transition_generator.h
@@ -1,3 +1,28 @@
+/**
+ * @file passthrough_transition_generator.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_PASSTHROUGH_TRANSITION_GENERATOR_H
 #define TESSERACT_PLANNING_PASSTHROUGH_TRANSITION_GENERATOR_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_definition.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_definition.h
@@ -1,3 +1,28 @@
+/**
+ * @file process_definition.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_PROCESS_DEFINITION_H
 #define TESSERACT_PLANNING_PROCESS_DEFINITION_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_definition.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_definition.h
@@ -1,6 +1,6 @@
 /**
  * @file process_definition.h
- * @brief
+ * @brief describes the basic definition of a process, as expected by the process planners
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_planner.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_planner.h
@@ -1,6 +1,6 @@
 /**
  * @file process_planner.h
- * @brief
+ * @brief defines the basic structure of a process planner
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_planner.h
+++ b/tesseract/tesseract_planning/tesseract_process_planners/include/tesseract_process_planners/process_planner.h
@@ -1,3 +1,28 @@
+/**
+ * @file process_planner.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef TESSERACT_PLANNING_PROCESS_PLANNER_H
 #define TESSERACT_PLANNING_PROCESS_PLANNER_H
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/src/tesseract_process_planners/process_definition.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_planners/src/tesseract_process_planners/process_definition.cpp
@@ -1,6 +1,7 @@
 /**
  * @file process_definition.cpp
- * @brief
+ * @brief defines the basic structure of a process, as expected by the
+ * process planners
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/src/tesseract_process_planners/process_definition.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_planners/src/tesseract_process_planners/process_definition.cpp
@@ -1,3 +1,27 @@
+/**
+ * @file process_definition.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <tesseract_process_planners/process_definition.h>
 

--- a/tesseract/tesseract_planning/tesseract_process_planners/test/custom_iterator_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_planners/test/custom_iterator_unit.cpp
@@ -1,3 +1,28 @@
+/**
+ * @file custom_iterator_unit.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>

--- a/tesseract/tesseract_planning/tesseract_process_planners/test/custom_iterator_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_planners/test/custom_iterator_unit.cpp
@@ -1,6 +1,6 @@
 /**
  * @file custom_iterator_unit.cpp
- * @brief
+ * @brief tests for a custom iterator over the process definitions
  *
  * @author Levi Armstrong
  * @version TODO

--- a/tesseract/tesseract_planning/tesseract_process_planners/test/tesseract_process_planners_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_planners/test/tesseract_process_planners_unit.cpp
@@ -1,3 +1,28 @@
+/**
+ * @file tesseract_process_planners_unit.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>

--- a/tesseract/tesseract_planning/tesseract_process_planners/test/tesseract_process_planners_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_planners/test/tesseract_process_planners_unit.cpp
@@ -1,6 +1,7 @@
 /**
  * @file tesseract_process_planners_unit.cpp
- * @brief
+ * @brief tests for the process planner generators. Several of the
+ * generators are instantiated.
  *
  * @author Levi Armstrong
  * @version TODO


### PR DESCRIPTION
If a path has all poses in all raster strokes with x and y pointing in the same direction (not flipping back and forth each stroke), a departure with x/y components will 'backtrack' on some strokes and continue 'forward' on others.  This commit changes that so that 'positive' x/y values always move away from the penultimate pose in a stroke, and 'negative' x/y values always move back towards the penultimate pose in a stroke.

If the general method used is agreeable, I could add a second commit doing the same for the axial approach generator.