### PR TITLE
Add tesseract_scene_graph_example

### DIFF
--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/CMakeLists.txt
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tesseract_ros_examples)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   roslib
+  tesseract_monitoring
   tesseract_rosutils
   octomap_ros
   pcl_conversions
@@ -152,6 +153,26 @@ target_include_directories(${PROJECT_NAME}_pick_and_place_example_node PRIVATE
 target_include_directories(${PROJECT_NAME}_pick_and_place_example_node SYSTEM PRIVATE
     ${catkin_INCLUDE_DIRS})
 
+add_library(${PROJECT_NAME}_scene_graph_example src/scene_graph_example.cpp)
+target_link_libraries(${PROJECT_NAME}_scene_graph_example tesseract::tesseract tesseract::tesseract_motion_planners_trajopt jsoncpp_lib ${catkin_LIBRARIES})
+tesseract_target_compile_options(${PROJECT_NAME}_scene_graph_example PUBLIC)
+tesseract_clang_tidy(${PROJECT_NAME}_scene_graph_example)
+target_include_directories(${PROJECT_NAME}_scene_graph_example PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME}_scene_graph_example SYSTEM PUBLIC
+    ${catkin_INCLUDE_DIRS})
+
+add_executable(${PROJECT_NAME}_scene_graph_example_node src/scene_graph_example_node.cpp)
+target_link_libraries(${PROJECT_NAME}_scene_graph_example_node ${PROJECT_NAME}_scene_graph_example ${catkin_LIBRARIES})
+tesseract_target_compile_options(${PROJECT_NAME}_scene_graph_example_node PRIVATE)
+tesseract_clang_tidy(${PROJECT_NAME}_scene_graph_example_node)
+target_include_directories(${PROJECT_NAME}_scene_graph_example_node PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME}_scene_graph_example_node SYSTEM PRIVATE
+    ${catkin_INCLUDE_DIRS})
+
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}
   DESTINATION include
@@ -174,6 +195,8 @@ install(
     ${PROJECT_NAME}_pick_and_place_example_node
     ${PROJECT_NAME}_puzzle_piece_auxillary_axes_example
     ${PROJECT_NAME}_puzzle_piece_auxillary_axes_example_node
+    ${PROJECT_NAME}_scene_graph_example
+    ${PROJECT_NAME}_scene_graph_example_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -252,6 +275,16 @@ if(CATKIN_ENABLE_TESTING)
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:include>")
     target_include_directories(${PROJECT_NAME}_pick_and_place_example_unit SYSTEM PRIVATE
+        ${catkin_INCLUDE_DIRS})
+
+    add_rostest_gtest(${PROJECT_NAME}_scene_graph_example_unit test/scene_graph_example_unit.test test/scene_graph_example_unit.cpp)
+    target_link_libraries(${PROJECT_NAME}_scene_graph_example_unit GTest::GTest GTest::Main ${PROJECT_NAME}_scene_graph_example ${catkin_LIBRARIES})
+    tesseract_target_compile_options(${PROJECT_NAME}_scene_graph_example_unit PRIVATE)
+    tesseract_clang_tidy(${PROJECT_NAME}_scene_graph_example_unit)
+    target_include_directories(${PROJECT_NAME}_scene_graph_example_unit PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include>")
+    target_include_directories(${PROJECT_NAME}_scene_graph_example_unit SYSTEM PRIVATE
         ${catkin_INCLUDE_DIRS})
 endif()
 

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/examples.rviz
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/examples.rviz
@@ -5,9 +5,10 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /Status1
+        - /TesseractTrajectory1/Environment1
+        - /TesseractTrajectory1/Joint State Monitor1
       Splitter Ratio: 0.5077950954437256
-    Tree Height: 755
+    Tree Height: 728
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -61,11 +62,11 @@ Visualization Manager:
         Show Collision: false
         Show Highlights: true
         Show Visual: true
-        Tesseract State Topic: ""
+        Tesseract State Topic: /tesseract_ros_examples_scene_graph_example_node/environment_monitor
         URDF Description: robot_description
         Value: ""
       Joint State Monitor:
-        Topic: joint_states
+        Topic: /joint_states
         Value: ""
       Links:
         All Links Enabled: true
@@ -82,6 +83,77 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        ee_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        grinder_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        grinder_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        iiwa_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        iiwa_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         link_1:
           Alpha: 1
           Show Axes: false
@@ -112,17 +184,33 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        link_7:
+        link_grinder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_grinder_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        part:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        octomap_attached:
+        table:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
         tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tool1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        world:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -142,6 +230,169 @@ Visualization Manager:
       Namespaces:
         {}
       Queue Size: 100
+      Value: true
+    - Class: tesseract_rviz/TesseractState
+      Enabled: true
+      Environment:
+        Alpha: 1
+        Interface Namespace: env_widget_1/
+        Show All Links: true
+        Show Collision: false
+        Show Highlights: true
+        Show Visual: true
+        Tesseract State Topic: /monitored_environment
+        URDF Description: robot_description
+        Value: ""
+      Joint State Monitor:
+        Topic: /joint_states
+        Value: ""
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        ee_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        grinder_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        grinder_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        iiwa_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        iiwa_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_link_7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        iiwa_tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_grinder:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        link_grinder_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        part:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        table:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        tool0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tool1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: TesseractState
       Value: true
   Enabled: true
   Global Options:
@@ -186,18 +437,18 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.3553984463214874
+      Pitch: 0.39539840817451477
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 5.793576717376709
+      Yaw: 5.648575782775879
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1052
+  Height: 1025
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001c30000037efc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000037e000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000120020002d00200053006c00690064006500720000000000ffffffff0000000000000000fb00000038005400650073007300650072006100630074005400720061006a006500630074006f007200790020002d00200053006c00690064006500720000000000ffffffff0000004100ffffff00000001000001000000037efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d0000037e000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004b10000037e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001c300000363fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000120020002d00200053006c00690064006500720000000000ffffffff0000000000000000fb00000038005400650073007300650072006100630074005400720061006a006500630074006f007200790020002d00200053006c00690064006500720000000000ffffffff0000004100ffffff000000010000010000000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d006501000000000000045000000000000000000000046e0000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   TesseractTrajectory - Slider:
@@ -208,6 +459,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1920
-  X: 0
-  Y: 0
+  Width: 1853
+  X: 67
+  Y: 27

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/scene_graph_example.srdf
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/config/scene_graph_example.srdf
@@ -1,0 +1,142 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="irb2400_iiwa_cowork">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="iiwa_manipulator">
+        <chain base_link="iiwa_base" tip_link="iiwa_tool0" />
+    </group>
+    <group name="abb_manipulator">
+        <chain base_link="base_link" tip_link="tool0" />
+    </group>
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base_link" link2="ee_base" reason="Never" />
+    <disable_collisions link1="base_link" link2="grinder_base" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_base_link" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_1" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_2" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_3" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_4" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_5" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_6" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_link_7" reason="Never" />
+    <disable_collisions link1="base_link" link2="iiwa_mount" reason="Never" />
+    <disable_collisions link1="base_link" link2="link_1" reason="Adjacent" />
+    <disable_collisions link1="base_link" link2="link_2" reason="Never" />
+    <disable_collisions link1="base_link" link2="link_3" reason="Never" />
+    <disable_collisions link1="base_link" link2="part" reason="Never" />
+    <disable_collisions link1="base_link" link2="table" reason="Adjacent" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_1" reason="Never" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_2" reason="Never" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_3" reason="Never" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_4" reason="Never" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_5" reason="Never" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_6" reason="Never" />
+    <disable_collisions link1="ee_base" link2="iiwa_link_7" reason="Adjacent" />
+    <disable_collisions link1="ee_base" link2="link_1" reason="Never" />
+    <disable_collisions link1="ee_base" link2="part" reason="Adjacent" />
+    <disable_collisions link1="grinder_base" link2="iiwa_base_link" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="iiwa_link_1" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="iiwa_link_2" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="iiwa_link_3" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="iiwa_link_4" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="iiwa_mount" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="link_1" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="link_2" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="link_3" reason="Never" />
+    <disable_collisions link1="grinder_base" link2="table" reason="Adjacent" />
+    <disable_collisions link1="iiwa_base_link" link2="iiwa_link_1" reason="Adjacent" />
+    <disable_collisions link1="iiwa_base_link" link2="iiwa_link_2" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="iiwa_link_3" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="iiwa_link_4" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="iiwa_mount" reason="Adjacent" />
+    <disable_collisions link1="iiwa_base_link" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="link_3" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="link_5" reason="Never" />
+    <disable_collisions link1="iiwa_base_link" link2="table" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_link_2" reason="Adjacent" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_link_3" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_link_4" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_link_5" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_link_6" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_link_7" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="iiwa_mount" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="link_3" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="link_4" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="link_5" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="link_6" reason="Never" />
+    <disable_collisions link1="iiwa_link_1" link2="table" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="iiwa_link_3" reason="Adjacent" />
+    <disable_collisions link1="iiwa_link_2" link2="iiwa_link_4" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="iiwa_link_5" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="iiwa_link_6" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="iiwa_link_7" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="iiwa_mount" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="link_3" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="part" reason="Never" />
+    <disable_collisions link1="iiwa_link_2" link2="table" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="iiwa_link_4" reason="Adjacent" />
+    <disable_collisions link1="iiwa_link_3" link2="iiwa_link_5" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="iiwa_link_6" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="iiwa_link_7" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="iiwa_mount" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="link_3" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="part" reason="Never" />
+    <disable_collisions link1="iiwa_link_3" link2="table" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="iiwa_link_5" reason="Adjacent" />
+    <disable_collisions link1="iiwa_link_4" link2="iiwa_link_6" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="iiwa_link_7" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="iiwa_mount" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="link_3" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="part" reason="Never" />
+    <disable_collisions link1="iiwa_link_4" link2="table" reason="Never" />
+    <disable_collisions link1="iiwa_link_5" link2="iiwa_link_6" reason="Adjacent" />
+    <disable_collisions link1="iiwa_link_5" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_5" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_link_5" link2="part" reason="Never" />
+    <disable_collisions link1="iiwa_link_5" link2="table" reason="Never" />
+    <disable_collisions link1="iiwa_link_6" link2="iiwa_link_7" reason="Adjacent" />
+    <disable_collisions link1="iiwa_link_6" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_6" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_link_6" link2="part" reason="Never" />
+    <disable_collisions link1="iiwa_link_7" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_link_7" link2="part" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="link_1" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="link_2" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="link_3" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="link_4" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="link_5" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="link_6" reason="Never" />
+    <disable_collisions link1="iiwa_mount" link2="table" reason="Adjacent" />
+    <disable_collisions link1="link_1" link2="link_2" reason="Adjacent" />
+    <disable_collisions link1="link_1" link2="link_3" reason="Never" />
+    <disable_collisions link1="link_1" link2="part" reason="Never" />
+    <disable_collisions link1="link_1" link2="table" reason="Never" />
+    <disable_collisions link1="link_2" link2="link_3" reason="Adjacent" />
+    <disable_collisions link1="link_2" link2="link_4" reason="Never" />
+    <disable_collisions link1="link_2" link2="link_5" reason="Never" />
+    <disable_collisions link1="link_2" link2="link_6" reason="Never" />
+    <disable_collisions link1="link_2" link2="table" reason="Never" />
+    <disable_collisions link1="link_3" link2="link_4" reason="Adjacent" />
+    <disable_collisions link1="link_3" link2="link_5" reason="Never" />
+    <disable_collisions link1="link_3" link2="link_6" reason="Never" />
+    <disable_collisions link1="link_3" link2="table" reason="Never" />
+    <disable_collisions link1="link_4" link2="link_5" reason="Adjacent" />
+    <disable_collisions link1="link_4" link2="link_6" reason="Default" />
+    <disable_collisions link1="link_5" link2="link_6" reason="Adjacent" />
+</robot>

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/include/tesseract_ros_examples/scene_graph_example.h
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/include/tesseract_ros_examples/scene_graph_example.h
@@ -1,0 +1,63 @@
+/**
+ * @file scene_graph_example.h
+ * @brief This example initializes 2 robots from a URDF. It then reattaches one of the robots to the end effector of the
+ * other robot
+ *
+ * @author Matthew Powelson
+ * @date Feb 17, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_ROS_EXAMPLES_SCENE_GRAPH_EXAMPLE_H
+#define TESSERACT_ROS_EXAMPLES_SCENE_GRAPH_EXAMPLE_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ros/ros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_monitoring/environment_monitor.h>
+#include <tesseract_ros_examples/example.h>
+
+namespace tesseract_ros_examples
+{
+/**
+ * @brief Basic example leveraging trajopt and tesseract for cartesian planning
+ */
+class SceneGraphExample : public Example
+{
+public:
+  SceneGraphExample(const ros::NodeHandle& nh, bool plotting, bool rviz) : Example(plotting, rviz), nh_(nh) {}
+  ~SceneGraphExample() override = default;
+  SceneGraphExample(const SceneGraphExample&) = default;
+  SceneGraphExample& operator=(const SceneGraphExample&) = default;
+  SceneGraphExample(SceneGraphExample&&) = default;
+  SceneGraphExample& operator=(SceneGraphExample&&) = default;
+
+  bool run() override;
+
+private:
+  ros::NodeHandle nh_;
+
+  std::shared_ptr<tesseract_monitoring::EnvironmentMonitor> environment_monitor_;
+};
+
+}  // namespace tesseract_ros_examples
+
+#endif  // TESSERACT_ROS_EXAMPLES_BASIC_CARTESIAN_EXAMPLE_H

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/launch/scene_graph_example.launch
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/launch/scene_graph_example.launch
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg name="robot_description" default="robot_description"/>
+  <arg name="trajopt_description" default="trajopt_description"/>
+  <arg name="plotting" default="true"/>
+  <arg name="rviz" default="true"/>
+  <arg name="testing" default="false"/>
+
+  <!-- Load universal robot description format (URDF) -->
+  <param name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find tesseract_ros_examples)/urdf/irb2400_iiwa_cowork.xacro'" />
+
+  <!-- The semantic description that corresponds to the URDF -->
+  <param name="$(arg robot_description)_semantic" textfile="$(find tesseract_ros_examples)/config/scene_graph_example.srdf" />
+
+  <group unless="$(arg testing)">
+    <node pkg="tesseract_ros_examples" type="tesseract_ros_examples_scene_graph_example_node" name="tesseract_ros_examples_scene_graph_example_node">
+      <param name="plotting" type="bool" value="$(arg plotting)"/>
+      <param name="rviz" type="bool" value="$(arg rviz)"/>
+    </node>
+
+    <!-- Launch visualization -->
+    <node if="$(arg rviz)" pkg="rviz" type="rviz" name="tesseract_ros_examples_scene_graph_example_rviz"
+         args="-d $(find tesseract_ros_examples)/config/examples.rviz" />
+  </group>
+</launch>

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/package.xml
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/package.xml
@@ -16,6 +16,7 @@
   <depend>roslib</depend>
   <depend>trajopt</depend>
   <depend>tesseract_collision</depend>
+  <depend>tesseract_monitoring</depend>
   <depend>tesseract_motion_planners</depend>
   <depend>tesseract_kinematics</depend>
   <depend>tesseract_environment</depend>

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/scene_graph_example.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/scene_graph_example.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file scene_graph_example.cpp
+ * @brief scene_graph_example implementation
+ *
+ * @author Matthew Powelson
+ * @date Feb 17, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ros/ros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_ros_examples/scene_graph_example.h>
+#include <tesseract_environment/core/utils.h>
+
+using namespace tesseract;
+using namespace tesseract_environment;
+using namespace tesseract_scene_graph;
+
+const std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
+const std::string ROBOT_SEMANTIC_PARAM =
+    "robot_description_semantic"; /**< Default ROS parameter for robot description */
+const std::string ENVIRONMENT_TOPIC = "/monitored_environment";
+const std::string JOINT_STATE_TOPIC = "/joint_states";
+
+namespace tesseract_ros_examples
+{
+bool SceneGraphExample::run()
+{
+  // Initial setup
+  std::string urdf_xml_string, srdf_xml_string;
+  nh_.getParam(ROBOT_DESCRIPTION_PARAM, urdf_xml_string);
+  nh_.getParam(ROBOT_SEMANTIC_PARAM, srdf_xml_string);
+
+  ResourceLocator::Ptr locator = std::make_shared<tesseract_rosutils::ROSResourceLocator>();
+  if (!tesseract_->init(urdf_xml_string, srdf_xml_string, locator))
+    return false;
+  environment_monitor_ = std::make_shared<tesseract_monitoring::EnvironmentMonitor>(tesseract_, "environment_monitor");
+  environment_monitor_->startStateMonitor(JOINT_STATE_TOPIC);
+  environment_monitor_->startPublishingEnvironment(tesseract_monitoring::EnvironmentMonitor::UPDATE_ENVIRONMENT,
+                                                   ENVIRONMENT_TOPIC);
+
+  environment_monitor_->getTesseract()->getEnvironment()->getSceneGraph()->saveDOT("scene_graph_example.dot");
+
+  if (plotting_)
+  {
+    ROS_ERROR("Press enter to continue");
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    ROS_INFO("Reconfiguring using moveJoint");
+  }
+  // Attach the iiwa to the end of the ABB using moveJoint. Notice that the joint transform stays the same. Only the
+  // parent changes.
+  environment_monitor_->getTesseract()->getEnvironment()->moveJoint("to_iiwa_mount", "tool0");
+
+  // Save the scene graph to a file and publish the change
+  environment_monitor_->getTesseract()->getEnvironment()->getSceneGraph()->saveDOT("scene_graph_example_moveJoint.dot");
+  environment_monitor_->triggerEnvironmentUpdateEvent(environment_monitor_->UPDATE_ENVIRONMENT);
+
+  if (plotting_)
+  {
+    ROS_ERROR("Press enter to continue");
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    ROS_INFO("Reconfiguring using moveLink");
+  }
+
+  // Attach the iiwa to the end of the ABB using moveLink. The link to be moved is inferred to be the given Joint's
+  // child
+  tesseract_scene_graph::Joint new_joint("to_iiwa_mount");
+  new_joint.parent_link_name = "tool0";
+  new_joint.child_link_name = "iiwa_mount";
+  new_joint.type = tesseract_scene_graph::JointType::FIXED;
+  new_joint.parent_to_joint_origin_transform = Eigen::Isometry3d::Identity();
+  new_joint.parent_to_joint_origin_transform.rotate(Eigen::AngleAxisd(-M_PI / 2, Eigen::Vector3d(0, 1, 0)));
+  new_joint.parent_to_joint_origin_transform.translate(Eigen::Vector3d(0.15, 0.0, 0.0));
+  environment_monitor_->getTesseract()->getEnvironment()->moveLink(std::move(new_joint));
+
+  // Save the scene graph to a file and publish the change
+  environment_monitor_->getTesseract()->getEnvironment()->getSceneGraph()->saveDOT("scene_graph_example_moveLink.dot");
+  environment_monitor_->triggerEnvironmentUpdateEvent(environment_monitor_->UPDATE_ENVIRONMENT);
+
+  if (plotting_)
+  {
+    ROS_ERROR("Press enter to continue");
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    ROS_INFO("Open .dot files  in ~/.ros to see scene graph");
+  }
+  return true;
+}
+}  // namespace tesseract_ros_examples

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/scene_graph_example_node.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/src/scene_graph_example_node.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file scene_graph_example_node.cpp
+ * @brief Demonstrates manipulating the scene graph with a robot picking up another robot
+ *
+ * @author Matthew Powelson
+ * @date Feb 17, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_ros_examples/scene_graph_example.h>
+
+using namespace tesseract_ros_examples;
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "scene_graph_example_node");
+  ros::NodeHandle pnh("~");
+  ros::NodeHandle nh;
+
+  bool step_through = true;
+  bool rviz = true;
+
+  // Get ROS Parameters
+  pnh.param("plotting", step_through, step_through);
+  pnh.param("rviz", rviz, rviz);
+
+  SceneGraphExample example(nh, step_through, rviz);
+  example.run();
+}

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/test/scene_graph_example_unit.cpp
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/test/scene_graph_example_unit.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file scene_graph_example_unit.cpp
+ * @brief Runs the scene_graph_example
+ *
+ * @author Matthew Powelson
+ * @date Feb 17, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ros/ros.h>
+#include <gtest/gtest.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_ros_examples/scene_graph_example.h>
+
+using namespace tesseract_ros_examples;
+
+TEST(TesseractROSExamples, SceneGraphExampleUnit)  // NOLINT
+{
+  ros::NodeHandle nh;
+  SceneGraphExample example(nh, false, false);
+  EXPECT_TRUE(example.run());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "scene_graph_example_unit");
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/test/scene_graph_example_unit.test
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/test/scene_graph_example_unit.test
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="plotting" default="false"/>
+  <arg name="rviz" default="false"/>
+  <arg name="testing" default="true"/>
+
+  <include file="$(find tesseract_ros_examples)/launch/scene_graph_example.launch" pass_all_args="true"/>
+  <test pkg="tesseract_ros_examples" type="tesseract_ros_examples_scene_graph_example_unit" test-name="scene_graph_example_unit" time-limit="120.0"/>
+</launch>

--- a/tesseract_ros/tesseract_examples/tesseract_ros_examples/urdf/irb2400_iiwa_cowork.xacro
+++ b/tesseract_ros/tesseract_examples/tesseract_ros_examples/urdf/irb2400_iiwa_cowork.xacro
@@ -1,0 +1,96 @@
+<?xml version="1.0" ?>
+<robot name="irb2400_iiwa_cowork" xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include filename="$(find tesseract_ros_examples)/urdf/lbr_iiwa_14_r820_macro.xacro" />
+  <xacro:include filename="$(find tesseract_support)/urdf/abb_irb2400.urdf" />
+
+  <!-- This contains the macro "ses_part_macro" that places the clip wrt the tool tip -->
+  <xacro:include filename="$(find tesseract_ros_examples)/urdf/puzzle_mount.xacro" />
+  <xacro:include filename="$(find tesseract_ros_examples)/urdf/grinder.xacro" />
+
+  <link name="world"/>
+
+  <link name="table">
+    <visual>
+      <geometry>
+        <box size="6.0 2.0 0.05"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="1.0 1.0 0.05"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="iiwa_mount">
+    <visual>
+      <geometry>
+        <box size="0.3 0.3 0.3"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.3 0.3 0.3"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <xacro:kuka_lbr_iiwa_14_r820 prefix="iiwa_"/>
+  <xacro:grinder prefix=""/>
+  <xacro:puzzle_piece prefix=""/>
+
+  <joint name="world_to_abb" type="fixed">
+    <parent link="table"/>
+    <child link="base_link"/>
+    <origin xyz="-1.0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <joint name="world_to_table" type="fixed">
+    <parent link="world"/>
+    <child link="table"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <link name="link_grinder"/>
+  <joint name="table_to_grinder" type="fixed">
+    <parent link="table"/>
+    <child link="link_grinder"/>
+    <origin xyz="0.35 -0.35 0.125" rpy="0 0 0"/>
+  </joint>
+
+  <link name="link_grinder_1"/>
+  <joint name="joint_aux1" type="revolute">
+    <parent link="link_grinder"/>
+    <child link="link_grinder_1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1" />
+    <limit lower="-3.14159" upper="3.14159" effort="0" velocity="1.0" />
+  </joint>
+
+  <joint name="joint_aux2" type="revolute">
+    <parent link="link_grinder_1"/>
+    <child link="grinder_base"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0" />
+    <limit lower="-0.785398" upper="0.785398" effort="0" velocity="1.0" />
+  </joint>
+
+  <joint name="to_iiwa_mount" type="fixed">
+    <parent link="table"/>
+    <child link="iiwa_mount"/>
+    <origin xyz="0.75 0 0.175" rpy="0 0 0"/>
+  </joint>
+
+  <joint name="iiwa_mount_to_iiwa_baselink" type="fixed">
+    <parent link="iiwa_mount"/>
+    <child link="iiwa_base_link"/>
+    <origin xyz="0 0 0.15" rpy="0 0 0"/>
+  </joint>
+
+  <joint name="robot_tool" type="fixed">
+    <parent link="iiwa_tool0"/>
+    <child link="ee_mount"/>
+    <origin xyz="0 0 0" rpy="1.5708 0 0"/>
+  </joint>
+
+</robot>


### PR DESCRIPTION
This example initializes 2 robots from a URDF. It then reattaches one of the robots to the end effector of the other robot. Here are some screenshots. Attached are the resulting .dot files

Before:
![Screenshot from 2020-02-10 11-05-33](https://user-images.githubusercontent.com/12128406/74172223-7928a900-4bf5-11ea-81ed-3de3af90da68.png)

After:
![Screenshot from 2020-02-10 11-05-52](https://user-images.githubusercontent.com/12128406/74172236-7f1e8a00-4bf5-11ea-9370-e2efefe7dbf0.png)



[scene_graph_example.dot.txt](https://github.com/ros-industrial-consortium/tesseract/files/4182097/scene_graph_example.dot.txt)
[scene_graph_example_moveLink.dot.txt](https://github.com/ros-industrial-consortium/tesseract/files/4182098/scene_graph_example_moveLink.dot.txt)
