### PR TITLE
Planner fixes

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -215,7 +215,7 @@ void TrajOptPlannerDefaultConfig::addWaypoints(trajopt::ProblemConstructionInfo&
      * that are incapable of changing (i.e. joint positions). Therefore, the first and last indices of these
      * costs (which equal 0 and num_steps-1 by default) should be changed to exclude those states
      */
-    if (target_waypoints[ind]->getType() == WaypointType::JOINT_WAYPOINT)
+    if (target_waypoints[ind]->getType() == WaypointType::JOINT_WAYPOINT && target_waypoints[ind]->isCritical())
     {
       fixed_steps.push_back(static_cast<int>(ind));
     }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -179,6 +179,16 @@ bool TrajOptPlannerDefaultConfig::addInitTrajectory(trajopt::ProblemConstruction
       }
     }
   }
+  if (init_type == trajopt::InitInfo::JOINT_INTERPOLATED)
+  {
+    if (seed_trajectory.size() != pci.kin->numJoints())
+    {
+      CONSOLE_BRIDGE_logError("Init type is set to JOINT_INTERPOLATED but seed_trajectory.size() != "
+                              "pci.kin->numJoints().");
+      return false;
+    }
+    pci.init_info.data = seed_trajectory;
+  }
 
   return true;
 }


### PR DESCRIPTION
Allows the use of JOINT_INTERPOLATED in Trajopt_planner.

Only add waypoints to the fixed_waypoint list if they are critical. Currently it treats any joint position waypoint as fixed which may not be the case depending on the coefficient