### PR TITLE
Refactor/contact monitor lib

### DIFF
--- a/tesseract_ros/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_ros/tesseract_monitoring/CMakeLists.txt
@@ -86,7 +86,7 @@ target_include_directories(${PROJECT_NAME}_environment_node PUBLIC "$<BUILD_INTE
 target_include_directories(${PROJECT_NAME}_environment_node SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
 
 # Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_environment ${PROJECT_NAME}_contacts_node ${PROJECT_NAME}_environment_node demo_scene
+install(TARGETS ${PROJECT_NAME}_environment ${PROJECT_NAME}_contacts ${PROJECT_NAME}_contacts_node ${PROJECT_NAME}_environment_node demo_scene
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/tesseract_ros/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_ros/tesseract_monitoring/CMakeLists.txt
@@ -48,12 +48,20 @@ include_directories(
 )
 
 # Tesseract ROS Nodes
-add_executable(${PROJECT_NAME}_contacts_node src/contact_monitor.cpp)
-target_link_libraries(${PROJECT_NAME}_contacts_node PRIVATE tesseract::tesseract ${catkin_LIBRARIES})
+add_executable(${PROJECT_NAME}_contacts_node src/contact_monitor_node.cpp)
+target_link_libraries(${PROJECT_NAME}_contacts_node PRIVATE tesseract::tesseract ${PROJECT_NAME}_contacts ${catkin_LIBRARIES})
 tesseract_target_compile_options(${PROJECT_NAME}_contacts_node PRIVATE)
 tesseract_clang_tidy(${PROJECT_NAME}_contacts_node)
 target_include_directories(${PROJECT_NAME}_contacts_node PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_include_directories(${PROJECT_NAME}_contacts_node SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}_contacts src/contact_monitor.cpp)
+target_link_libraries(${PROJECT_NAME}_contacts PRIVATE tesseract::tesseract ${catkin_LIBRARIES})
+tesseract_target_compile_options(${PROJECT_NAME}_contacts PRIVATE)
+tesseract_clang_tidy(${PROJECT_NAME}_contacts)
+target_include_directories(${PROJECT_NAME}_contacts PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+target_include_directories(${PROJECT_NAME}_contacts SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
+add_dependencies(${PROJECT_NAME}_contacts ${PROJECT_NAME}_gencfg)
 
 add_library(${PROJECT_NAME}_environment SHARED src/environment_monitor.cpp src/current_state_monitor.cpp)
 target_link_libraries(${PROJECT_NAME}_environment PUBLIC tesseract::tesseract ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
@@ -1,18 +1,30 @@
-/*
- * Copyright 2020 Southwest Research Institute
+/**
+ * @file contact_monitor.h
+ * @brief definition of the contact_monitor library.  It publishes
+ * info about which links are (almost) in collision, and how far from/in
+ * collision they are.
  *
+ * @author David Merz, Jr.
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef CONTACT_MONITOR_H
 #define CONTACT_MONITOR_H
 

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
@@ -38,14 +38,13 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp> // boost::thread and boost::condition_variable
+#include <boost/thread/thread.hpp>  // boost::thread and boost::condition_variable
 
 #include <tesseract_collision/core/discrete_contact_manager.h>
 #include <tesseract/tesseract.h>
 
 namespace contact_monitor
 {
-
 class ContactMonitor
 {
 public:
@@ -95,9 +94,8 @@ private:
   boost::mutex modify_mutex_;
   boost::shared_ptr<sensor_msgs::JointState> current_joint_states_;
   boost::condition_variable current_joint_states_evt_;
-
 };
 
-} // end namespace contact_monitor
+}  // end namespace contact_monitor
 
-#endif // CONTACT_MONITOR_H
+#endif  // CONTACT_MONITOR_H

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CONTACT_MONITOR_H
+#define CONTACT_MONITOR_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ros/ros.h>
+#include <sensor_msgs/JointState.h>
+#include <tesseract_msgs/ComputeContactResultVector.h>
+#include <tesseract_msgs/ModifyEnvironment.h>
+#include <tesseract_msgs/TesseractState.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp> // boost::thread and boost::condition_variable
+
+#include <tesseract_collision/core/discrete_contact_manager.h>
+#include <tesseract/tesseract.h>
+
+namespace contact_monitor
+{
+
+class ContactMonitor
+{
+public:
+  ContactMonitor(const tesseract::Tesseract::Ptr& tess,
+                 ros::NodeHandle& nh,
+                 ros::NodeHandle& pnh,
+                 const std::vector<std::string>& monitored_link_names,
+                 const tesseract_collision::ContactTestType& type,
+                 const double contact_distance = 0.1,
+                 const bool publish_environment = false,
+                 const bool publish_markers = false);
+
+  ~ContactMonitor();
+
+  /**
+   * @brief Compute collision results and publish results.
+   *
+   * This also publishes environment and contact markers if correct flags are enabled for visualization and debuging.
+   */
+  void computeCollisionReportThread();
+
+  void callbackJointState(boost::shared_ptr<sensor_msgs::JointState> msg);
+
+  bool callbackModifyTesseractEnv(tesseract_msgs::ModifyEnvironment::Request& request,
+                                  tesseract_msgs::ModifyEnvironment::Response& response);
+
+  bool callbackComputeContactResultVector(tesseract_msgs::ComputeContactResultVector::Request& request,
+                                          tesseract_msgs::ComputeContactResultVector::Response& response);
+
+  void callbackTesseractEnvDiff(const tesseract_msgs::TesseractStatePtr& state);
+
+private:
+  tesseract::Tesseract::Ptr tess_;
+  std::vector<std::string> monitored_link_names_;
+  tesseract_collision::ContactTestType type_;
+  double contact_distance_;
+  bool publish_environment_;
+  bool publish_markers_;
+  tesseract_collision::DiscreteContactManager::Ptr manager_;
+  ros::Subscriber joint_states_sub_;
+  ros::Publisher contact_results_pub_;
+  ros::Publisher environment_pub_;
+  ros::Publisher contact_marker_pub_;
+  ros::Subscriber environment_diff_sub_;
+  ros::ServiceServer modify_env_service_;
+  ros::ServiceServer compute_contact_results_;
+  boost::mutex modify_mutex_;
+  boost::shared_ptr<sensor_msgs::JointState> current_joint_states_;
+  boost::condition_variable current_joint_states_evt_;
+
+};
+
+} // end namespace contact_monitor
+
+#endif // CONTACT_MONITOR_H

--- a/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
+++ b/tesseract_ros/tesseract_monitoring/include/tesseract_monitoring/contact_monitor.h
@@ -53,11 +53,21 @@ public:
                  ros::NodeHandle& pnh,
                  const std::vector<std::string>& monitored_link_names,
                  const tesseract_collision::ContactTestType& type,
-                 const double contact_distance = 0.1,
-                 const bool publish_environment = false,
-                 const bool publish_markers = false);
-
+                 double contact_distance = 0.1,
+                 bool publish_environment = false,
+                 bool publish_markers = false);
   ~ContactMonitor();
+  /**
+   * @brief Custom copy constructor, copy assignment, move constructor, and move
+   * assignment.  Because the condition vairable current_joint_states_evt_
+   * requires a 'cleanup' function call, a custom destructor is required.
+   * When a custom destructor is required, it is best to explicitly create
+   * these functions.  Here, we do so by assigning them to default values.
+   */
+  ContactMonitor(const ContactMonitor&) = delete;
+  ContactMonitor& operator=(const ContactMonitor&) = delete;
+  ContactMonitor(ContactMonitor&&) = delete;
+  ContactMonitor& operator=(ContactMonitor&&) = delete;
 
   /**
    * @brief Compute collision results and publish results.

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
@@ -14,219 +14,27 @@
  * limitations under the License.
  */
 
+#include <tesseract_monitoring/contact_monitor.h>
+
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <ros/ros.h>
-#include <ros/package.h>
-#include <sensor_msgs/JointState.h>
 #include <tesseract_msgs/ContactResultVector.h>
-#include <tesseract_msgs/ModifyEnvironment.h>
-#include <tesseract_msgs/ComputeContactResultVector.h>
 #include <visualization_msgs/MarkerArray.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
-
-#include <tesseract_collision/core/discrete_contact_manager.h>
-#include <tesseract/tesseract.h>
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_scene_graph/utils.h>
-#include <tesseract_scene_graph/parser/srdf_parser.h>
-#include <tesseract_urdf/urdf_parser.h>
-#include <tesseract_environment/kdl/kdl_env.h>
-#include <tesseract_environment/core/utils.h>
 #include <tesseract_rosutils/utils.h>
 #include <tesseract_rosutils/plotting.h>
 
-// Stuff for the contact monitor
-const std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
-const double DEFAULT_CONTACT_DISTANCE = 0.1;
-
 namespace contact_monitor
 {
-
-class ContactMonitor
-{
-private:
-  tesseract::Tesseract::Ptr tess_;
-  std::vector<std::string> monitored_link_names_;
-  tesseract_collision::ContactTestType type_;
-  double contact_distance_;
-  bool publish_environment_;
-  bool publish_markers_;
-  tesseract_collision::DiscreteContactManager::Ptr manager_;
-  ros::Subscriber joint_states_sub_;
-  ros::Publisher contact_results_pub_;
-  ros::Publisher environment_pub_;
-  ros::Publisher contact_marker_pub_;
-  ros::Subscriber environment_diff_sub_;
-  ros::ServiceServer modify_env_service_;
-  ros::ServiceServer compute_contact_results_;
-  boost::mutex modify_mutex_;
-  boost::shared_ptr<sensor_msgs::JointState> current_joint_states_;
-  boost::condition_variable current_joint_states_evt_;
-
-public:
-
-  /**
- * @brief Compute collision results and publish results.
- *
- * This also publishes environment and contact markers if correct flags are enabled for visualization and debuging.
- */
-  void computeCollisionReportThread()
-  {
-    while (!ros::isShuttingDown())
-    {
-      boost::shared_ptr<sensor_msgs::JointState> msg = nullptr;
-      tesseract_collision::ContactResultMap contacts;
-      tesseract_msgs::ContactResultVector contacts_msg;
-      // Limit the lock
-      {
-        boost::mutex::scoped_lock lock(modify_mutex_);
-        if (!current_joint_states_)
-        {
-          current_joint_states_evt_.wait(lock);
-        }
-
-        if (!current_joint_states_)
-          continue;
-
-        msg = current_joint_states_;
-        current_joint_states_.reset();
-
-        contacts.clear();
-        contacts_msg.contacts.clear();
-
-        tess_->getEnvironment()->setState(msg->name, msg->position);
-        tesseract_environment::EnvState::ConstPtr state = tess_->getEnvironment()->getCurrentState();
-
-        manager_->setCollisionObjectsTransform(state->transforms);
-        manager_->contactTest(contacts, type_);
-      }
-
-      if (publish_environment_)
-      {
-        tesseract_msgs::TesseractState state_msg;
-        tesseract_rosutils::toMsg(state_msg, *(tess_->getEnvironment()));
-        environment_pub_.publish(state_msg);
-      }
-
-      tesseract_collision::ContactResultVector contacts_vector;
-      tesseract_collision::flattenResults(std::move(contacts), contacts_vector);
-      Eigen::VectorXd safety_distance(contacts_vector.size());
-      contacts_msg.contacts.reserve(contacts_vector.size());
-      for (std::size_t i = 0; i < contacts_vector.size(); ++i)
-      {
-        safety_distance[static_cast<long>(i)] = contact_distance_;
-        tesseract_msgs::ContactResult contact_msg;
-        tesseract_rosutils::toMsg(contact_msg, contacts_vector[i], msg->header.stamp);
-        contacts_msg.contacts.push_back(contact_msg);
-      }
-      contact_results_pub_.publish(contacts_msg);
-
-      if (publish_markers_)
-      {
-        int id_counter = 0;
-        visualization_msgs::MarkerArray marker_msg =
-            tesseract_rosutils::ROSPlotting::getContactResultsMarkerArrayMsg(id_counter,
-                                                                             tess_->getEnvironment()->getSceneGraph()->getRoot(),
-                                                                             "contact_monitor",
-                                                                             msg->header.stamp,
-                                                                             monitored_link_names_,
-                                                                             contacts_vector,
-                                                                             safety_distance);
-        contact_marker_pub_.publish(marker_msg);
-      }
-    }
-  }
-
-  void callbackJointState(boost::shared_ptr<sensor_msgs::JointState> msg)
-  {
-    boost::mutex::scoped_lock lock(modify_mutex_);
-    current_joint_states_ = std::move(msg);
-    current_joint_states_evt_.notify_all();
-  }
-
-  bool callbackModifyTesseractEnv(tesseract_msgs::ModifyEnvironmentRequest& request,
-                                  tesseract_msgs::ModifyEnvironmentResponse& response)
-  {
-    boost::mutex::scoped_lock lock(modify_mutex_);
-    response.success = tesseract_rosutils::processMsg(*(tess_->getEnvironment()), request.commands);
-    response.revision = static_cast<unsigned long>(tess_->getEnvironmentConst()->getRevision());
-
-    // Create a new manager
-    std::vector<std::string> active = manager_->getActiveCollisionObjects();
-    double contact_distance = manager_->getContactDistanceThreshold();
-    tesseract_collision::IsContactAllowedFn fn = manager_->getIsContactAllowedFn();
-
-    manager_ = tess_->getEnvironment()->getDiscreteContactManager();
-    manager_->setActiveCollisionObjects(active);
-    manager_->setContactDistanceThreshold(contact_distance);
-    manager_->setIsContactAllowedFn(fn);
-
-    return true;
-  }
-
-  bool callbackComputeContactResultVector(tesseract_msgs::ComputeContactResultVectorRequest& request,
-                                          tesseract_msgs::ComputeContactResultVectorResponse& response)
-  {
-    tesseract_collision::ContactResultMap contact_results;
-
-    // Limit the lock
-    {
-      boost::mutex::scoped_lock lock(modify_mutex_);
-
-      tess_->getEnvironment()->setState(request.joint_states.name, request.joint_states.position);
-      tesseract_environment::EnvState::ConstPtr state = tess_->getEnvironment()->getCurrentState();
-
-      manager_->setCollisionObjectsTransform(state->transforms);
-      manager_->contactTest(contact_results, type_);
-    }
-
-    tesseract_collision::ContactResultVector contacts_vector;
-    tesseract_collision::flattenResults(std::move(contact_results), contacts_vector);
-    response.collision_result.contacts.reserve(contacts_vector.size());
-    for (const auto& contact : contacts_vector)
-    {
-      tesseract_msgs::ContactResult contact_msg;
-      tesseract_rosutils::toMsg(contact_msg, contact, request.joint_states.header.stamp);
-      response.collision_result.contacts.push_back(contact_msg);
-    }
-    response.success = true;
-
-    return true;
-  }
-
-  void callbackTesseractEnvDiff(const tesseract_msgs::TesseractStatePtr& state)
-  {
-    boost::mutex::scoped_lock lock(modify_mutex_);
-    if (!tesseract_rosutils::processMsg(*(tess_->getEnvironment()), *state))
-    {
-      ROS_ERROR("Invalid TesseractState diff message");
-    }
-
-    // Create a new manager
-    std::vector<std::string> active = manager_->getActiveCollisionObjects();
-    double contact_distance = manager_->getContactDistanceThreshold();
-    tesseract_collision::IsContactAllowedFn fn = manager_->getIsContactAllowedFn();
-
-    manager_ = tess_->getEnvironment()->getDiscreteContactManager();
-    manager_->setActiveCollisionObjects(active);
-    manager_->setContactDistanceThreshold(contact_distance);
-    manager_->setIsContactAllowedFn(fn);
-
-    return;
-  }
-
-  ContactMonitor(const tesseract::Tesseract::Ptr& tess,
+  ContactMonitor::ContactMonitor(const tesseract::Tesseract::Ptr& tess,
                  ros::NodeHandle& nh,
                  ros::NodeHandle& pnh,
                  const std::vector<std::string>& monitored_link_names,
                  const tesseract_collision::ContactTestType& type,
                  const double contact_distance,
-                 const bool publish_environment = false,
-                 const bool publish_markers = false
+                 const bool publish_environment,
+                 const bool publish_markers
       )
     : tess_ (tess)
     , monitored_link_names_ (monitored_link_names)
@@ -266,94 +74,166 @@ public:
     return;
   }
 
-  ~ContactMonitor()
+  ContactMonitor::~ContactMonitor()
   {
     current_joint_states_evt_.notify_all();
     return;
   }
 
-};
+
+/**
+* @brief Compute collision results and publish results.
+*
+* This also publishes environment and contact markers if correct flags are enabled for visualization and debuging.
+*/
+void ContactMonitor::computeCollisionReportThread()
+{
+  while (!ros::isShuttingDown())
+  {
+    boost::shared_ptr<sensor_msgs::JointState> msg = nullptr;
+    tesseract_collision::ContactResultMap contacts;
+    tesseract_msgs::ContactResultVector contacts_msg;
+    // Limit the lock
+    {
+      boost::mutex::scoped_lock lock(modify_mutex_);
+      if (!current_joint_states_)
+      {
+        current_joint_states_evt_.wait(lock);
+      }
+
+      if (!current_joint_states_)
+        continue;
+
+      msg = current_joint_states_;
+      current_joint_states_.reset();
+
+      contacts.clear();
+      contacts_msg.contacts.clear();
+
+      tess_->getEnvironment()->setState(msg->name, msg->position);
+      tesseract_environment::EnvState::ConstPtr state = tess_->getEnvironment()->getCurrentState();
+
+      manager_->setCollisionObjectsTransform(state->transforms);
+      manager_->contactTest(contacts, type_);
+    }
+
+    if (publish_environment_)
+    {
+      tesseract_msgs::TesseractState state_msg;
+      tesseract_rosutils::toMsg(state_msg, *(tess_->getEnvironment()));
+      environment_pub_.publish(state_msg);
+    }
+
+    tesseract_collision::ContactResultVector contacts_vector;
+    tesseract_collision::flattenResults(std::move(contacts), contacts_vector);
+    Eigen::VectorXd safety_distance(contacts_vector.size());
+    contacts_msg.contacts.reserve(contacts_vector.size());
+    for (std::size_t i = 0; i < contacts_vector.size(); ++i)
+    {
+      safety_distance[static_cast<long>(i)] = contact_distance_;
+      tesseract_msgs::ContactResult contact_msg;
+      tesseract_rosutils::toMsg(contact_msg, contacts_vector[i], msg->header.stamp);
+      contacts_msg.contacts.push_back(contact_msg);
+    }
+    contact_results_pub_.publish(contacts_msg);
+
+    if (publish_markers_)
+    {
+      int id_counter = 0;
+      visualization_msgs::MarkerArray marker_msg =
+          tesseract_rosutils::ROSPlotting::getContactResultsMarkerArrayMsg(id_counter,
+                                                                           tess_->getEnvironment()->getSceneGraph()->getRoot(),
+                                                                           "contact_monitor",
+                                                                           msg->header.stamp,
+                                                                           monitored_link_names_,
+                                                                           contacts_vector,
+                                                                           safety_distance);
+      contact_marker_pub_.publish(marker_msg);
+    }
+  }
+}
+
+void ContactMonitor::callbackJointState(boost::shared_ptr<sensor_msgs::JointState> msg)
+{
+  boost::mutex::scoped_lock lock(modify_mutex_);
+  current_joint_states_ = std::move(msg);
+  current_joint_states_evt_.notify_all();
+}
+
+bool ContactMonitor::callbackModifyTesseractEnv(tesseract_msgs::ModifyEnvironmentRequest& request,
+                                tesseract_msgs::ModifyEnvironmentResponse& response)
+{
+  boost::mutex::scoped_lock lock(modify_mutex_);
+  response.success = tesseract_rosutils::processMsg(*(tess_->getEnvironment()), request.commands);
+  response.revision = static_cast<unsigned long>(tess_->getEnvironmentConst()->getRevision());
+
+  // Create a new manager
+  std::vector<std::string> active = manager_->getActiveCollisionObjects();
+  double contact_distance = manager_->getContactDistanceThreshold();
+  tesseract_collision::IsContactAllowedFn fn = manager_->getIsContactAllowedFn();
+
+  manager_ = tess_->getEnvironment()->getDiscreteContactManager();
+  manager_->setActiveCollisionObjects(active);
+  manager_->setContactDistanceThreshold(contact_distance);
+  manager_->setIsContactAllowedFn(fn);
+
+  return true;
+}
+
+bool ContactMonitor::callbackComputeContactResultVector(tesseract_msgs::ComputeContactResultVectorRequest& request,
+                                        tesseract_msgs::ComputeContactResultVectorResponse& response)
+{
+  tesseract_collision::ContactResultMap contact_results;
+
+  // Limit the lock
+  {
+    boost::mutex::scoped_lock lock(modify_mutex_);
+
+    tess_->getEnvironment()->setState(request.joint_states.name, request.joint_states.position);
+    tesseract_environment::EnvState::ConstPtr state = tess_->getEnvironment()->getCurrentState();
+
+    manager_->setCollisionObjectsTransform(state->transforms);
+    manager_->contactTest(contact_results, type_);
+  }
+
+  tesseract_collision::ContactResultVector contacts_vector;
+  tesseract_collision::flattenResults(std::move(contact_results), contacts_vector);
+  response.collision_result.contacts.reserve(contacts_vector.size());
+  for (const auto& contact : contacts_vector)
+  {
+    tesseract_msgs::ContactResult contact_msg;
+    tesseract_rosutils::toMsg(contact_msg, contact, request.joint_states.header.stamp);
+    response.collision_result.contacts.push_back(contact_msg);
+  }
+  response.success = true;
+
+  return true;
+}
+
+void ContactMonitor::callbackTesseractEnvDiff(const tesseract_msgs::TesseractStatePtr& state)
+{
+  boost::mutex::scoped_lock lock(modify_mutex_);
+  if (!tesseract_rosutils::processMsg(*(tess_->getEnvironment()), *state))
+  {
+    ROS_ERROR("Invalid TesseractState diff message");
+  }
+
+  // Create a new manager
+  std::vector<std::string> active = manager_->getActiveCollisionObjects();
+  double contact_distance = manager_->getContactDistanceThreshold();
+  tesseract_collision::IsContactAllowedFn fn = manager_->getIsContactAllowedFn();
+
+  manager_ = tess_->getEnvironment()->getDiscreteContactManager();
+  manager_->setActiveCollisionObjects(active);
+  manager_->setContactDistanceThreshold(contact_distance);
+  manager_->setIsContactAllowedFn(fn);
+
+  return;
+}
+
+
 
 } // end namespace contact monitor
 
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "tesseract_contact_monitoring");
-  ros::NodeHandle nh;
-  ros::NodeHandle pnh("~");
 
-  tesseract_scene_graph::SceneGraph::Ptr scene_graph;
-  tesseract_scene_graph::SRDFModel::Ptr srdf_model;
-  std::string robot_description;
-  bool publish_environment;
-  bool publish_markers;
-
-  pnh.param<std::string>("robot_description", robot_description, ROBOT_DESCRIPTION_PARAM);
-  pnh.param<bool>("publish_environment", publish_environment, false);
-  pnh.param<bool>("publish_markers", publish_markers, false);
-
-  // Initial setup
-  std::string urdf_xml_string, srdf_xml_string;
-  if (!nh.hasParam(robot_description))
-  {
-    ROS_ERROR("Failed to find parameter: %s", robot_description.c_str());
-    return -1;
-  }
-
-  if (!nh.hasParam(robot_description + "_semantic"))
-  {
-    ROS_ERROR("Failed to find parameter: %s", (robot_description + "_semantic").c_str());
-    return -1;
-  }
-
-  nh.getParam(robot_description, urdf_xml_string);
-  nh.getParam(robot_description + "_semantic", srdf_xml_string);
-
-  tesseract::Tesseract::Ptr tess = std::make_shared<tesseract::Tesseract>();
-  tesseract_scene_graph::ResourceLocator::Ptr locator = std::make_shared<tesseract_rosutils::ROSResourceLocator>();
-  if (!tess->init(urdf_xml_string, srdf_xml_string, locator))
-  {
-    ROS_ERROR("Failed to initialize environment.");
-    return -1;
-  }
-
-  double contact_distance;
-  pnh.param<double>("contact_distance", contact_distance, DEFAULT_CONTACT_DISTANCE);
-
-  std::vector<std::string> monitored_link_names;
-  monitored_link_names = tess->getEnvironment()->getLinkNames();
-  if (pnh.hasParam("monitor_links"))
-    pnh.getParam("monitor_links", monitored_link_names);
-
-  if (monitored_link_names.empty())
-    monitored_link_names = tess->getEnvironment()->getLinkNames();
-
-  int contact_test_type = 2;
-  if (pnh.hasParam("contact_test_type"))
-    pnh.getParam("contact_test_type", contact_test_type);
-
-  if (contact_test_type < 0 || contact_test_type > 3)
-  {
-    ROS_WARN("Request type must be 0, 1, 2 or 3. Setting to 2(ALL)!");
-    contact_test_type = 2;
-  }
-  tesseract_collision::ContactTestType type = static_cast<tesseract_collision::ContactTestType>(contact_test_type);
-
-  contact_monitor::ContactMonitor cm(tess,
-                                     nh,
-                                     pnh,
-                                     monitored_link_names,
-                                     type,
-                                     contact_distance,
-                                     publish_environment,
-                                     publish_markers);
-
-  boost::thread t (&contact_monitor::ContactMonitor::computeCollisionReportThread, &cm);
-
-  ROS_INFO("Contact Monitor Running!");
-
-  ros::spin();
-
-  return 0;
-}
 

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
@@ -1,12 +1,23 @@
-/*
- * Copyright 2020 Southwest Research Institute
+/**
+ * @file contact_monitor.cpp
+ * @brief implementation of the contact_monitor library.  It publishes
+ * info about which links are (almost) in collision, and how far from/in
+ * collision they are.
  *
+ * @author David Merz, Jr.
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
@@ -43,9 +43,9 @@ ContactMonitor::ContactMonitor(const tesseract::Tesseract::Ptr& tess,
                                ros::NodeHandle& pnh,
                                const std::vector<std::string>& monitored_link_names,
                                const tesseract_collision::ContactTestType& type,
-                               const double contact_distance,
-                               const bool publish_environment,
-                               const bool publish_markers)
+                               double contact_distance,
+                               bool publish_environment,
+                               bool publish_markers)
   : tess_(tess)
   , monitored_link_names_(monitored_link_names)
   , type_(type)

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor.cpp
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2020 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <pluginlib/class_loader.hpp>
 #include <ros/ros.h>
 #include <ros/package.h>
 #include <sensor_msgs/JointState.h>
@@ -9,6 +24,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_msgs/ComputeContactResultVector.h>
 #include <visualization_msgs/MarkerArray.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
 
 #include <tesseract_collision/core/discrete_contact_manager.h>
 #include <tesseract/tesseract.h>
@@ -21,186 +39,242 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_rosutils/utils.h>
 #include <tesseract_rosutils/plotting.h>
 
-using namespace tesseract;
-using namespace tesseract_environment;
-using namespace tesseract_rosutils;
-using namespace tesseract_collision;
-using namespace tesseract_scene_graph;
-
-using DiscreteContactManagerPluginLoader = pluginlib::ClassLoader<DiscreteContactManager>;
-using DiscreteContactManagerPluginLoaderPtr = std::shared_ptr<DiscreteContactManagerPluginLoader>;
-
+// Stuff for the contact monitor
 const std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
-
 const double DEFAULT_CONTACT_DISTANCE = 0.1;
 
-static Tesseract::Ptr tess;
-static DiscreteContactManager::Ptr manager;
-static ros::Subscriber joint_states_sub;
-static ros::Publisher contact_results_pub;
-static ros::Publisher environment_pub;
-static ros::Publisher contact_marker_pub;
-static ros::Subscriber environment_diff_sub;
-static ros::ServiceServer modify_env_service;
-static ros::ServiceServer compute_contact_results;
-static ContactTestType type;
-static ContactResultMap contacts;
-static tesseract_msgs::ContactResultVector contacts_msg;
-static bool publish_environment;
-static bool publish_markers;
-static boost::mutex modify_mutex;
-static DiscreteContactManagerPluginLoaderPtr discrete_manager_loader; /**< The discrete contact manager loader */
-static std::vector<std::string> monitored_link_names;
-static double contact_distance;
-static boost::shared_ptr<sensor_msgs::JointState> current_joint_states;
-static boost::condition_variable current_joint_states_evt;
+namespace contact_monitor
+{
 
-/**
+class ContactMonitor
+{
+private:
+  tesseract::Tesseract::Ptr tess_;
+  std::vector<std::string> monitored_link_names_;
+  tesseract_collision::ContactTestType type_;
+  double contact_distance_;
+  bool publish_environment_;
+  bool publish_markers_;
+  tesseract_collision::DiscreteContactManager::Ptr manager_;
+  ros::Subscriber joint_states_sub_;
+  ros::Publisher contact_results_pub_;
+  ros::Publisher environment_pub_;
+  ros::Publisher contact_marker_pub_;
+  ros::Subscriber environment_diff_sub_;
+  ros::ServiceServer modify_env_service_;
+  ros::ServiceServer compute_contact_results_;
+  boost::mutex modify_mutex_;
+  boost::shared_ptr<sensor_msgs::JointState> current_joint_states_;
+  boost::condition_variable current_joint_states_evt_;
+
+public:
+
+  /**
  * @brief Compute collision results and publish results.
  *
  * This also publishes environment and contact markers if correct flags are enabled for visualization and debuging.
  */
-void computeCollisionReportThread()
-{
-  while (!ros::isShuttingDown())
+  void computeCollisionReportThread()
   {
-    boost::shared_ptr<sensor_msgs::JointState> msg = nullptr;
+    while (!ros::isShuttingDown())
+    {
+      boost::shared_ptr<sensor_msgs::JointState> msg = nullptr;
+      tesseract_collision::ContactResultMap contacts;
+      tesseract_msgs::ContactResultVector contacts_msg;
+      // Limit the lock
+      {
+        boost::mutex::scoped_lock lock(modify_mutex_);
+        if (!current_joint_states_)
+        {
+          current_joint_states_evt_.wait(lock);
+        }
+
+        if (!current_joint_states_)
+          continue;
+
+        msg = current_joint_states_;
+        current_joint_states_.reset();
+
+        contacts.clear();
+        contacts_msg.contacts.clear();
+
+        tess_->getEnvironment()->setState(msg->name, msg->position);
+        tesseract_environment::EnvState::ConstPtr state = tess_->getEnvironment()->getCurrentState();
+
+        manager_->setCollisionObjectsTransform(state->transforms);
+        manager_->contactTest(contacts, type_);
+      }
+
+      if (publish_environment_)
+      {
+        tesseract_msgs::TesseractState state_msg;
+        tesseract_rosutils::toMsg(state_msg, *(tess_->getEnvironment()));
+        environment_pub_.publish(state_msg);
+      }
+
+      tesseract_collision::ContactResultVector contacts_vector;
+      tesseract_collision::flattenResults(std::move(contacts), contacts_vector);
+      Eigen::VectorXd safety_distance(contacts_vector.size());
+      contacts_msg.contacts.reserve(contacts_vector.size());
+      for (std::size_t i = 0; i < contacts_vector.size(); ++i)
+      {
+        safety_distance[static_cast<long>(i)] = contact_distance_;
+        tesseract_msgs::ContactResult contact_msg;
+        tesseract_rosutils::toMsg(contact_msg, contacts_vector[i], msg->header.stamp);
+        contacts_msg.contacts.push_back(contact_msg);
+      }
+      contact_results_pub_.publish(contacts_msg);
+
+      if (publish_markers_)
+      {
+        int id_counter = 0;
+        visualization_msgs::MarkerArray marker_msg =
+            tesseract_rosutils::ROSPlotting::getContactResultsMarkerArrayMsg(id_counter,
+                                                                             tess_->getEnvironment()->getSceneGraph()->getRoot(),
+                                                                             "contact_monitor",
+                                                                             msg->header.stamp,
+                                                                             monitored_link_names_,
+                                                                             contacts_vector,
+                                                                             safety_distance);
+        contact_marker_pub_.publish(marker_msg);
+      }
+    }
+  }
+
+  void callbackJointState(boost::shared_ptr<sensor_msgs::JointState> msg)
+  {
+    boost::mutex::scoped_lock lock(modify_mutex_);
+    current_joint_states_ = std::move(msg);
+    current_joint_states_evt_.notify_all();
+  }
+
+  bool callbackModifyTesseractEnv(tesseract_msgs::ModifyEnvironmentRequest& request,
+                                  tesseract_msgs::ModifyEnvironmentResponse& response)
+  {
+    boost::mutex::scoped_lock lock(modify_mutex_);
+    response.success = tesseract_rosutils::processMsg(*(tess_->getEnvironment()), request.commands);
+    response.revision = static_cast<unsigned long>(tess_->getEnvironmentConst()->getRevision());
+
+    // Create a new manager
+    std::vector<std::string> active = manager_->getActiveCollisionObjects();
+    double contact_distance = manager_->getContactDistanceThreshold();
+    tesseract_collision::IsContactAllowedFn fn = manager_->getIsContactAllowedFn();
+
+    manager_ = tess_->getEnvironment()->getDiscreteContactManager();
+    manager_->setActiveCollisionObjects(active);
+    manager_->setContactDistanceThreshold(contact_distance);
+    manager_->setIsContactAllowedFn(fn);
+
+    return true;
+  }
+
+  bool callbackComputeContactResultVector(tesseract_msgs::ComputeContactResultVectorRequest& request,
+                                          tesseract_msgs::ComputeContactResultVectorResponse& response)
+  {
+    tesseract_collision::ContactResultMap contact_results;
 
     // Limit the lock
     {
-      boost::mutex::scoped_lock lock(modify_mutex);
-      if (!current_joint_states)
-      {
-        current_joint_states_evt.wait(lock);
-      }
+      boost::mutex::scoped_lock lock(modify_mutex_);
 
-      if (!current_joint_states)
-        continue;
+      tess_->getEnvironment()->setState(request.joint_states.name, request.joint_states.position);
+      tesseract_environment::EnvState::ConstPtr state = tess_->getEnvironment()->getCurrentState();
 
-      msg = current_joint_states;
-      current_joint_states.reset();
-
-      contacts.clear();
-      contacts_msg.contacts.clear();
-
-      tess->getEnvironment()->setState(msg->name, msg->position);
-      EnvState::ConstPtr state = tess->getEnvironment()->getCurrentState();
-
-      manager->setCollisionObjectsTransform(state->transforms);
-      manager->contactTest(contacts, type);
+      manager_->setCollisionObjectsTransform(state->transforms);
+      manager_->contactTest(contact_results, type_);
     }
 
-    if (publish_environment)
+    tesseract_collision::ContactResultVector contacts_vector;
+    tesseract_collision::flattenResults(std::move(contact_results), contacts_vector);
+    response.collision_result.contacts.reserve(contacts_vector.size());
+    for (const auto& contact : contacts_vector)
     {
-      tesseract_msgs::TesseractState state_msg;
-      toMsg(state_msg, *(tess->getEnvironment()));
-      environment_pub.publish(state_msg);
-    }
-
-    ContactResultVector contacts_vector;
-    tesseract_collision::flattenResults(std::move(contacts), contacts_vector);
-    Eigen::VectorXd safety_distance(contacts_vector.size());
-    contacts_msg.contacts.reserve(contacts_vector.size());
-    for (std::size_t i = 0; i < contacts_vector.size(); ++i)
-    {
-      safety_distance[static_cast<long>(i)] = contact_distance;
       tesseract_msgs::ContactResult contact_msg;
-      toMsg(contact_msg, contacts_vector[i], msg->header.stamp);
-      contacts_msg.contacts.push_back(contact_msg);
+      tesseract_rosutils::toMsg(contact_msg, contact, request.joint_states.header.stamp);
+      response.collision_result.contacts.push_back(contact_msg);
     }
-    contact_results_pub.publish(contacts_msg);
+    response.success = true;
 
-    if (publish_markers)
+    return true;
+  }
+
+  void callbackTesseractEnvDiff(const tesseract_msgs::TesseractStatePtr& state)
+  {
+    boost::mutex::scoped_lock lock(modify_mutex_);
+    if (!tesseract_rosutils::processMsg(*(tess_->getEnvironment()), *state))
     {
-      int id_counter = 0;
-      visualization_msgs::MarkerArray marker_msg =
-          ROSPlotting::getContactResultsMarkerArrayMsg(id_counter,
-                                                       tess->getEnvironment()->getSceneGraph()->getRoot(),
-                                                       "contact_monitor",
-                                                       msg->header.stamp,
-                                                       monitored_link_names,
-                                                       contacts_vector,
-                                                       safety_distance);
-      contact_marker_pub.publish(marker_msg);
+      ROS_ERROR("Invalid TesseractState diff message");
     }
+
+    // Create a new manager
+    std::vector<std::string> active = manager_->getActiveCollisionObjects();
+    double contact_distance = manager_->getContactDistanceThreshold();
+    tesseract_collision::IsContactAllowedFn fn = manager_->getIsContactAllowedFn();
+
+    manager_ = tess_->getEnvironment()->getDiscreteContactManager();
+    manager_->setActiveCollisionObjects(active);
+    manager_->setContactDistanceThreshold(contact_distance);
+    manager_->setIsContactAllowedFn(fn);
+
+    return;
   }
-}
 
-void callbackJointState(boost::shared_ptr<sensor_msgs::JointState> msg)
-{
-  boost::mutex::scoped_lock lock(modify_mutex);
-  current_joint_states = std::move(msg);
-  current_joint_states_evt.notify_all();
-}
-
-bool callbackModifyTesseractEnv(tesseract_msgs::ModifyEnvironmentRequest& request,
-                                tesseract_msgs::ModifyEnvironmentResponse& response)
-{
-  boost::mutex::scoped_lock lock(modify_mutex);
-  response.success = processMsg(*(tess->getEnvironment()), request.commands);
-  response.revision = static_cast<unsigned long>(tess->getEnvironmentConst()->getRevision());
-
-  // Create a new manager
-  std::vector<std::string> active = manager->getActiveCollisionObjects();
-  double contact_distance = manager->getContactDistanceThreshold();
-  IsContactAllowedFn fn = manager->getIsContactAllowedFn();
-
-  manager = tess->getEnvironment()->getDiscreteContactManager();
-  manager->setActiveCollisionObjects(active);
-  manager->setContactDistanceThreshold(contact_distance);
-  manager->setIsContactAllowedFn(fn);
-
-  return true;
-}
-
-bool callbackComputeContactResultVector(tesseract_msgs::ComputeContactResultVectorRequest& request,
-                                        tesseract_msgs::ComputeContactResultVectorResponse& response)
-{
-  ContactResultMap contact_results;
-
-  // Limit the lock
+  ContactMonitor(const tesseract::Tesseract::Ptr& tess,
+                 ros::NodeHandle& nh,
+                 ros::NodeHandle& pnh,
+                 const std::vector<std::string>& monitored_link_names,
+                 const tesseract_collision::ContactTestType& type,
+                 const double contact_distance,
+                 const bool publish_environment = false,
+                 const bool publish_markers = false
+      )
+    : tess_ (tess)
+    , monitored_link_names_ (monitored_link_names)
+    , type_ (type)
+    , contact_distance_ (contact_distance)
+    , publish_environment_ (publish_environment)
+    , publish_markers_ (publish_markers)
   {
-    boost::mutex::scoped_lock lock(modify_mutex);
+    if (tess_ == nullptr)
+    {
+      ROS_ERROR("Null pointer passed for tesseract object.  Not setting up contact monitor.");
+      return;
+    }
+    manager_ = tess->getEnvironment()->getDiscreteContactManager();
+    if (manager_ == nullptr)
+    {
+      ROS_ERROR("Discrete contact manager is a null pointer.  Not setting up contact monitor.");
+      return;
+    }
+    manager_->setActiveCollisionObjects(monitored_link_names);
+    manager_->setContactDistanceThreshold(contact_distance);
 
-    tess->getEnvironment()->setState(request.joint_states.name, request.joint_states.position);
-    EnvState::ConstPtr state = tess->getEnvironment()->getCurrentState();
+    joint_states_sub_ = nh.subscribe("joint_states", 1, &ContactMonitor::callbackJointState, this);
+    contact_results_pub_ = pnh.advertise<tesseract_msgs::ContactResultVector>("contact_results", 1, true);
+    modify_env_service_ = pnh.advertiseService("modify_environment", &ContactMonitor::callbackModifyTesseractEnv, this);
 
-    manager->setCollisionObjectsTransform(state->transforms);
-    manager->contactTest(contact_results, type);
+    if (publish_environment_)
+      environment_pub_ = pnh.advertise<tesseract_msgs::TesseractState>("tesseract", 100, false);
+
+    if (publish_markers_)
+      contact_marker_pub_ = pnh.advertise<visualization_msgs::MarkerArray>("contact_results_markers", 1, true);
+
+    compute_contact_results_ = pnh.advertiseService("compute_contact_results", &ContactMonitor::callbackComputeContactResultVector, this);
+
+    environment_diff_sub_ = pnh.subscribe("tesseract_diff", 100, &ContactMonitor::callbackTesseractEnvDiff, this);
+
+    return;
   }
 
-  ContactResultVector contacts_vector;
-  tesseract_collision::flattenResults(std::move(contact_results), contacts_vector);
-  response.collision_result.contacts.reserve(contacts_vector.size());
-  for (const auto& contact : contacts_vector)
+  ~ContactMonitor()
   {
-    tesseract_msgs::ContactResult contact_msg;
-    toMsg(contact_msg, contact, request.joint_states.header.stamp);
-    response.collision_result.contacts.push_back(contact_msg);
-  }
-  response.success = true;
-
-  return true;
-}
-
-void callbackTesseractEnvDiff(const tesseract_msgs::TesseractStatePtr& state)
-{
-  boost::mutex::scoped_lock lock(modify_mutex);
-  if (!processMsg(*(tess->getEnvironment()), *state))
-  {
-    ROS_ERROR("Invalid TesseractState diff message");
+    current_joint_states_evt_.notify_all();
+    return;
   }
 
-  // Create a new manager
-  std::vector<std::string> active = manager->getActiveCollisionObjects();
-  double contact_distance = manager->getContactDistanceThreshold();
-  IsContactAllowedFn fn = manager->getIsContactAllowedFn();
+};
 
-  manager = tess->getEnvironment()->getDiscreteContactManager();
-  manager->setActiveCollisionObjects(active);
-  manager->setContactDistanceThreshold(contact_distance);
-  manager->setIsContactAllowedFn(fn);
-}
+} // end namespace contact monitor
 
 int main(int argc, char** argv)
 {
@@ -208,26 +282,15 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
   ros::NodeHandle pnh("~");
 
-  SceneGraph::Ptr scene_graph;
-  SRDFModel::Ptr srdf_model;
+  tesseract_scene_graph::SceneGraph::Ptr scene_graph;
+  tesseract_scene_graph::SRDFModel::Ptr srdf_model;
   std::string robot_description;
-  std::string plugin;
+  bool publish_environment;
+  bool publish_markers;
 
   pnh.param<std::string>("robot_description", robot_description, ROBOT_DESCRIPTION_PARAM);
   pnh.param<bool>("publish_environment", publish_environment, false);
   pnh.param<bool>("publish_markers", publish_markers, false);
-  //  if (pnh.hasParam("plugin"))
-  //  {
-  //    discrete_manager_loader.reset(new DiscreteContactManagerPluginLoader("tesseract_collision",
-  //    "tesseract_collision::DiscreteContactManager")); pnh.getParam("plugin", plugin); if
-  //    (discrete_manager_loader->isClassAvailable(plugin))
-  //    {
-  //      ROS_ERROR("Failed to load tesseract contact checker plugin: %s.", plugin.c_str());
-  //      return -1;
-  //    }
-  //    auto fn = [&]() -> DiscreteContactManagerPtr { return ::discrete_manager_loader->createUniqueInstance(plugin);
-  //    }; env->registerDiscreteContactManager(plugin, fn); env->setActiveDiscreteContactManager(plugin);
-  //  }
 
   // Initial setup
   std::string urdf_xml_string, srdf_xml_string;
@@ -246,7 +309,7 @@ int main(int argc, char** argv)
   nh.getParam(robot_description, urdf_xml_string);
   nh.getParam(robot_description + "_semantic", srdf_xml_string);
 
-  tess = std::make_shared<tesseract::Tesseract>();
+  tesseract::Tesseract::Ptr tess = std::make_shared<tesseract::Tesseract>();
   tesseract_scene_graph::ResourceLocator::Ptr locator = std::make_shared<tesseract_rosutils::ROSResourceLocator>();
   if (!tess->init(urdf_xml_string, srdf_xml_string, locator))
   {
@@ -254,8 +317,10 @@ int main(int argc, char** argv)
     return -1;
   }
 
+  double contact_distance;
   pnh.param<double>("contact_distance", contact_distance, DEFAULT_CONTACT_DISTANCE);
 
+  std::vector<std::string> monitored_link_names;
   monitored_link_names = tess->getEnvironment()->getLinkNames();
   if (pnh.hasParam("monitor_links"))
     pnh.getParam("monitor_links", monitored_link_names);
@@ -272,37 +337,23 @@ int main(int argc, char** argv)
     ROS_WARN("Request type must be 0, 1, 2 or 3. Setting to 2(ALL)!");
     contact_test_type = 2;
   }
-  type = static_cast<ContactTestType>(contact_test_type);
+  tesseract_collision::ContactTestType type = static_cast<tesseract_collision::ContactTestType>(contact_test_type);
 
-  manager = tess->getEnvironment()->getDiscreteContactManager();
-  manager->setActiveCollisionObjects(monitored_link_names);
-  manager->setContactDistanceThreshold(contact_distance);
+  contact_monitor::ContactMonitor cm(tess,
+                                     nh,
+                                     pnh,
+                                     monitored_link_names,
+                                     type,
+                                     contact_distance,
+                                     publish_environment,
+                                     publish_markers);
 
-  joint_states_sub = nh.subscribe("joint_states", 1, &callbackJointState);
-  contact_results_pub = pnh.advertise<tesseract_msgs::ContactResultVector>("contact_results", 1, true);
-  modify_env_service =
-      pnh.advertiseService<tesseract_msgs::ModifyEnvironmentRequest, tesseract_msgs::ModifyEnvironmentResponse>(
-          "modify_environment", &callbackModifyTesseractEnv);
-
-  if (publish_environment)
-    environment_pub = pnh.advertise<tesseract_msgs::TesseractState>("tesseract", 100, false);
-
-  if (publish_markers)
-    contact_marker_pub = pnh.advertise<visualization_msgs::MarkerArray>("contact_results_markers", 1, true);
-
-  compute_contact_results = pnh.advertiseService<tesseract_msgs::ComputeContactResultVectorRequest,
-                                                 tesseract_msgs::ComputeContactResultVectorResponse>(
-      "compute_contact_results", &callbackComputeContactResultVector);
-
-  environment_diff_sub = pnh.subscribe("tesseract_diff", 100, &callbackTesseractEnvDiff);
-
-  boost::thread t(&computeCollisionReportThread);
+  boost::thread t (&contact_monitor::ContactMonitor::computeCollisionReportThread, &cm);
 
   ROS_INFO("Contact Monitor Running!");
 
   ros::spin();
 
-  current_joint_states_evt.notify_all();
-
   return 0;
 }
+

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor_node.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor_node.cpp
@@ -1,18 +1,28 @@
-/*
- * Copyright 2020 Southwest Research Institute
+/**
+ * @file contact_monitor_node.cpp
+ * @brief Node that instantiates a contact_monitor
  *
+ * @author David Merz, Jr.
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <tesseract_monitoring/contact_monitor.h>
 
 #include <tesseract_common/macros.h>

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor_node.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor_node.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_monitoring/contact_monitor.h>
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ros/ros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <boost/thread/thread.hpp>
+
+#include <tesseract/tesseract.h>
+#include <tesseract_scene_graph/graph.h>
+#include <tesseract_scene_graph/utils.h>
+#include <tesseract_scene_graph/parser/srdf_parser.h>
+#include <tesseract_urdf/urdf_parser.h>
+#include <tesseract_rosutils/utils.h>
+
+// Stuff for the contact monitor
+const static std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
+const static double DEFAULT_CONTACT_DISTANCE = 0.1;
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "tesseract_contact_monitoring");
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+
+  tesseract_scene_graph::SceneGraph::Ptr scene_graph;
+  tesseract_scene_graph::SRDFModel::Ptr srdf_model;
+  std::string robot_description;
+  bool publish_environment;
+  bool publish_markers;
+
+  pnh.param<std::string>("robot_description", robot_description, ROBOT_DESCRIPTION_PARAM);
+  pnh.param<bool>("publish_environment", publish_environment, false);
+  pnh.param<bool>("publish_markers", publish_markers, false);
+
+  // Initial setup
+  std::string urdf_xml_string, srdf_xml_string;
+  if (!nh.hasParam(robot_description))
+  {
+    ROS_ERROR("Failed to find parameter: %s", robot_description.c_str());
+    return -1;
+  }
+
+  if (!nh.hasParam(robot_description + "_semantic"))
+  {
+    ROS_ERROR("Failed to find parameter: %s", (robot_description + "_semantic").c_str());
+    return -1;
+  }
+
+  nh.getParam(robot_description, urdf_xml_string);
+  nh.getParam(robot_description + "_semantic", srdf_xml_string);
+
+  tesseract::Tesseract::Ptr tess = std::make_shared<tesseract::Tesseract>();
+  tesseract_scene_graph::ResourceLocator::Ptr locator = std::make_shared<tesseract_rosutils::ROSResourceLocator>();
+  if (!tess->init(urdf_xml_string, srdf_xml_string, locator))
+  {
+    ROS_ERROR("Failed to initialize environment.");
+    return -1;
+  }
+
+  double contact_distance;
+  pnh.param<double>("contact_distance", contact_distance, DEFAULT_CONTACT_DISTANCE);
+
+  std::vector<std::string> monitored_link_names;
+  monitored_link_names = tess->getEnvironment()->getLinkNames();
+  if (pnh.hasParam("monitor_links"))
+    pnh.getParam("monitor_links", monitored_link_names);
+
+  if (monitored_link_names.empty())
+    monitored_link_names = tess->getEnvironment()->getLinkNames();
+
+  int contact_test_type = 2;
+  if (pnh.hasParam("contact_test_type"))
+    pnh.getParam("contact_test_type", contact_test_type);
+
+  if (contact_test_type < 0 || contact_test_type > 3)
+  {
+    ROS_WARN("Request type must be 0, 1, 2 or 3. Setting to 2(ALL)!");
+    contact_test_type = 2;
+  }
+  tesseract_collision::ContactTestType type = static_cast<tesseract_collision::ContactTestType>(contact_test_type);
+
+  contact_monitor::ContactMonitor cm(tess,
+                                     nh,
+                                     pnh,
+                                     monitored_link_names,
+                                     type,
+                                     contact_distance,
+                                     publish_environment,
+                                     publish_markers);
+
+  boost::thread t (&contact_monitor::ContactMonitor::computeCollisionReportThread, &cm);
+
+  ROS_INFO("Contact Monitor Running!");
+
+  ros::spin();
+
+  return 0;
+}

--- a/tesseract_ros/tesseract_monitoring/src/contact_monitor_node.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/contact_monitor_node.cpp
@@ -40,7 +40,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_rosutils/utils.h>
 
 // Stuff for the contact monitor
-const static std::string ROBOT_DESCRIPTION_PARAM = "robot_description"; /**< Default ROS parameter for robot description */
+const static std::string ROBOT_DESCRIPTION_PARAM =
+    "robot_description"; /**< Default ROS parameter for robot description */
 const static double DEFAULT_CONTACT_DISTANCE = 0.1;
 
 int main(int argc, char** argv)
@@ -106,16 +107,10 @@ int main(int argc, char** argv)
   }
   tesseract_collision::ContactTestType type = static_cast<tesseract_collision::ContactTestType>(contact_test_type);
 
-  contact_monitor::ContactMonitor cm(tess,
-                                     nh,
-                                     pnh,
-                                     monitored_link_names,
-                                     type,
-                                     contact_distance,
-                                     publish_environment,
-                                     publish_markers);
+  contact_monitor::ContactMonitor cm(
+      tess, nh, pnh, monitored_link_names, type, contact_distance, publish_environment, publish_markers);
 
-  boost::thread t (&contact_monitor::ContactMonitor::computeCollisionReportThread, &cm);
+  boost::thread t(&contact_monitor::ContactMonitor::computeCollisionReportThread, &cm);
 
   ROS_INFO("Contact Monitor Running!");
 


### PR DESCRIPTION
Refactors the contact monitor into a library, with the executable tesseract_monitoring_contacts_node now merely instantiating it.