### PR TITLE
Add fields to OptimizationObjectiveAllocator for Tesseract environment and FK manager

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
@@ -38,7 +38,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_motion_planners
 {
 using OptimizationObjectiveAllocator =
-    std::function<ompl::base::OptimizationObjectivePtr(const ompl::base::SpaceInformationPtr&)>;
+    std::function<ompl::base::OptimizationObjectivePtr(const ompl::base::SpaceInformationPtr&,
+                                                       tesseract_environment::Environment::ConstPtr,
+                                                       tesseract_kinematics::ForwardKinematics::ConstPtr)>;
 
 struct OMPLPlannerFreespaceConfig : public OMPLPlannerConfig
 {
@@ -78,7 +80,9 @@ struct OMPLPlannerFreespaceConfig : public OMPLPlannerConfig
       std::bind(&OMPLPlannerFreespaceConfig::allocWeightedRealVectorStateSampler, this, std::placeholders::_1);
 
   /** @brief Set the optimization objective function allocator. Default is to minimize path length */
-  OptimizationObjectiveAllocator optimization_objective_allocator = [](const ompl::base::SpaceInformationPtr& si) {
+  OptimizationObjectiveAllocator optimization_objective_allocator = [](const ompl::base::SpaceInformationPtr& si,
+                                                                       tesseract_environment::Environment::ConstPtr env,
+                                                                       tesseract_kinematics::ForwardKinematics::ConstPtr kin) {
     return std::make_shared<ompl::base::PathLengthOptimizationObjective>(si);
   };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
@@ -80,11 +80,12 @@ struct OMPLPlannerFreespaceConfig : public OMPLPlannerConfig
       std::bind(&OMPLPlannerFreespaceConfig::allocWeightedRealVectorStateSampler, this, std::placeholders::_1);
 
   /** @brief Set the optimization objective function allocator. Default is to minimize path length */
-  OptimizationObjectiveAllocator optimization_objective_allocator = [](const ompl::base::SpaceInformationPtr& si,
-                                                                       tesseract_environment::Environment::ConstPtr env,
-                                                                       tesseract_kinematics::ForwardKinematics::ConstPtr kin) {
-    return std::make_shared<ompl::base::PathLengthOptimizationObjective>(si);
-  };
+  OptimizationObjectiveAllocator optimization_objective_allocator =
+      [](const ompl::base::SpaceInformationPtr& si,
+         tesseract_environment::Environment::ConstPtr env,
+         tesseract_kinematics::ForwardKinematics::ConstPtr kin) {
+        return std::make_shared<ompl::base::PathLengthOptimizationObjective>(si);
+      };
 
   /** @brief The ompl state validity checker. If nullptr it uses OMPLFreespacePlanner::isStateValid. */
   ompl::base::StateValidityCheckerFn svc;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
@@ -39,8 +39,7 @@ namespace tesseract_motion_planners
 {
 using OptimizationObjectiveAllocator =
     std::function<ompl::base::OptimizationObjectivePtr(const ompl::base::SpaceInformationPtr&,
-                                                       tesseract_environment::Environment::ConstPtr,
-                                                       tesseract_kinematics::ForwardKinematics::ConstPtr)>;
+                                                       const OMPLPlannerConfig& config)>;
 
 struct OMPLPlannerFreespaceConfig : public OMPLPlannerConfig
 {
@@ -82,8 +81,7 @@ struct OMPLPlannerFreespaceConfig : public OMPLPlannerConfig
   /** @brief Set the optimization objective function allocator. Default is to minimize path length */
   OptimizationObjectiveAllocator optimization_objective_allocator =
       [](const ompl::base::SpaceInformationPtr& si,
-         tesseract_environment::Environment::ConstPtr env,
-         tesseract_kinematics::ForwardKinematics::ConstPtr kin) {
+         const OMPLPlannerConfig& config) {
         return std::make_shared<ompl::base::PathLengthOptimizationObjective>(si);
       };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/config/ompl_planner_freespace_config.h
@@ -79,11 +79,10 @@ struct OMPLPlannerFreespaceConfig : public OMPLPlannerConfig
       std::bind(&OMPLPlannerFreespaceConfig::allocWeightedRealVectorStateSampler, this, std::placeholders::_1);
 
   /** @brief Set the optimization objective function allocator. Default is to minimize path length */
-  OptimizationObjectiveAllocator optimization_objective_allocator =
-      [](const ompl::base::SpaceInformationPtr& si,
-         const OMPLPlannerConfig& config) {
-        return std::make_shared<ompl::base::PathLengthOptimizationObjective>(si);
-      };
+  OptimizationObjectiveAllocator optimization_objective_allocator = [](const ompl::base::SpaceInformationPtr& si,
+                                                                       const OMPLPlannerConfig& /*config*/) {
+    return std::make_shared<ompl::base::PathLengthOptimizationObjective>(si);
+  };
 
   /** @brief The ompl state validity checker. If nullptr it uses OMPLFreespacePlanner::isStateValid. */
   ompl::base::StateValidityCheckerFn svc;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/config/ompl_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/config/ompl_planner_freespace_config.cpp
@@ -238,7 +238,7 @@ bool OMPLPlannerFreespaceConfig::generate()
   if (optimization_objective_allocator)
   {
     simple_setup->getProblemDefinition()->setOptimizationObjective(
-        optimization_objective_allocator(simple_setup->getSpaceInformation()));
+        optimization_objective_allocator(simple_setup->getSpaceInformation(), env, kin));
   }
 
   return true;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/config/ompl_planner_freespace_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/config/ompl_planner_freespace_config.cpp
@@ -238,7 +238,7 @@ bool OMPLPlannerFreespaceConfig::generate()
   if (optimization_objective_allocator)
   {
     simple_setup->getProblemDefinition()->setOptimizationObjective(
-        optimization_objective_allocator(simple_setup->getSpaceInformation(), env, kin));
+        optimization_objective_allocator(simple_setup->getSpaceInformation(), *this));
   }
 
   return true;


### PR DESCRIPTION
This allows the use of custom optimization objective functions that evaluate costs based on the Tesseract collision environment.

Is there a more flexible way to do this so the scope of what can be used in an objective function isn't limited to the arguments of the function allocator defined here?

e: Based on talking to @Levi-Armstrong it would probably be best to just pass in the planner config object.