### PR TITLE
Set SWIG Python version based on ROS_PYTHON_VERSION

### DIFF
--- a/tesseract_python/tesseract_python/CMakeLists.txt
+++ b/tesseract_python/tesseract_python/CMakeLists.txt
@@ -27,7 +27,9 @@ find_package(tesseract_visualization REQUIRED)
 find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
 find_package(trajopt REQUIRED)
 
-find_package(PythonInterp REQUIRED)
+set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
+
+find_package(PythonInterp ${ROS_PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs REQUIRED)
 
 # Find NumPy


### PR DESCRIPTION
Partially addresses #238 . The correct version of Python 3 is now found in ROS 2. However tesseract_python still does not build because of tessseract_ros. Breaking that out will be handled in a future PR. Hopefully this will preemptively fix Noetic assuming they set that variable.