### PR TITLE
Adding contact monitor library to catkin package

### DIFF
--- a/tesseract_ros/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_ros/tesseract_monitoring/CMakeLists.txt
@@ -26,6 +26,7 @@ catkin_package(
     include
   LIBRARIES
     ${PROJECT_NAME}_environment
+    ${PROJECT_NAME}_contacts
   CATKIN_DEPENDS
     roscpp
     tesseract_msgs


### PR DESCRIPTION
Missed a line that needed to be added to the CMakeLists.txt in order to expose the library to other ROS packages.