### PR TITLE
Feature/create multi chain

### DIFF
--- a/tesseract/tesseract/src/tesseract.cpp
+++ b/tesseract/tesseract/src/tesseract.cpp
@@ -288,9 +288,8 @@ bool Tesseract::registerDefaultFwdKinSolvers()
   {
     if (!group.chains_.empty())
     {
-      assert(group.chains_.size() == 1);
-      tesseract_kinematics::ForwardKinematics::Ptr solver = chain_factory->create(
-          environment_->getSceneGraph(), group.chains_.front().first, group.chains_.front().second, group.name_);
+      tesseract_kinematics::ForwardKinematics::Ptr solver =
+          chain_factory->create(environment_->getSceneGraph(), group.chains_, group.name_);
       if (solver != nullptr)
       {
         if (!fwd_kin_manager_->addFwdKinematicSolver(solver))
@@ -365,9 +364,8 @@ bool Tesseract::registerDefaultInvKinSolvers()
   {
     if (!group.chains_.empty())
     {
-      assert(group.chains_.size() == 1);
-      tesseract_kinematics::InverseKinematics::Ptr solver = factory->create(
-          environment_->getSceneGraph(), group.chains_.front().first, group.chains_.front().second, group.name_);
+      tesseract_kinematics::InverseKinematics::Ptr solver =
+          factory->create(environment_->getSceneGraph(), group.chains_, group.name_);
       if (solver != nullptr)
       {
         if (!inv_kin_manager_->addInvKinematicSolver(solver))

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/core/forward_kinematics_factory.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/core/forward_kinematics_factory.h
@@ -81,6 +81,23 @@ public:
   }
 
   /**
+   * @brief Create Forward Kinematics Chain Object
+   * This only need to be implemented if of type chain
+   * @param scene_graph The Tesseract Scene Graph
+   * @param chains The chains that make up the kinematic chain
+   * @param name The name of the kinematic chain
+   * @return True if init() completes successfully
+   */
+  virtual ForwardKinematics::Ptr create(tesseract_scene_graph::SceneGraph::ConstPtr /*scene_graph*/,         // NOLINT
+                                        const std::vector<std::pair<std::string, std::string>>& /*chains*/,  // NOLINT
+                                                                                                             // //
+                                                                                                             // NOLINT
+                                        const std::string /*name*/) const                                    // NOLINT
+  {
+    return nullptr;
+  }
+
+  /**
    * @brief Create Forward Kinematics Tree Object
    * This only need to be implemented if of type chain
    * @param scene_graph The tesseract scene graph

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain.h
@@ -114,6 +114,18 @@ public:
             std::string name);
 
   /**
+   * @brief Initializes Forward Kinematics as chain
+   * Creates a forward kinematic chain object from sequential chains
+   * @param scene_graph The Tesseract Scene Graph
+   * @param chains A vector of kinematics chains <base_link, tip_link> that get concatenated
+   * @param name The name of the kinematic chain
+   * @return True if init() completes successfully
+   */
+  bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+            const std::vector<std::pair<std::string, std::string> >& chains,
+            std::string name);
+
+  /**
    * @brief Checks if kinematics has been initialized
    * @return True if init() has completed successfully
    */

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain_factory.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain_factory.h
@@ -51,6 +51,17 @@ public:
     return kin;
   }
 
+  virtual ForwardKinematics::Ptr create(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                                        const std::vector<std::pair<std::string, std::string>>& chains,  // NOLINT
+                                        const std::string name) const
+  {
+    auto kin = std::make_shared<KDLFwdKinChain>();
+    if (!kin->init(scene_graph, chains, name))
+      return nullptr;
+
+    return kin;
+  }
+
 private:
   std::string name_;
 };

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h
@@ -100,6 +100,19 @@ public:
             const std::string& base_link,
             const std::string& tip_link,
             std::string name);
+
+  /**
+   * @brief Initializes Inverse Kinematics as chain
+   * Creates a inverse kinematic chain object from sequential chains
+   * @param scene_graph The Tesseract Scene Graph
+   * @param chains A vector of kinematics chains <base_link, tip_link> that get concatenated
+   * @param name The name of the kinematic chain
+   * @return True if init() completes successfully
+   */
+  bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+            const std::vector<std::pair<std::string, std::string> >& chains,
+            std::string name);
+
   /**
    * @brief Checks if kinematics has been initialized
    * @return True if init() has completed successfully

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma_factory.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma_factory.h
@@ -51,6 +51,17 @@ public:
     return kin;
   }
 
+  InverseKinematics::Ptr create(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                                const std::vector<std::pair<std::string, std::string>>& chains,  // NOLINT
+                                const std::string name) const
+  {
+    auto kin = std::make_shared<KDLInvKinChainLMA>();
+    if (!kin->init(scene_graph, chains, name))
+      return nullptr;
+
+    return kin;
+  }
+
 private:
   std::string name_;
 };

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr.h
@@ -104,6 +104,18 @@ public:
             const std::string& name);
 
   /**
+   * @brief Initializes Inverse Kinematics as chain
+   * Creates a inverse kinematic chain object from sequential chains
+   * @param scene_graph The Tesseract Scene Graph
+   * @param chains A vector of kinematics chains <base_link, tip_link> that get concatenated
+   * @param name The name of the kinematic chain
+   * @return True if init() completes successfully
+   */
+  bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+            const std::vector<std::pair<std::string, std::string> >& chains,
+            std::string name);
+
+  /**
    * @brief Checks if kinematics has been initialized
    * @return True if init() has completed successfully
    */

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr_factory.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr_factory.h
@@ -51,6 +51,17 @@ public:
     return kin;
   }
 
+  InverseKinematics::Ptr create(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                                const std::vector<std::pair<std::string, std::string>>& chains,  // NOLINT
+                                const std::string name) const
+  {
+    auto kin = std::make_shared<KDLInvKinChainNR>();
+    if (!kin->init(scene_graph, chains, name))
+      return nullptr;
+
+    return kin;
+  }
+
 private:
   std::string name_;
 };

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_utils.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_utils.h
@@ -148,36 +148,40 @@ struct KDLChainData
   std::vector<std::string> active_link_list; /**< List of link names that move with changes in joint values */
   Eigen::MatrixX2d joint_limits;             /**< Joint limits */
   std::map<std::string, int> segment_index;  /**< A map from chain link name to kdl chain segment number */
+  std::vector<std::pair<std::string, std::string>> chains; /**< The chains used to create the object */
 };
 
 /**
  * @brief Parse KDL chain data from the scene graph
  * @param results KDL Chain data
  * @param scene_graph The Scene Graph
- * @param base_name The base link name of chain
- * @param tip_name The tip link name of chain
+ * @param chains A vector of link pairs that represent a chain which all get concatenated together
  * @return True if successful otherwise false
  */
 inline bool parseSceneGraph(KDLChainData& results,
                             const tesseract_scene_graph::SceneGraph& scene_graph,
-                            const std::string& base_name,
-                            const std::string& tip_name)
+                            const std::vector<std::pair<std::string, std::string>>& chains)
 {
-  results.base_name = base_name;
-  results.tip_name = tip_name;
-
   if (!tesseract_scene_graph::parseSceneGraph(scene_graph, results.kdl_tree))
   {
     CONSOLE_BRIDGE_logError("Failed to parse KDL tree from Scene Graph");
     return false;
   }
 
-  if (!results.kdl_tree.getChain(results.base_name, results.tip_name, results.robot_chain))
+  results.chains = chains;
+  results.base_name = chains.front().first;
+  for (const auto& chain : chains)
   {
-    CONSOLE_BRIDGE_logError(
-        "Failed to initialize KDL between links: '%s' and '%s'", results.base_name.c_str(), results.tip_name.c_str());
-    return false;
+    KDL::Chain sub_chain;
+    if (!results.kdl_tree.getChain(chain.first, chain.second, sub_chain))
+    {
+      CONSOLE_BRIDGE_logError(
+          "Failed to initialize KDL between links: '%s' and '%s'", chain.first.c_str(), chain.second.c_str());
+      return false;
+    }
+    results.robot_chain.addChain(sub_chain);
   }
+  results.tip_name = chains.back().second;
 
   results.joint_list.resize(results.robot_chain.getNrOfJoints());
   results.joint_limits.resize(results.robot_chain.getNrOfJoints(), 2);
@@ -227,6 +231,24 @@ inline bool parseSceneGraph(KDLChainData& results,
   }
 
   return true;
+}
+
+/**
+ * @brief Parse KDL chain data from the scene graph
+ * @param results KDL Chain data
+ * @param scene_graph The Scene Graph
+ * @param base_name The base link name of chain
+ * @param tip_name The tip link name of chain
+ * @return True if successful otherwise false
+ */
+inline bool parseSceneGraph(KDLChainData& results,
+                            const tesseract_scene_graph::SceneGraph& scene_graph,
+                            const std::string& base_name,
+                            const std::string& tip_name)
+{
+  std::vector<std::pair<std::string, std::string>> chains;
+  chains.emplace_back(base_name, tip_name);
+  return parseSceneGraph(results, scene_graph, chains);
 }
 }  // namespace tesseract_kinematics
 #endif  // TESSERACT_KINEMATICS_KDL_UTILS_H

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_chain.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_chain.cpp
@@ -224,8 +224,7 @@ const std::vector<std::string>& KDLFwdKinChain::getActiveLinkNames() const
 const Eigen::MatrixX2d& KDLFwdKinChain::getLimits() const { return kdl_data_.joint_limits; }
 
 bool KDLFwdKinChain::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
-                          const std::string& base_link,
-                          const std::string& tip_link,
+                          const std::vector<std::pair<std::string, std::string>>& chains,
                           std::string name)
 {
   initialized_ = false;
@@ -245,7 +244,7 @@ bool KDLFwdKinChain::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_grap
     return false;
   }
 
-  if (!parseSceneGraph(kdl_data_, *scene_graph_, base_link, tip_link))
+  if (!parseSceneGraph(kdl_data_, *scene_graph_, chains))
   {
     CONSOLE_BRIDGE_logError("Failed to parse KDL data from Scene Graph");
     return false;
@@ -256,6 +255,16 @@ bool KDLFwdKinChain::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_grap
 
   initialized_ = true;
   return initialized_;
+}
+
+bool KDLFwdKinChain::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                          const std::string& base_link,
+                          const std::string& tip_link,
+                          std::string name)
+{
+  std::vector<std::pair<std::string, std::string>> chains;
+  chains.push_back(std::make_pair(base_link, tip_link));
+  return init(scene_graph, chains, name);
 }
 
 bool KDLFwdKinChain::init(const KDLFwdKinChain& kin)

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_lma.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_lma.cpp
@@ -153,8 +153,7 @@ const std::vector<std::string>& KDLInvKinChainLMA::getActiveLinkNames() const
 const Eigen::MatrixX2d& KDLInvKinChainLMA::getLimits() const { return kdl_data_.joint_limits; }
 
 bool KDLInvKinChainLMA::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
-                             const std::string& base_link,
-                             const std::string& tip_link,
+                             const std::vector<std::pair<std::string, std::string>>& chains,
                              std::string name)
 {
   initialized_ = false;
@@ -174,7 +173,7 @@ bool KDLInvKinChainLMA::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_g
     return false;
   }
 
-  if (!parseSceneGraph(kdl_data_, *scene_graph_, base_link, tip_link))
+  if (!parseSceneGraph(kdl_data_, *scene_graph_, chains))
   {
     CONSOLE_BRIDGE_logError("Failed to parse KDL data from Scene Graph");
     return false;
@@ -184,6 +183,16 @@ bool KDLInvKinChainLMA::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_g
 
   initialized_ = true;
   return initialized_;
+}
+
+bool KDLInvKinChainLMA::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                             const std::string& base_link,
+                             const std::string& tip_link,
+                             std::string name)
+{
+  std::vector<std::pair<std::string, std::string>> chains;
+  chains.push_back(std::make_pair(base_link, tip_link));
+  return init(scene_graph, chains, name);
 }
 
 bool KDLInvKinChainLMA::init(const KDLInvKinChainLMA& kin)

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_nr.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_nr.cpp
@@ -159,10 +159,9 @@ const std::vector<std::string>& KDLInvKinChainNR::getActiveLinkNames() const
 
 const Eigen::MatrixX2d& KDLInvKinChainNR::getLimits() const { return kdl_data_.joint_limits; }
 
-bool KDLInvKinChainNR::init(const tesseract_scene_graph::SceneGraph::ConstPtr& scene_graph,
-                            const std::string& base_link,
-                            const std::string& tip_link,
-                            const std::string& name)
+bool KDLInvKinChainNR::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                            const std::vector<std::pair<std::string, std::string>>& chains,
+                            std::string name)
 {
   initialized_ = false;
 
@@ -181,7 +180,7 @@ bool KDLInvKinChainNR::init(const tesseract_scene_graph::SceneGraph::ConstPtr& s
     return false;
   }
 
-  if (!parseSceneGraph(kdl_data_, *scene_graph_, base_link, tip_link))
+  if (!parseSceneGraph(kdl_data_, *scene_graph_, chains))
   {
     CONSOLE_BRIDGE_logError("Failed to parse KDL data from Scene Graph");
     return false;
@@ -193,6 +192,16 @@ bool KDLInvKinChainNR::init(const tesseract_scene_graph::SceneGraph::ConstPtr& s
 
   initialized_ = true;
   return initialized_;
+}
+
+bool KDLInvKinChainNR::init(const tesseract_scene_graph::SceneGraph::ConstPtr& scene_graph,
+                            const std::string& base_link,
+                            const std::string& tip_link,
+                            const std::string& name)
+{
+  std::vector<std::pair<std::string, std::string>> chains;
+  chains.push_back(std::make_pair(base_link, tip_link));
+  return init(scene_graph, chains, name);
 }
 
 bool KDLInvKinChainNR::init(const KDLInvKinChainNR& kin)


### PR DESCRIPTION
The PR adds the ability to construct a kinematic chain from a series of kinematic chains. This is useful in the situation where you have multiple tools that get changed out throughout the process you can create a kinematic chain for each providing a chain for the robot and a chain for the tool.