### PR TITLE
Add lcov to package.xml

### DIFF
--- a/tesseract/tesseract_common/package.xml
+++ b/tesseract/tesseract_common/package.xml
@@ -11,6 +11,7 @@
   <build_export_depend>eigen</build_export_depend>
 
   <test_depend>gtest</test_depend>
+  <test_depend>lcov</test_depend>
   <test_depend>libclang-dev</test_depend>
 
   <export>


### PR DESCRIPTION
Adding lcov similar to how we add clang. I got the error `lcov not found! Aborting...`  when I ran it without lcov. 

Rosdep key is lcov:https://github.com/ros/rosdistro/blob/5287b527aa3831decf1b34e26f6b8ca354a1307c/rosdep/base.yaml#L1482