### PR TITLE
WIP: Switch to using type erasure for forward kinematics

### DIFF
--- a/tesseract/tesseract/include/tesseract/forward_kinematics_manager.h
+++ b/tesseract/tesseract/include/tesseract/forward_kinematics_manager.h
@@ -183,7 +183,7 @@ public:
   {
     auto it = fwd_kin_manipulators_.find(std::make_pair(manipulator, name));
     if (it != fwd_kin_manipulators_.end())
-      return it->second->clone();
+      return std::make_shared<tesseract_kinematics::ForwardKinematics>(*(it->second));
 
     return nullptr;
   }
@@ -197,7 +197,7 @@ public:
   {
     auto it = fwd_kin_manipulators_default_.find(manipulator);
     if (it != fwd_kin_manipulators_default_.end())
-      return it->second->clone();
+      return std::make_shared<tesseract_kinematics::ForwardKinematics>(*(it->second));
 
     return nullptr;
   }

--- a/tesseract/tesseract_common/include/tesseract_common/macros.h
+++ b/tesseract/tesseract_common/include/tesseract_common/macros.h
@@ -34,7 +34,8 @@
               _Pragma("GCC diagnostic ignored \"-Wsuggest-override\"")                                                 \
                   _Pragma("GCC diagnostic ignored \"-Wconversion\"")                                                   \
                       _Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"")                                         \
-                          _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+                          _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")                                      \
+                              _Pragma("GCC diagnostic ignored \"-Wreturn-type\"")
 
 #define TESSERACT_COMMON_IGNORE_WARNINGS_POP _Pragma("GCC diagnostic pop")
 

--- a/tesseract/tesseract_common/include/tesseract_common/types.h
+++ b/tesseract/tesseract_common/include/tesseract_common/types.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <map>
 #include <unordered_map>
+#include <type_traits>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_common

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain_factory.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain_factory.h
@@ -44,22 +44,14 @@ public:
                                 const std::string& tip_link,
                                 const std::string name) const override
   {
-    auto kin = std::make_shared<KDLFwdKinChain>();
-    if (!kin->init(scene_graph, base_link, tip_link, name))
-      return nullptr;
-
-    return kin;
+    return std::make_shared<ForwardKinematics>(KDLFwdKinChain(scene_graph, base_link, tip_link, name));
   }
 
   virtual ForwardKinematics::Ptr create(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
                                         const std::vector<std::pair<std::string, std::string>>& chains,  // NOLINT
                                         const std::string name) const
   {
-    auto kin = std::make_shared<KDLFwdKinChain>();
-    if (!kin->init(scene_graph, chains, name))
-      return nullptr;
-
-    return kin;
+    return std::make_shared<ForwardKinematics>(KDLFwdKinChain(scene_graph, chains, name));
   }
 
 private:

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_tree_factory.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/kdl/kdl_fwd_kin_tree_factory.h
@@ -45,11 +45,7 @@ public:
          const std::string name,
          std::unordered_map<std::string, double> start_state = std::unordered_map<std::string, double>()) const override
   {
-    auto kin = std::make_shared<KDLFwdKinTree>();
-    if (!kin->init(scene_graph, joint_names, name, start_state))
-      return nullptr;
-
-    return kin;
+    return std::make_shared<ForwardKinematics>(KDLFwdKinTree(scene_graph, joint_names, name, start_state));
   }
 
 private:

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_tree.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_tree.cpp
@@ -37,11 +37,50 @@ namespace tesseract_kinematics
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
-ForwardKinematics::Ptr KDLFwdKinTree::clone() const
+KDLFwdKinTree::KDLFwdKinTree(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
+                             const std::vector<std::string>& joint_names,
+                             std::string name,
+                             const std::unordered_map<std::string, double>& start_state)
 {
-  auto cloned_fwdkin = std::make_shared<KDLFwdKinTree>();
-  cloned_fwdkin->init(*this);
-  return std::move(cloned_fwdkin);
+  init(scene_graph, joint_names, name, start_state);
+}
+
+KDLFwdKinTree::KDLFwdKinTree(const KDLFwdKinTree& kin)
+{
+  initialized_ = kin.initialized_;
+  name_ = kin.name_;
+  solver_name_ = kin.solver_name_;
+  kdl_tree_ = kin.kdl_tree_;
+  joint_limits_ = kin.joint_limits_;
+  joint_list_ = kin.joint_list_;
+  link_list_ = kin.link_list_;
+  active_link_list_ = kin.active_link_list_;
+  fk_solver_ = std::make_unique<KDL::TreeFkSolverPos_recursive>(kdl_tree_);
+  jac_solver_ = std::make_unique<KDL::TreeJntToJacSolver>(kdl_tree_);
+  scene_graph_ = kin.scene_graph_;
+  start_state_ = kin.start_state_;
+  joint_qnr_ = kin.joint_qnr_;
+  joint_to_qnr_ = kin.joint_to_qnr_;
+}
+
+KDLFwdKinTree& KDLFwdKinTree::operator=(const KDLFwdKinTree& kin)
+{
+  initialized_ = kin.initialized_;
+  name_ = kin.name_;
+  solver_name_ = kin.solver_name_;
+  kdl_tree_ = kin.kdl_tree_;
+  joint_limits_ = kin.joint_limits_;
+  joint_list_ = kin.joint_list_;
+  link_list_ = kin.link_list_;
+  active_link_list_ = kin.active_link_list_;
+  fk_solver_ = std::make_unique<KDL::TreeFkSolverPos_recursive>(kdl_tree_);
+  jac_solver_ = std::make_unique<KDL::TreeJntToJacSolver>(kdl_tree_);
+  scene_graph_ = kin.scene_graph_;
+  start_state_ = kin.start_state_;
+  joint_qnr_ = kin.joint_qnr_;
+  joint_to_qnr_ = kin.joint_to_qnr_;
+
+  return (*this);
 }
 
 KDL::JntArray KDLFwdKinTree::getKDLJntArray(const std::vector<std::string>& joint_names,
@@ -310,26 +349,6 @@ bool KDLFwdKinTree::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph
 
   initialized_ = true;
   return initialized_;
-}
-
-bool KDLFwdKinTree::init(const KDLFwdKinTree& kin)
-{
-  initialized_ = kin.initialized_;
-  name_ = kin.name_;
-  solver_name_ = kin.solver_name_;
-  kdl_tree_ = kin.kdl_tree_;
-  joint_limits_ = kin.joint_limits_;
-  joint_list_ = kin.joint_list_;
-  link_list_ = kin.link_list_;
-  active_link_list_ = kin.active_link_list_;
-  fk_solver_ = std::make_unique<KDL::TreeFkSolverPos_recursive>(kdl_tree_);
-  jac_solver_ = std::make_unique<KDL::TreeJntToJacSolver>(kdl_tree_);
-  scene_graph_ = kin.scene_graph_;
-  start_state_ = kin.start_state_;
-  joint_qnr_ = kin.joint_qnr_;
-  joint_to_qnr_ = kin.joint_to_qnr_;
-
-  return true;
 }
 
 }  // namespace tesseract_kinematics

--- a/tesseract/tesseract_kinematics/test/kdl_kinematics_unit.cpp
+++ b/tesseract/tesseract_kinematics/test/kdl_kinematics_unit.cpp
@@ -5,6 +5,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_urdf/urdf_parser.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_kinematics/core/forward_kinematics.h>
 #include "tesseract_kinematics/kdl/kdl_fwd_kin_chain.h"
 #include "tesseract_kinematics/kdl/kdl_fwd_kin_tree.h"
 #include "tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h"
@@ -363,11 +364,15 @@ void runInvKinTest(const tesseract_kinematics::InverseKinematics& inv_kin,
 
 TEST(TesseractKinematicsUnit, KDLKinChainActiveLinkNamesUnit)  // NOLINT
 {
-  tesseract_kinematics::KDLFwdKinChain kin;
   tesseract_scene_graph::SceneGraph::Ptr scene_graph = getSceneGraph();
-  EXPECT_TRUE(kin.init(scene_graph, "base_link", "tool0", "manip"));
-
-  runActiveLinkNamesTest(kin, false);
+  tesseract_kinematics::KDLFwdKinChain kin(scene_graph, "base_link", "tool0", "manip");
+  tesseract_kinematics::ForwardKinematics fwd_kin1 = kin;
+  tesseract_kinematics::ForwardKinematics fwd_kin2(
+      tesseract_kinematics::KDLFwdKinChain(scene_graph, "base_link", "tool0", "manip"));
+  tesseract_kinematics::ForwardKinematics fwd_kin3(fwd_kin2);
+  runActiveLinkNamesTest(fwd_kin1, false);
+  runActiveLinkNamesTest(fwd_kin2, false);
+  runActiveLinkNamesTest(fwd_kin3, false);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinTreeActiveLinkNamesUnit)  // NOLINT
@@ -388,21 +393,28 @@ TEST(TesseractKinematicsUnit, KDLKinTreeActiveLinkNamesUnit)  // NOLINT
 
   EXPECT_TRUE(kin.init(scene_graph, joint_names, "manip", start_state));
 
-  runActiveLinkNamesTest(kin, true);
+  tesseract_kinematics::ForwardKinematics fwd_kin = kin;
+  runActiveLinkNamesTest(fwd_kin, true);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinChainForwardKinematicUnit)  // NOLINT
 {
-  tesseract_kinematics::KDLFwdKinChain kin;
   tesseract_scene_graph::SceneGraph::Ptr scene_graph = getSceneGraph();
-  EXPECT_TRUE(kin.init(scene_graph, "base_link", "tool0", "manip"));
+  tesseract_kinematics::KDLFwdKinChain kin(scene_graph, "base_link", "tool0", "manip");
+  tesseract_kinematics::ForwardKinematics fwd_kin1 = kin;
+  tesseract_kinematics::ForwardKinematics fwd_kin2(
+      tesseract_kinematics::KDLFwdKinChain(scene_graph, "base_link", "tool0", "manip"));
+  tesseract_kinematics::ForwardKinematics fwd_kin3(kin);
+  tesseract_kinematics::ForwardKinematics fwd_kin4(fwd_kin2);
 
-  runFwdKinTest(kin);
+  runFwdKinTest(fwd_kin1);
+  runFwdKinTest(fwd_kin2);
+  runFwdKinTest(fwd_kin3);
+  runFwdKinTest(fwd_kin4);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinTreeForwardKinematicUnit)  // NOLINT
 {
-  tesseract_kinematics::KDLFwdKinTree kin;
   tesseract_scene_graph::SceneGraph::Ptr scene_graph = getSceneGraph();
   std::vector<std::string> joint_names = { "joint_a1", "joint_a2", "joint_a3", "joint_a4",
                                            "joint_a5", "joint_a6", "joint_a7" };
@@ -416,9 +428,17 @@ TEST(TesseractKinematicsUnit, KDLKinTreeForwardKinematicUnit)  // NOLINT
   start_state["joint_a6"] = 0;
   start_state["joint_a7"] = 0;
 
-  EXPECT_TRUE(kin.init(scene_graph, joint_names, "manip", start_state));
+  tesseract_kinematics::KDLFwdKinTree kin(scene_graph, joint_names, "manip", start_state);
+  tesseract_kinematics::ForwardKinematics fwd_kin1 = kin;
+  tesseract_kinematics::ForwardKinematics fwd_kin2(
+      tesseract_kinematics::KDLFwdKinTree(scene_graph, joint_names, "manip", start_state));
+  tesseract_kinematics::ForwardKinematics fwd_kin3(kin);
+  tesseract_kinematics::ForwardKinematics fwd_kin4(fwd_kin2);
 
-  runFwdKinTest(kin);
+  runFwdKinTest(fwd_kin1);
+  runFwdKinTest(fwd_kin2);
+  runFwdKinTest(fwd_kin3);
+  runFwdKinTest(fwd_kin4);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinChainJacobianUnit)  // NOLINT
@@ -427,7 +447,8 @@ TEST(TesseractKinematicsUnit, KDLKinChainJacobianUnit)  // NOLINT
   tesseract_scene_graph::SceneGraph::Ptr scene_graph = getSceneGraph();
   EXPECT_TRUE(kin.init(scene_graph, "base_link", "tool0", "manip"));
 
-  runJacobianTest(kin);
+  tesseract_kinematics::ForwardKinematics fwd_kin = kin;
+  runJacobianTest(fwd_kin);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinTreeJacobianUnit)  // NOLINT
@@ -448,7 +469,8 @@ TEST(TesseractKinematicsUnit, KDLKinTreeJacobianUnit)  // NOLINT
 
   EXPECT_TRUE(kin.init(scene_graph, joint_names, "manip", start_state));
 
-  runJacobianTest(kin);
+  tesseract_kinematics::ForwardKinematics fwd_kin = kin;
+  runJacobianTest(fwd_kin);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinChainLMAInverseKinematicUnit)  // NOLINT
@@ -459,7 +481,8 @@ TEST(TesseractKinematicsUnit, KDLKinChainLMAInverseKinematicUnit)  // NOLINT
   EXPECT_TRUE(inv_kin.init(scene_graph, "base_link", "tool0", "manip"));
   EXPECT_TRUE(fwd_kin.init(scene_graph, "base_link", "tool0", "manip"));
 
-  runInvKinTest(inv_kin, fwd_kin);
+  tesseract_kinematics::ForwardKinematics fkin = fwd_kin;
+  runInvKinTest(inv_kin, fkin);
 }
 
 TEST(TesseractKinematicsUnit, KDLKinChainNRInverseKinematicUnit)  // NOLINT
@@ -470,7 +493,8 @@ TEST(TesseractKinematicsUnit, KDLKinChainNRInverseKinematicUnit)  // NOLINT
   EXPECT_TRUE(inv_kin.init(scene_graph, "base_link", "tool0", "manip"));
   EXPECT_TRUE(fwd_kin.init(scene_graph, "base_link", "tool0", "manip"));
 
-  runInvKinTest(inv_kin, fwd_kin);
+  tesseract_kinematics::ForwardKinematics fkin = fwd_kin;
+  runInvKinTest(inv_kin, fkin);
 }
 
 int main(int argc, char** argv)

--- a/tesseract_python/tesseract_python/CMakeLists.txt
+++ b/tesseract_python/tesseract_python/CMakeLists.txt
@@ -13,7 +13,7 @@ MESSAGE(STATUS "tesseract_python version: ${tesseract_python_version}")
 
 if (NOT MSVC)
   #add_compile_options(-std=c++11 -Wall -Wextra -Wno-write-strings -Wno-unused-paramete -Wno-suggest-override)
-  add_compile_options(-std=c++11 -w)
+  add_compile_options(-std=c++14 -w)
 else()
   add_compile_options(/bigobj)
 endif()


### PR DESCRIPTION
We have been discussing for a while to switch to suing Type Erasure for interface within Tesseract. I have an initial pass for the Forward kinematics and I wanted to get this up sooner to begin discussion.