### PR TITLE
Minor fixes for Descartes

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -87,7 +87,7 @@ bool DescartesMotionPlanner<FloatType>::setConfiguration(const DescartesMotionPl
 
   if (config.samplers.empty())
   {
-    CONSOLE_BRIDGE_logError("In %s: waypoints is a required parameter and has not been set", name_.c_str());
+    CONSOLE_BRIDGE_logError("In %s: samplers is a required parameter and has not been set", name_.c_str());
     return false;
   }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/hybrid/descartes_trajopt_array_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/hybrid/descartes_trajopt_array_planner.cpp
@@ -130,4 +130,8 @@ bool DescartesTrajOptArrayPlanner<FloatType>::setConfiguration(
 
   return success;
 }
+
+template class DescartesTrajOptArrayPlanner<double>;
+template class DescartesTrajOptArrayPlanner<float>;
+
 }  // namespace tesseract_motion_planners


### PR DESCRIPTION
This PR addresses two small issues I encountered when playing with Descartes and the Descartes TrajOpt hybrid planner:
- One error message is wrong, which lead to some head scratching. It talks about waypoints size, but is really related to the sampler size.
- The templated hybrid planner is never instantiated and is defined in a CPP, so attempting to use it results in undefined symbols. Just added two explicit instantiations to fix that issue.