### PR TITLE
Changes to tesseract_collision ContactTestData structure

### DIFF
--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -383,8 +383,8 @@ inline btScalar addDiscreteSingleResult(btManifoldPoint& cp,
 
   ObjectPairKey pc = getObjectPairKey(cd0->getName(), cd1->getName());
 
-  const auto& it = collisions.res.find(pc);
-  bool found = (it != collisions.res.end());
+  const auto& it = collisions.res->find(pc);
+  bool found = (it != collisions.res->end());
 
   //    size_t l = 0;
   //    if (found)
@@ -522,8 +522,8 @@ inline btScalar addCastSingleResult(btManifoldPoint& cp,
                                                       std::make_pair(cd0->getName(), cd1->getName()) :
                                                       std::make_pair(cd1->getName(), cd0->getName());
 
-  auto it = collisions.res.find(pc);
-  bool found = it != collisions.res.end();
+  auto it = collisions.res->find(pc);
+  bool found = it != collisions.res->end();
 
   //    size_t l = 0;
   //    if (found)

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/common.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/common.h
@@ -122,11 +122,11 @@ inline ContactResult* processResult(ContactTestData& cdata,
       data.emplace_back(contact);
     }
 
-    return &(cdata.res.insert(std::make_pair(key, data)).first->second.back());
+    return &(cdata.res->insert(std::make_pair(key, data)).first->second.back());
   }
 
   assert(cdata.type != ContactTestType::FIRST);
-  ContactResultVector& dr = cdata.res[key];
+  ContactResultVector& dr = (*cdata.res)[key];
   if (cdata.type == ContactTestType::ALL)
   {
     dr.emplace_back(contact);

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
@@ -161,30 +161,41 @@ inline std::size_t flattenResults(ContactResultMap&& m, ContactResultVector& v)
   return flattenMoveResults(std::move(m), v);
 }
 
-/// Contact test data and query results information
+/**
+ * @brief This data is intended only to be used internal to the collision checkers as a container and should not
+ *        be externally used by other libraries or packages.
+ */
 struct ContactTestData
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  ContactTestData() = default;
   ContactTestData(const std::vector<std::string>& active,
-                  const double& contact_distance,
-                  const IsContactAllowedFn& fn,
-                  const ContactTestType& type,
+                  double contact_distance,
+                  IsContactAllowedFn fn,
+                  ContactTestType type,
                   ContactResultMap& res)
-    : active(active), contact_distance(contact_distance), fn(fn), type(type), res(res), done(false)
+    : active(&active), contact_distance(contact_distance), fn(std::move(fn)), type(type), res(&res)
   {
   }
 
-  const std::vector<std::string>& active;
-  const double& contact_distance;
-  const IsContactAllowedFn& fn;
-  const ContactTestType& type;
+  /** @brief A vector of active links */
+  const std::vector<std::string>* active{ nullptr };
 
-  /// Destance query results information
-  ContactResultMap& res;
+  /** @brief The current contact_distance threshold */
+  double contact_distance{ 0 };
 
-  /// Indicate if search is finished
-  bool done;
+  /** @brief The allowed collision function used to check if two links should be excluded from collision checking */
+  IsContactAllowedFn fn{ nullptr };
+
+  /** @brief The type of contact test to perform */
+  ContactTestType type{ ContactTestType::ALL };
+
+  /** @brief Destance query results information */
+  ContactResultMap* res{ nullptr };
+
+  /** @brief Indicate if search is finished */
+  bool done{ false };
 };
 }  // namespace tesseract_collision
 

--- a/tesseract/tesseract_collision/src/fcl/fcl_utils.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_utils.cpp
@@ -215,8 +215,8 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
       cd1->m_enabled && cd2->m_enabled && (cd1->m_collisionFilterGroup & cd2->m_collisionFilterMask) &&
       (cd2->m_collisionFilterGroup & cd1->m_collisionFilterMask) &&
       !isContactAllowed(cd1->getName(), cd2->getName(), cdata->fn, false) &&
-      (std::find(cdata->active.begin(), cdata->active.end(), cd1->getName()) != cdata->active.end() ||
-       std::find(cdata->active.begin(), cdata->active.end(), cd2->getName()) != cdata->active.end());
+      (std::find(cdata->active->begin(), cdata->active->end(), cd1->getName()) != cdata->active->end() ||
+       std::find(cdata->active->begin(), cdata->active->end(), cd2->getName()) != cdata->active->end());
 
   if (!needs_collision)
     return false;
@@ -248,8 +248,8 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
       contact.normal = fcl_contact.normal;
 
       ObjectPairKey pc = getObjectPairKey(cd1->getName(), cd2->getName());
-      const auto& it = cdata->res.find(pc);
-      bool found = (it != cdata->res.end());
+      const auto& it = cdata->res->find(pc);
+      bool found = (it != cdata->res->end());
 
       processResult(*cdata, contact, pc, found);
     }
@@ -273,8 +273,8 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
       cd1->m_enabled && cd2->m_enabled && (cd1->m_collisionFilterGroup & cd2->m_collisionFilterMask) &&
       (cd2->m_collisionFilterGroup & cd1->m_collisionFilterMask) &&
       !isContactAllowed(cd1->getName(), cd2->getName(), cdata->fn, false) &&
-      (std::find(cdata->active.begin(), cdata->active.end(), cd1->getName()) != cdata->active.end() ||
-       std::find(cdata->active.begin(), cdata->active.end(), cd2->getName()) != cdata->active.end());
+      (std::find(cdata->active->begin(), cdata->active->end(), cd1->getName()) != cdata->active->end() ||
+       std::find(cdata->active->begin(), cdata->active->end(), cd2->getName()) != cdata->active->end());
 
   if (!needs_collision)
     return false;
@@ -306,8 +306,8 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     }
 
     ObjectPairKey pc = getObjectPairKey(cd1->getName(), cd2->getName());
-    const auto& it = cdata->res.find(pc);
-    bool found = (it != cdata->res.end());
+    const auto& it = cdata->res->find(pc);
+    bool found = (it != cdata->res->end());
 
     processResult(*cdata, contact, pc, found);
   }


### PR DESCRIPTION
Modify the ContactTestData structure to use raw pointer instead of reference so members can be assigned and does not require the developer to use the constructor. This is beneficial if you want store this structure as a class member and reuse it for new contact requests instead of creating a new one each time. If there is a better way to accomplish this please provide suggestions. 