### PR TITLE
Add Bullet Discrete Simple ContactTest Benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
              ROS_REPO: main,
              UPSTREAM_WORKSPACE: 'github:swri-robotics/descartes_light#master github:Jmeyer1292/opw_kinematics#master',
              TARGET_WORKSPACE: '. github:ros-industrial-consortium/trajopt_ros#master',
-             ROSDEP_SKIP_KEYS: "bullet3 fcl",
+             ROSDEP_SKIP_KEYS: "bullet3 fcl benchmark",
              DOCKER_IMAGE: "lharmstrong/tesseract:kinetic",
              CCACHE_DIR: "/home/runner/work/tesseract/tesseract/Xenial-Build/.ccache",
              PARALLEL_TESTS: false,

--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -100,6 +100,20 @@ target_include_directories(${PROJECT_NAME}_test_suite SYSTEM INTERFACE
     ${EIGEN3_INCLUDE_DIRS}
     $<TARGET_PROPERTY:tesseract::tesseract_common,INTERFACE_INCLUDE_DIRECTORIES>) #tesseract::tesseract_common Due to bug in catkin, there is an open PR
 
+# Create test suite interface
+add_library(${PROJECT_NAME}_test_suite_benchmarks INTERFACE)
+target_link_libraries(${PROJECT_NAME}_test_suite_benchmarks INTERFACE tesseract::tesseract_geometry)
+tesseract_target_compile_options(${PROJECT_NAME}_test_suite_benchmarks INTERFACE)
+tesseract_clang_tidy(${PROJECT_NAME}_test_suite_benchmarks)
+tesseract_code_coverage(${PROJECT_NAME}_test_suite_benchmarks ALL EXCLUDE ${COVERAGE_EXCLUDE})
+target_compile_definitions(${PROJECT_NAME}_test_suite_benchmarks INTERFACE TEST_SUITE_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/test_suite/data")
+target_include_directories(${PROJECT_NAME}_test_suite_benchmarks INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME}_test_suite_benchmarks SYSTEM INTERFACE
+    ${EIGEN3_INCLUDE_DIRS}
+    $<TARGET_PROPERTY:tesseract::tesseract_common,INTERFACE_INCLUDE_DIRECTORIES>) #tesseract::tesseract_common Due to bug in catkin, there is an open PR
+
 tesseract_configure_package(${PROJECT_NAME}_core ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl ${PROJECT_NAME}_test_suite create_convex_hull)
 
 # Mark cpp header files for installation
@@ -125,3 +139,8 @@ if (TESSERACT_ENABLE_TESTING)
   tesseract_add_run_tests_target()
   add_subdirectory(test)
 endif()
+
+if (TESSERACT_ENABLE_BENCHMARKING)
+  add_subdirectory(test/benchmarks)
+endif()
+

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
@@ -69,6 +69,13 @@ enum class ContactTestType
   LIMITED = 3  /**< Return limited set of contacts for a pair of objects */
 };
 
+static const std::vector<std::string> ContactTestTypeStrings = {
+  "FIRST",
+  "CLOSEST",
+  "ALL",
+  "LIMITED",
+};
+
 struct ContactResult
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/benchmark_utils.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/benchmark_utils.hpp
@@ -1,0 +1,42 @@
+#ifndef TESSERACT_COLLISION_BENCHMARK_UTILS_HPP
+#define TESSERACT_COLLISION_BENCHMARK_UTILS_HPP
+
+#include <benchmark/benchmark.h>
+#include <Eigen/Eigen>
+#include <console_bridge/console.h>
+
+using namespace tesseract_collision;
+using namespace test_suite;
+using namespace tesseract_geometry;
+
+inline tesseract_geometry::Geometry::Ptr CreateUnitPrimative(const tesseract_geometry::GeometryType type,
+                                                             const double scale = 1.0)
+{
+  tesseract_geometry::Geometry::Ptr geom;
+  switch (type)
+  {
+    case tesseract_geometry::GeometryType::BOX:
+      geom = std::make_shared<tesseract_geometry::Box>(scale, scale, scale);
+      break;
+    case tesseract_geometry::GeometryType::CONE:
+      geom = std::make_shared<tesseract_geometry::Cone>(scale, scale);
+      break;
+    case tesseract_geometry::GeometryType::PLANE:
+      geom = std::make_shared<tesseract_geometry::Plane>(scale, scale, scale, scale);
+      break;
+    case tesseract_geometry::GeometryType::SPHERE:
+      geom = std::make_shared<tesseract_geometry::Sphere>(scale);
+      break;
+    case tesseract_geometry::GeometryType::CAPSULE:
+      geom = std::make_shared<tesseract_geometry::Capsule>(scale, scale);
+      break;
+    case tesseract_geometry::GeometryType::CYLINDER:
+      geom = std::make_shared<tesseract_geometry::Cylinder>(scale, scale);
+      break;
+    default:
+      CONSOLE_BRIDGE_logError("Invalid Geometry Type. Can only create primatives");
+      break;
+  }
+  return geom;
+};
+#endif

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/collision_benchmarks.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/collision_benchmarks.hpp
@@ -1,0 +1,60 @@
+#ifndef TESSERACT_COLLISION_BENCHMARKS_HPP
+#define TESSERACT_COLLISION_BENCHMARKS_HPP
+
+#include <tesseract_collision/core/discrete_contact_manager.h>
+#include <tesseract_geometry/geometries.h>
+
+#include <Eigen/Eigen>
+
+namespace tesseract_collision
+{
+namespace test_suite
+{
+/**
+ * @brief Contains the information necessary to run the benchmarks for discrete collision checking
+ */
+struct DiscreteBenchmarkInfo
+{
+  DiscreteBenchmarkInfo(const DiscreteContactManager::Ptr& contact_manager,
+                        const tesseract_geometry::Geometry::ConstPtr& geom1,
+                        const Eigen::Isometry3d& pose1,
+                        const tesseract_geometry::Geometry::ConstPtr& geom2,
+                        const Eigen::Isometry3d& pose2,
+                        ContactTestType contact_test_type)
+
+  {
+    contact_manager_ = contact_manager->clone();
+    geom1_.push_back(geom1->clone());
+    geom2_.push_back(geom2->clone());
+    obj1_poses.push_back(pose1);
+    obj2_poses.push_back(pose2);
+    contact_test_type_ = contact_test_type;
+  }
+  DiscreteContactManager::Ptr contact_manager_;
+  CollisionShapesConst geom1_;
+  tesseract_common::VectorIsometry3d obj1_poses;
+  CollisionShapesConst geom2_;
+  tesseract_common::VectorIsometry3d obj2_poses;
+  ContactTestType contact_test_type_;
+};
+
+/** @brief Benchmark that checks the contactTest function in discrete contact managers*/
+static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)
+{
+  info.contact_manager_->addCollisionObject(std::string("geom1"), 0, info.geom1_, info.obj1_poses);
+  info.contact_manager_->addCollisionObject(std::string("geom2"), 0, info.geom2_, info.obj2_poses);
+
+  info.contact_manager_->setActiveCollisionObjects({ "geom1", "geom2" });
+  info.contact_manager_->setContactDistanceThreshold(0.5);
+
+  ContactResultMap result;
+  for (auto _ : state)
+  {
+    info.contact_manager_->contactTest(result, info.contact_test_type_);
+  }
+};
+
+}  // namespace test_suite
+}  // namespace tesseract_collision
+
+#endif

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/collision_benchmarks.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/collision_benchmarks.hpp
@@ -15,7 +15,7 @@ namespace test_suite
  */
 struct DiscreteBenchmarkInfo
 {
-  DiscreteBenchmarkInfo(const DiscreteContactManager::Ptr& contact_manager,
+  DiscreteBenchmarkInfo(const DiscreteContactManager::ConstPtr& contact_manager,
                         const tesseract_geometry::Geometry::ConstPtr& geom1,
                         const Eigen::Isometry3d& pose1,
                         const tesseract_geometry::Geometry::ConstPtr& geom2,
@@ -36,6 +36,26 @@ struct DiscreteBenchmarkInfo
   CollisionShapesConst geom2_;
   tesseract_common::VectorIsometry3d obj2_poses;
   ContactTestType contact_test_type_;
+};
+
+/** @brief Benchmark that checks the clone method in discrete contact managers*/
+static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, int num_obj)
+{
+  std::vector<std::string> active_obj(num_obj);
+  for (int ind = 0; ind < num_obj; ind++)
+  {
+    std::string name = "geom_" + std::to_string(ind);
+    active_obj.push_back(name);
+    info.contact_manager_->addCollisionObject(name, 0, info.geom1_, info.obj1_poses);
+  }
+  info.contact_manager_->setActiveCollisionObjects(active_obj);
+  info.contact_manager_->setContactDistanceThreshold(0.5);
+
+  DiscreteContactManager::Ptr clone;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(clone = info.contact_manager_->clone());
+  }
 };
 
 /** @brief Benchmark that checks the contactTest function in discrete contact managers*/

--- a/tesseract/tesseract_collision/package.xml
+++ b/tesseract/tesseract_collision/package.xml
@@ -16,6 +16,7 @@
   <depend>fcl</depend>
   <depend>libconsole-bridge-dev</depend>
 
+  <test_depend>benchmark</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>tesseract_scene_graph</test_depend>
 

--- a/tesseract/tesseract_collision/test/benchmarks/CMakeLists.txt
+++ b/tesseract/tesseract_collision/test/benchmarks/CMakeLists.txt
@@ -1,0 +1,30 @@
+find_package(benchmark REQUIRED)
+find_package(tesseract_scene_graph REQUIRED)
+
+macro(add_benchmark benchmark_name benchmark_file)
+  add_executable(${benchmark_name} ${benchmark_file})
+  tesseract_target_compile_options(${benchmark_name} PRIVATE)
+  tesseract_clang_tidy(${benchmark_name})
+  target_link_libraries(${benchmark_name}
+
+      benchmark::benchmark
+      ${PROJECT_NAME}_test_suite
+      ${PROJECT_NAME}_bullet
+      ${PROJECT_NAME}_fcl
+      tesseract::tesseract_geometry
+      tesseract::tesseract_scene_graph
+      console_bridge
+      ${BULLET_LIBRARIES}
+      ${Boost_LIBRARIES}
+      ${OCTOMAP_LIBRARIES}
+      ${LIBFCL_LIBRARIES}
+      )
+  target_include_directories(${benchmark_name} PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
+  add_dependencies(${benchmark_name}
+    ${PROJECT_NAME}_bullet
+    ${PROJECT_NAME}_fcl)
+  tesseract_add_run_benchmark_target(${benchmark_name})
+endmacro()
+
+add_benchmark(${PROJECT_NAME}_bullet_discrete_simple_benchmarks bullet_discrete_simple_benchmarks.cpp)

--- a/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
+++ b/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
     std::function<void(benchmark::State&, int)> BM_SELECT_RANDOM_OBJECT_FUNC = BM_SELECT_RANDOM_OBJECT;
     benchmark::RegisterBenchmark("BM_SELECT_RANDOM_OBJECT", BM_SELECT_RANDOM_OBJECT_FUNC, 256)
         ->UseRealTime()
-        ->Unit(benchmark::TimeUnit::kMicrosecond);
+        ->Unit(benchmark::TimeUnit::kNanosecond);
   }
   {
     std::function<void(benchmark::State&, DiscreteBenchmarkInfo, int)> BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE_FUNC =
@@ -163,7 +163,53 @@ int main(int argc, char** argv)
                                                          ContactTestType::ALL),
                                    num_link)
           ->UseRealTime()
-          ->Unit(benchmark::TimeUnit::kMicrosecond);
+          ->Unit(benchmark::TimeUnit::kNanosecond);
+    }
+  }
+  {
+    std::function<void(benchmark::State&, DiscreteBenchmarkInfo, int)> BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR_FUNC =
+        BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR;
+    std::vector<std::size_t> num_links = { 2, 4, 8, 16, 32, 64, 128, 256, 512 };
+
+    for (const auto& num_link : num_links)
+    {
+      auto tf = Eigen::Isometry3d::Identity();
+      std::string name =
+          "BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR_" + checker->name() + "_ACTIVE_OBJ_" + std::to_string(num_link);
+      benchmark::RegisterBenchmark(name.c_str(),
+                                   BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR_FUNC,
+                                   DiscreteBenchmarkInfo(checker,
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         Eigen::Isometry3d::Identity(),
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         tf.translate(Eigen::Vector3d(2, 0, 0)),
+                                                         ContactTestType::ALL),
+                                   num_link)
+          ->UseRealTime()
+          ->Unit(benchmark::TimeUnit::kNanosecond);
+    }
+  }
+  {
+    std::function<void(benchmark::State&, DiscreteBenchmarkInfo, int)> BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP_FUNC =
+        BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP;
+    std::vector<std::size_t> num_links = { 2, 4, 8, 16, 32, 64, 128, 256, 512 };
+
+    for (const auto& num_link : num_links)
+    {
+      auto tf = Eigen::Isometry3d::Identity();
+      std::string name =
+          "BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP_" + checker->name() + "_ACTIVE_OBJ_" + std::to_string(num_link);
+      benchmark::RegisterBenchmark(name.c_str(),
+                                   BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP_FUNC,
+                                   DiscreteBenchmarkInfo(checker,
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         Eigen::Isometry3d::Identity(),
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         tf.translate(Eigen::Vector3d(2, 0, 0)),
+                                                         ContactTestType::ALL),
+                                   num_link)
+          ->UseRealTime()
+          ->Unit(benchmark::TimeUnit::kNanosecond);
     }
   }
 

--- a/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
+++ b/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
@@ -1,0 +1,112 @@
+#include <benchmark/benchmark.h>
+#include <Eigen/Eigen>
+
+#include <tesseract_collision/test_suite/benchmarks/collision_benchmarks.hpp>
+#include <tesseract_collision/test_suite/benchmarks/benchmark_utils.hpp>
+#include <tesseract_collision/bullet/bullet_discrete_simple_manager.h>
+
+using namespace tesseract_collision;
+using namespace test_suite;
+using namespace tesseract_geometry;
+
+int main(int argc, char** argv)
+{
+  std::function<void(benchmark::State & state, DiscreteBenchmarkInfo info)> BM_CONTACT_TEST_FUNC = BM_CONTACT_TEST;
+
+  // Make vector of all shapes to try
+  std::vector<tesseract_geometry::GeometryType> geometry_types = {
+    GeometryType::BOX, GeometryType::CONE, GeometryType::SPHERE, GeometryType::CAPSULE, GeometryType::CYLINDER
+  };
+
+  std::vector<ContactTestType> test_types = {
+    ContactTestType::ALL, ContactTestType::FIRST, ContactTestType::CLOSEST, ContactTestType::LIMITED
+  };
+
+  // BulletDiscreteSimpleManager - In Collision
+  {
+    auto checker = std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
+    for (const auto& test_type : test_types)
+    {
+      // Loop over all primative combinations
+      for (const auto& type1 : geometry_types)
+      {
+        for (const auto& type2 : geometry_types)
+        {
+          std::string name = "BM_CONTACT_TEST_0_" + checker->name() + "_" +
+                             ContactTestTypeStrings[static_cast<std::size_t>(test_type)] + "_" +
+                             GeometryTypeStrings[type1] + "_" + GeometryTypeStrings[type2];
+          benchmark::RegisterBenchmark(name.c_str(),
+                                       BM_CONTACT_TEST_FUNC,
+                                       DiscreteBenchmarkInfo(checker,
+                                                             CreateUnitPrimative(type1),
+                                                             Eigen::Isometry3d::Identity(),
+                                                             CreateUnitPrimative(type2),
+                                                             Eigen::Isometry3d::Identity(),
+                                                             test_type))
+              ->UseRealTime()
+              ->Unit(benchmark::TimeUnit::kMicrosecond);
+        }
+      }
+    }
+  }
+  // BulletDiscreteSimpleManager - Not in collision. Within contact threshold
+  {
+    auto checker = std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
+    for (const auto& test_type : test_types)
+    {
+      // Loop over all primative combinations
+      for (const auto& type1 : geometry_types)
+      {
+        for (const auto& type2 : geometry_types)
+        {
+          auto tf = Eigen::Isometry3d::Identity();
+          std::string name = "BM_CONTACT_TEST_1_" + checker->name() + "_" +
+                             ContactTestTypeStrings[static_cast<std::size_t>(test_type)] + "_" +
+                             GeometryTypeStrings[type1] + "_" + GeometryTypeStrings[type2];
+          benchmark::RegisterBenchmark(name.c_str(),
+                                       BM_CONTACT_TEST_FUNC,
+                                       DiscreteBenchmarkInfo(checker,
+                                                             CreateUnitPrimative(type1),
+                                                             Eigen::Isometry3d::Identity(),
+                                                             CreateUnitPrimative(type2),
+                                                             tf.translate(Eigen::Vector3d(0.6, 0, 0)),
+                                                             test_type))
+              ->UseRealTime()
+              ->Unit(benchmark::TimeUnit::kMicrosecond);
+        }
+      }
+    }
+  }
+
+  // BulletDiscreteSimpleManager - Not in collision. Outside contact threshold
+  {
+    auto checker = std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
+    for (const auto& test_type : test_types)
+    {
+      // Loop over all primative combinations
+      for (const auto& type1 : geometry_types)
+      {
+        for (const auto& type2 : geometry_types)
+        {
+          auto tf = Eigen::Isometry3d::Identity();
+          std::string name = "BM_CONTACT_TEST_2_" + checker->name() + "_" +
+                             ContactTestTypeStrings[static_cast<std::size_t>(test_type)] + "_" +
+                             GeometryTypeStrings[type1] + "_" + GeometryTypeStrings[type2];
+          benchmark::RegisterBenchmark(name.c_str(),
+                                       BM_CONTACT_TEST_FUNC,
+                                       DiscreteBenchmarkInfo(checker,
+                                                             CreateUnitPrimative(type1),
+                                                             Eigen::Isometry3d::Identity(),
+                                                             CreateUnitPrimative(type2),
+                                                             tf.translate(Eigen::Vector3d(2, 0, 0)),
+                                                             test_type))
+              ->UseRealTime()
+              ->Unit(benchmark::TimeUnit::kMicrosecond);
+        }
+      }
+    }
+  }
+
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
+++ b/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
@@ -134,6 +134,39 @@ int main(int argc, char** argv)
     }
   }
 
+  //////////////////////////////////////
+  // setCollisionObjectTransform
+  //////////////////////////////////////
+  {
+    std::function<void(benchmark::State&, int)> BM_SELECT_RANDOM_OBJECT_FUNC = BM_SELECT_RANDOM_OBJECT;
+    benchmark::RegisterBenchmark("BM_SELECT_RANDOM_OBJECT", BM_SELECT_RANDOM_OBJECT_FUNC, 256)
+        ->UseRealTime()
+        ->Unit(benchmark::TimeUnit::kMicrosecond);
+  }
+  {
+    std::function<void(benchmark::State&, DiscreteBenchmarkInfo, int)> BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE_FUNC =
+        BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE;
+    std::vector<int> num_links = { 2, 4, 8, 16, 32, 64, 128, 256, 512 };
+
+    for (const auto& num_link : num_links)
+    {
+      auto tf = Eigen::Isometry3d::Identity();
+      std::string name =
+          "BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE_" + checker->name() + "_ACTIVE_OBJ_" + std::to_string(num_link);
+      benchmark::RegisterBenchmark(name.c_str(),
+                                   BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE_FUNC,
+                                   DiscreteBenchmarkInfo(checker,
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         Eigen::Isometry3d::Identity(),
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         tf.translate(Eigen::Vector3d(2, 0, 0)),
+                                                         ContactTestType::ALL),
+                                   num_link)
+          ->UseRealTime()
+          ->Unit(benchmark::TimeUnit::kMicrosecond);
+    }
+  }
+
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
 }

--- a/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
+++ b/tesseract/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
@@ -11,7 +11,37 @@ using namespace tesseract_geometry;
 
 int main(int argc, char** argv)
 {
-  std::function<void(benchmark::State & state, DiscreteBenchmarkInfo info)> BM_CONTACT_TEST_FUNC = BM_CONTACT_TEST;
+  const tesseract_collision_bullet::BulletDiscreteSimpleManager::ConstPtr checker =
+      std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
+
+  //////////////////////////////////////
+  // Clone
+  //////////////////////////////////////
+
+  {
+    std::vector<int> num_links = { 0, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
+    std::function<void(benchmark::State&, DiscreteBenchmarkInfo, int)> BM_CLONE_FUNC = BM_CLONE;
+    for (const auto& num_link : num_links)
+    {
+      std::string name = "BM_CLONE_" + checker->name() + "_ACTIVE_OBJ_" + std::to_string(num_link);
+      benchmark::RegisterBenchmark(name.c_str(),
+                                   BM_CLONE_FUNC,
+                                   DiscreteBenchmarkInfo(checker,
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         Eigen::Isometry3d::Identity(),
+                                                         CreateUnitPrimative(GeometryType::BOX),
+                                                         Eigen::Isometry3d::Identity(),
+                                                         ContactTestType::ALL),
+                                   num_link)
+          ->UseRealTime()
+          ->Unit(benchmark::TimeUnit::kMicrosecond);
+    }
+  }
+
+  //////////////////////////////////////
+  // contactTest
+  //////////////////////////////////////
+  std::function<void(benchmark::State&, DiscreteBenchmarkInfo)> BM_CONTACT_TEST_FUNC = BM_CONTACT_TEST;
 
   // Make vector of all shapes to try
   std::vector<tesseract_geometry::GeometryType> geometry_types = {
@@ -24,7 +54,6 @@ int main(int argc, char** argv)
 
   // BulletDiscreteSimpleManager - In Collision
   {
-    auto checker = std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
     for (const auto& test_type : test_types)
     {
       // Loop over all primative combinations
@@ -51,7 +80,6 @@ int main(int argc, char** argv)
   }
   // BulletDiscreteSimpleManager - Not in collision. Within contact threshold
   {
-    auto checker = std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
     for (const auto& test_type : test_types)
     {
       // Loop over all primative combinations
@@ -80,7 +108,6 @@ int main(int argc, char** argv)
 
   // BulletDiscreteSimpleManager - Not in collision. Outside contact threshold
   {
-    auto checker = std::make_shared<tesseract_collision_bullet::BulletDiscreteSimpleManager>();
     for (const auto& test_type : test_types)
     {
       // Loop over all primative combinations

--- a/tesseract/tesseract_common/cmake/tesseract_macros.cmake
+++ b/tesseract/tesseract_common/cmake/tesseract_macros.cmake
@@ -168,6 +168,20 @@ macro(tesseract_add_run_tests_target)
   endif()
 endmacro()
 
+# This macro add a custom target that will run the benchmarks after they are finished building.
+# Usage: tesseract_add_run_benchmark_target(benchmark_name)
+# Results are saved to /test/benchmarks/${benchmark_name}_results.json in the build directory
+macro(tesseract_add_run_benchmark_target benchmark_name)
+  if(TESSERACT_ENABLE_RUN_BENCHMARKING)
+    add_custom_target(run_benchmark_${benchmark_name} ALL
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ./test/benchmarks/${benchmark_name} --benchmark_out_format=json --benchmark_out="./test/benchmarks/${benchmark_name}_results.json")
+  else()
+    add_custom_target(run_benchmark_${benchmark_name})
+  endif()
+  add_dependencies(run_benchmark_${benchmark_name} ${benchmark_name})
+endmacro()
+
 #http://www.stablecoder.ca/2018/01/15/code-coverage.html
 #code coverage
 #if(CMAKE_BUILD_TYPE STREQUAL "coverage" OR CODE_COVERAGE)

--- a/tesseract/tesseract_geometry/include/tesseract_geometry/geometry.h
+++ b/tesseract/tesseract_geometry/include/tesseract_geometry/geometry.h
@@ -47,6 +47,9 @@ enum GeometryType
   SDF_MESH,
   OCTREE
 };
+static const std::vector<std::string> GeometryTypeStrings = {
+  "SPHERE", "CYLINDER", "CAPSULE", "CONE", "BOX", "PLANE", "MESH", "CONVEX_MESH", "SDF_MESH", "OCTREE"
+};
 
 class Geometry
 {


### PR DESCRIPTION
Adds the beginnings of a benchmarking framework for Tesseract Collision. Currently it adds tests for one manager running contactTest on primitives (this is 300 tests by itself). The idea is that I will add another benchmark executable for each manager. Then we can compare the outputs of each one as well as the outputs of each over time.

Additions
1.  Macro to run benchmarks similar to tests
2.  Benchmarking library in test_suite
3.  Google benchmark executable for BulletDiscreteManager

To test, build with `-DTESSERACT_ENABLE_BENCHMARKING=ON` and run the executable `/tests/benchmarks/tesseract_collision_bullet_discrete_simple_benchmarks`