### PR TITLE
Fix Tesseract Nightly Workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly
 
 on:
   pull_request:
-    - labeled:
+    types: [labeled]
   schedule:
     - cron: '0 5 * * *'
 


### PR DESCRIPTION
Previously was getting `pull_request requires a map value` error. 

See [this example](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request)