### PR TITLE
Add Benchmarking Workflow

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,0 +1,69 @@
+name: Benchmarking
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  industrial_ci:
+    name: ${{ matrix.env.CI_NAME }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - {CI_NAME: Bionic-Benchmark,
+             OS_NAME: ubuntu,
+             OS_CODE_NAME: bionic,
+             ROS_DISTRO: melodic,
+             ROS_REPO: main,
+             UPSTREAM_WORKSPACE: 'github:swri-robotics/descartes_light#master github:Jmeyer1292/opw_kinematics#master',
+             TARGET_WORKSPACE: '. github:ros-industrial-consortium/trajopt_ros#master',
+             ROSDEP_SKIP_KEYS: "bullet3 fcl",
+             DOCKER_IMAGE: "lharmstrong/tesseract:melodic",
+             CCACHE_DIR: "/home/runner/work/tesseract/tesseract/Bionic-Benchmark/.ccache",
+             UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release",
+             TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release -DTESSERACT_ENABLE_TESTING=OFF -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=ON",
+             AFTER_SCRIPT: 'mkdir -p /root/.ccache/benchmarks && cp $target_ws/build/tesseract_collision/test/benchmarks/tesseract_collision_bullet_discrete_simple_benchmarks_results.json /root/.ccache/benchmarks/'}
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: ccache cache files
+        uses: actions/cache@v1.1.0
+        with:
+          path: ${{ matrix.env.CI_NAME }}/.ccache
+          key: ${{ matrix.env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.env.CI_NAME }}-ccache-
+
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}
+
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: C++ Benchmark
+          tool: 'googlecpp'
+          output-file-path: /home/runner/work/tesseract/tesseract/Bionic-Benchmark/.ccache/benchmarks/tesseract_collision_bullet_discrete_simple_benchmarks_results.json
+          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          auto-push: false
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@mpowelson'
+
+      - name: Push benchmark result
+        run: git push 'https://ros-industrial-consortium:${{ secrets.PERSONAL_GITHUB_TOKEN }}@github.com/ros-industrial-consortium/tesseract.git' gh-pages:gh-pages
+        if: github.event_name != 'pull_request'

--- a/.github_actions_benchmarking.yml
+++ b/.github_actions_benchmarking.yml
@@ -1,0 +1,1 @@
+.github/workflows/benchmarking.yml


### PR DESCRIPTION
Depends on #275 

Adds a separate workflow that builds and runs the benchmarks. The benchmark json output is then used to populate a gh_pages. [Here is an example result on my fork](https://mpowelson.github.io/tesseract/dev/bench/).[THIS](https://rhysd.github.io/github-action-benchmark/dev/bench/) is what it should look like over time. We will likely want to change the html later to make it a little more friendly since it currently makes one plot per benchmark. However, this should be a place to start. It works by reading in the json file, making changes to the html, and committing those changes to a gh-pages branch. 

Note: This will require some more setup from someone with more permissions that me before we will see any output (@Levi-Armstrong ). Notably we will need to set up an access token, add it to the repo secrets, and create the gh_pages branch. See [HERE](https://github.com/rhysd/github-action-benchmark#charts-on-github-pages-1)