### PR TITLE
Disable benchmarks in cron jobs

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -2,9 +2,6 @@ name: Benchmarking
 
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: '0 5 * * *'
 
 jobs:
   industrial_ci:


### PR DESCRIPTION
Cron jobs do not currently work due to [an issue](https://github.com/rhysd/github-action-benchmark/issues/24) in rhysd/github-action-benchmark. This temporarily disables them so I don't get emails every night telling me that it is broken.