### PR TITLE
Improve tesseract collision performance for bullet and fcl

### DIFF
--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -58,7 +58,10 @@ target_include_directories(${PROJECT_NAME}_bullet SYSTEM PUBLIC
     ${OCTOMAP_INCLUDE_DIRS})
 
 # Create target for FCL implementation
-add_library(${PROJECT_NAME}_fcl SHARED src/fcl/fcl_discrete_managers.cpp src/fcl/fcl_utils.cpp)
+add_library(${PROJECT_NAME}_fcl SHARED
+  src/fcl/fcl_discrete_managers.cpp
+  src/fcl/fcl_utils.cpp
+  src/fcl/fcl_collision_object_wrapper.cpp)
 target_link_libraries(${PROJECT_NAME}_fcl PUBLIC ${PROJECT_NAME}_core tesseract::tesseract_geometry console_bridge ${OCTOMAP_LIBRARIES} fcl)
 tesseract_target_compile_options(${PROJECT_NAME}_fcl PUBLIC)
 tesseract_clang_tidy(${PROJECT_NAME}_fcl)

--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(${PROJECT_NAME}_bullet SHARED
   src/bullet/tesseract_compound_collision_algorithm.cpp
   src/bullet/tesseract_compound_compound_collision_algorithm.cpp
   src/bullet/tesseract_collision_configuration.cpp
+  src/bullet/tesseract_convex_convex_algorithm.cpp
+  src/bullet/tesseract_gjk_pair_detector.cpp
 )
 target_link_libraries(${PROJECT_NAME}_bullet PUBLIC ${PROJECT_NAME}_core tesseract::tesseract_geometry console_bridge ${OCTOMAP_LIBRARIES})
 tesseract_target_compile_options(${PROJECT_NAME}_bullet PUBLIC)

--- a/tesseract/tesseract_collision/examples/box_box_example.cpp
+++ b/tesseract/tesseract_collision/examples/box_box_example.cpp
@@ -80,7 +80,8 @@ int main(int /*argc*/, char** /*argv*/)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  ContactRequest request(ContactTestType::CLOSEST);
+  checker.contactTest(result, request);
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -107,7 +108,7 @@ int main(int /*argc*/, char** /*argv*/)
   checker.setCollisionObjectsTransform(location);
 
   // Check for collision after moving object
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, request);
   flattenResults(std::move(result), result_vector);
 
   CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());
@@ -121,7 +122,7 @@ int main(int /*argc*/, char** /*argv*/)
   checker.setContactDistanceThreshold(0.25);
 
   // Check for contact with new threshold
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, request);
   flattenResults(std::move(result), result_vector);
 
   CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
@@ -119,7 +119,7 @@ public:
 
   IsContactAllowedFn getIsContactAllowedFn() const override;
 
-  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
+  void contactTest(ContactResultMap& collisions, const ContactRequest& request) override;
 
   /**
    * @brief A a bullet collision object to the manager

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
@@ -119,7 +119,7 @@ public:
 
   IsContactAllowedFn getIsContactAllowedFn() const override;
 
-  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
+  void contactTest(ContactResultMap& collisions, const ContactRequest& request) override;
 
   /**
    * @brief A a bullet collision object to the manager

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
@@ -108,7 +108,7 @@ public:
 
   IsContactAllowedFn getIsContactAllowedFn() const override;
 
-  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
+  void contactTest(ContactResultMap& collisions, const ContactRequest& request) override;
 
   /**
    * @brief A a bullet collision object to the manager

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
@@ -108,7 +108,7 @@ public:
 
   IsContactAllowedFn getIsContactAllowedFn() const override;
 
-  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
+  void contactTest(ContactResultMap& collisions, const ContactRequest& request) override;
 
   /**
    * @brief A a bullet collision object to the manager

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -880,10 +880,12 @@ public:
 
   bool needBroadphaseCollision(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1) const override
   {
-    return !contact_data_.done && needsCollisionCheck(*(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)),
-                                                      *(static_cast<CollisionObjectWrapper*>(proxy1->m_clientObject)),
-                                                      contact_data_.fn,
-                                                      verbose_);
+    // Note: We do not pass the allowed collision matrix because if it changes we do not know and this function only
+    // gets called under certain cases and it could cause overlapping pairs to not be processed.
+    return needsCollisionCheck(*(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)),
+                               *(static_cast<CollisionObjectWrapper*>(proxy1->m_clientObject)),
+                               nullptr,
+                               verbose_);
   }
 
 private:
@@ -1133,11 +1135,6 @@ inline void updateBroadphaseAABB(const COW::Ptr& cow,
   // Calculate the aabb
   btVector3 aabb_min, aabb_max;
   cow->getAABB(aabb_min, aabb_max);
-
-  //  // Bullet Double Broadphase interface add 0.05 margin so lets remove it.
-  //  btVector3 remove_bullet_buffer(0.05, 0.05, 0.05);
-  //  aabb_min += remove_bullet_buffer;
-  //  aabb_max -= remove_bullet_buffer;
 
   // Update the broadphase aabb
   assert(cow->getBroadphaseHandle() != nullptr);

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -52,8 +52,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/types.h>
 #include <tesseract_collision/core/common.h>
 
-extern btScalar gDbvtMargin;
-
 namespace tesseract_collision
 {
 namespace tesseract_collision_bullet

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -1184,9 +1184,11 @@ inline void addCollisionObjectToBroadphase(const COW::Ptr& cow,
 }
 
 /**
- * @brief Update a collision objects filters broadphase
+ * @brief Update a collision objects filters for broadphase
  * @param active A list of active collision objects
  * @param cow The collision object to update.
+ * @param broadphase The collision object to update.
+ * @param dispatcher The collision object to update.
  */
 inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
                                          const COW::Ptr& cow,
@@ -1195,7 +1197,9 @@ inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
 {
   updateCollisionObjectFilters(active, cow);
 
-  // Need to clean the proxy from broadphase so BroadPhaseFilter gets called again.
+  // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+  // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+  // this must be called or contacts between shapes will be missed.
   broadphase->getOverlappingPairCache()->cleanProxyFromPairs(cow->getBroadphaseHandle(), dispatcher.get());
 }
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_collision_configuration.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_collision_configuration.h
@@ -50,6 +50,14 @@ namespace tesseract_collision
 {
 namespace tesseract_collision_bullet
 {
+/**
+ * @brief This is a modified configuration that included the modified Bullet algorithms.
+ *
+ * This swaps out the following Bullet algorithms for modifed one:
+ *     - Compound to Collision
+ *     - Compound to Compound
+ *     - Convex to Convex
+ */
 class TesseractCollisionConfiguration : public btDefaultCollisionConfiguration
 {
 public:

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_compound_collision_algorithm.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_compound_collision_algorithm.h
@@ -40,7 +40,18 @@ namespace tesseract_collision
 {
 namespace tesseract_collision_bullet
 {
-/// btCompoundCollisionAlgorithm  supports collision between CompoundCollisionShapes and other collision shapes
+/**
+ * @brief Supports collision between CompoundCollisionShapes and other collision shapes
+ *
+ * The original implementation would check all collision objects before exiting the bvh of the compound shape. The
+ * original code had a callback, but it only passed in the collision shape and no the collision object which is where
+ * the user data is located. This was modifed to check if collision is done for the contact test type FIRST during the
+ * internal broadphase of the compound shapes and exit early.
+ *
+ * Note: This could be removed in the future but the callback need to be modifed to accept the collision object along
+ * with the collision shape. I don't believe this will be an issue since all of the other callback in Bullet accept
+ * both.
+ */
 class TesseractCompoundCollisionAlgorithm : public btActivatingCollisionAlgorithm  // NOLINT
 {
   btNodeStack stack2;

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_compound_compound_collision_algorithm.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_compound_compound_collision_algorithm.h
@@ -43,7 +43,18 @@ namespace tesseract_collision
 {
 namespace tesseract_collision_bullet
 {
-/// btCompoundCompoundCollisionAlgorithm  supports collision between two btCompoundCollisionShape shapes
+/**
+ * @brief Supports collision between two btCompoundCollisionShape shapes
+ *
+ * The original implementation would check all collision objects before exiting the bvh of the compound shape. The
+ * original code had a callback, but it only passed in the collision shape and no the collision object which is where
+ * the user data is located. This was modifed to check if collision is done for the contact test type FIRST during the
+ * internal broadphase of the compound shapes and exit early.
+ *
+ * Note: This could be removed in the future but the callback need to be modifed to accept the collision object along
+ * with the collision shape. I don't believe this will be an issue since all of the other callback in Bullet accept
+ * both.
+ */
 class TesseractCompoundCompoundCollisionAlgorithm : public TesseractCompoundCollisionAlgorithm  // NOLINT
 {
   class btHashedSimplePairCache* m_childCollisionAlgorithmCache;
@@ -53,9 +64,6 @@ class TesseractCompoundCompoundCollisionAlgorithm : public TesseractCompoundColl
   int m_compoundShapeRevision1;
 
   void removeChildAlgorithms();
-
-  //	void	preallocateChildAlgorithms(const btCollisionObjectWrapper* body0Wrap,const btCollisionObjectWrapper*
-  // body1Wrap);
 
 public:
   TesseractCompoundCompoundCollisionAlgorithm(const btCollisionAlgorithmConstructionInfo& ci,

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
@@ -50,6 +50,19 @@ namespace tesseract_collision_bullet
 /// calculations between two convex objects. Multiple contact points are calculated by perturbing the orientation of the
 /// smallest object orthogonal to the separating normal. This idea was described by Gino van den Bergen in this forum
 /// topic http://www.bulletphysics.com/Bullet/phpBB3/viewtopic.php?f=4&t=288&p=888#p888
+
+/**
+ * @brief This is a modifed Convex to Convex collision algorithm
+ *
+ * This was modified to leverage the Tesseract contact request to enable and disable different parts of the algorithm.
+ * The algorithm first does a quick binary check if the two objects are in collision. If in collision it runs
+ * the penetration algorithm to get the nearest points and penetration depths. If not in collision it runs the an
+ * algorithm to get the nearest points and distance. The Tesseract contact request allow you to now decide if you need
+ * all three. Example, in the case of OMPL if you have a contact distance of zero you can get a performance increase,
+ * by disabling the penetration and distance calculation because they add no value.
+ *
+ * Note: This will not be able to be removed.
+ */
 class TesseractConvexConvexAlgorithm : public btActivatingCollisionAlgorithm
 {
 #ifdef USE_SEPDISTANCE_UTIL2

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 class btConvexPenetrationDepthSolver;
 
+// LCOV_EXCL_START
 namespace tesseract_collision
 {
 namespace tesseract_collision_bullet
@@ -146,4 +147,5 @@ public:
 
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision
+// LCOV_EXCL_STOP
 #endif  // TESSERACT_COLLISION_TESSERACT_CONVEX_CONVEX_ALGORITHM_H

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
@@ -1,0 +1,134 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If
+you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not
+required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original
+software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+#ifndef TESSERACT_COLLISION_TESSERACT_CONVEX_CONVEX_ALGORITHM_H
+#define TESSERACT_COLLISION_TESSERACT_CONVEX_CONVEX_ALGORITHM_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/CollisionDispatch/btActivatingCollisionAlgorithm.h>
+#include <BulletCollision/NarrowPhaseCollision/btGjkPairDetector.h>
+#include <BulletCollision/NarrowPhaseCollision/btPersistentManifold.h>
+#include <BulletCollision/BroadphaseCollision/btBroadphaseProxy.h>
+#include <BulletCollision/NarrowPhaseCollision/btVoronoiSimplexSolver.h>
+#include <BulletCollision/CollisionDispatch/btCollisionCreateFunc.h>
+#include <BulletCollision/CollisionDispatch/btCollisionDispatcher.h>
+#include <LinearMath/btTransformUtil.h>  //for btConvexSeparatingDistanceUtil
+#include <BulletCollision/NarrowPhaseCollision/btPolyhedralContactClipping.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_collision/core/types.h>
+
+class btConvexPenetrationDepthSolver;
+
+namespace tesseract_collision
+{
+namespace tesseract_collision_bullet
+{
+/// Enabling USE_SEPDISTANCE_UTIL2 requires 100% reliable distance computation. However, when using large size ratios
+/// GJK can be imprecise so the distance is not conservative. In that case, enabling this USE_SEPDISTANCE_UTIL2 would
+/// result in failing/missing collisions. Either improve GJK for large size ratios (testing a 100 units versus a 0.1
+/// unit object) or only enable the util for certain pairs that have a small size ratio
+
+//#define USE_SEPDISTANCE_UTIL2 1
+
+/// The convexConvexAlgorithm collision algorithm implements time of impact, convex closest points and penetration depth
+/// calculations between two convex objects. Multiple contact points are calculated by perturbing the orientation of the
+/// smallest object orthogonal to the separating normal. This idea was described by Gino van den Bergen in this forum
+/// topic http://www.bulletphysics.com/Bullet/phpBB3/viewtopic.php?f=4&t=288&p=888#p888
+class TesseractConvexConvexAlgorithm : public btActivatingCollisionAlgorithm
+{
+#ifdef USE_SEPDISTANCE_UTIL2
+  btConvexSeparatingDistanceUtil m_sepDistance;
+#endif
+  btConvexPenetrationDepthSolver* m_pdSolver;
+
+  btVertexArray worldVertsB1;
+  btVertexArray worldVertsB2;
+
+  bool m_ownManifold;
+  btPersistentManifold* m_manifoldPtr;
+  bool m_lowLevelOfDetail;
+
+  int m_numPerturbationIterations;
+  int m_minimumPointsPerturbationThreshold;
+
+  ContactTestData* m_cdata;
+
+  /// cache separating vector to speedup collision detection
+
+public:
+  TesseractConvexConvexAlgorithm(btPersistentManifold* mf,
+                                 const btCollisionAlgorithmConstructionInfo& ci,
+                                 const btCollisionObjectWrapper* body0Wrap,
+                                 const btCollisionObjectWrapper* body1Wrap,
+                                 btConvexPenetrationDepthSolver* pdSolver,
+                                 int numPerturbationIterations,
+                                 int minimumPointsPerturbationThreshold);
+
+  virtual ~TesseractConvexConvexAlgorithm();
+
+  virtual void processCollision(const btCollisionObjectWrapper* body0Wrap,
+                                const btCollisionObjectWrapper* body1Wrap,
+                                const btDispatcherInfo& dispatchInfo,
+                                btManifoldResult* resultOut);
+
+  virtual btScalar calculateTimeOfImpact(btCollisionObject* body0,
+                                         btCollisionObject* body1,
+                                         const btDispatcherInfo& dispatchInfo,
+                                         btManifoldResult* resultOut);
+
+  virtual void getAllContactManifolds(btManifoldArray& manifoldArray)
+  {
+    /// should we use m_ownManifold to avoid adding duplicates?
+    if (m_manifoldPtr && m_ownManifold)
+      manifoldArray.push_back(m_manifoldPtr);
+  }
+
+  void setLowLevelOfDetail(bool useLowLevel);
+
+  const btPersistentManifold* getManifold() { return m_manifoldPtr; }
+
+  struct CreateFunc : public btCollisionAlgorithmCreateFunc
+  {
+    btConvexPenetrationDepthSolver* m_pdSolver;
+    int m_numPerturbationIterations;
+    int m_minimumPointsPerturbationThreshold;
+
+    CreateFunc(btConvexPenetrationDepthSolver* pdSolver);
+
+    virtual ~CreateFunc();
+
+    virtual btCollisionAlgorithm* CreateCollisionAlgorithm(btCollisionAlgorithmConstructionInfo& ci,
+                                                           const btCollisionObjectWrapper* body0Wrap,
+                                                           const btCollisionObjectWrapper* body1Wrap)
+    {
+      void* mem = ci.m_dispatcher1->allocateCollisionAlgorithm(sizeof(TesseractConvexConvexAlgorithm));
+      return new (mem) TesseractConvexConvexAlgorithm(ci.m_manifold,
+                                                      ci,
+                                                      body0Wrap,
+                                                      body1Wrap,
+                                                      m_pdSolver,
+                                                      m_numPerturbationIterations,
+                                                      m_minimumPointsPerturbationThreshold);
+    }
+  };
+};
+
+}  // namespace tesseract_collision_bullet
+}  // namespace tesseract_collision
+#endif  // TESSERACT_COLLISION_TESSERACT_CONVEX_CONVEX_ALGORITHM_H

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
@@ -80,19 +80,23 @@ public:
                                  int numPerturbationIterations,
                                  int minimumPointsPerturbationThreshold);
 
-  virtual ~TesseractConvexConvexAlgorithm();
+  ~TesseractConvexConvexAlgorithm() override;
+  TesseractConvexConvexAlgorithm(const TesseractConvexConvexAlgorithm&) = delete;
+  TesseractConvexConvexAlgorithm& operator=(const TesseractConvexConvexAlgorithm&) = delete;
+  TesseractConvexConvexAlgorithm(TesseractConvexConvexAlgorithm&&) = delete;
+  TesseractConvexConvexAlgorithm& operator=(TesseractConvexConvexAlgorithm&&) = delete;
 
-  virtual void processCollision(const btCollisionObjectWrapper* body0Wrap,
-                                const btCollisionObjectWrapper* body1Wrap,
-                                const btDispatcherInfo& dispatchInfo,
-                                btManifoldResult* resultOut);
+  void processCollision(const btCollisionObjectWrapper* body0Wrap,
+                        const btCollisionObjectWrapper* body1Wrap,
+                        const btDispatcherInfo& dispatchInfo,
+                        btManifoldResult* resultOut) override;
 
-  virtual btScalar calculateTimeOfImpact(btCollisionObject* body0,
-                                         btCollisionObject* body1,
-                                         const btDispatcherInfo& dispatchInfo,
-                                         btManifoldResult* resultOut);
+  btScalar calculateTimeOfImpact(btCollisionObject* body0,
+                                 btCollisionObject* body1,
+                                 const btDispatcherInfo& dispatchInfo,
+                                 btManifoldResult* resultOut) override;
 
-  virtual void getAllContactManifolds(btManifoldArray& manifoldArray)
+  void getAllContactManifolds(btManifoldArray& manifoldArray) override
   {
     /// should we use m_ownManifold to avoid adding duplicates?
     if (m_manifoldPtr && m_ownManifold)
@@ -111,11 +115,9 @@ public:
 
     CreateFunc(btConvexPenetrationDepthSolver* pdSolver);
 
-    virtual ~CreateFunc();
-
-    virtual btCollisionAlgorithm* CreateCollisionAlgorithm(btCollisionAlgorithmConstructionInfo& ci,
-                                                           const btCollisionObjectWrapper* body0Wrap,
-                                                           const btCollisionObjectWrapper* body1Wrap)
+    btCollisionAlgorithm* CreateCollisionAlgorithm(btCollisionAlgorithmConstructionInfo& ci,
+                                                   const btCollisionObjectWrapper* body0Wrap,
+                                                   const btCollisionObjectWrapper* body1Wrap) override
     {
       void* mem = ci.m_dispatcher1->allocateCollisionAlgorithm(sizeof(TesseractConvexConvexAlgorithm));
       return new (mem) TesseractConvexConvexAlgorithm(ci.m_manifold,

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
@@ -1,0 +1,109 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If
+you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not
+required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original
+software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+#ifndef TESSERACT_COLLISION_TESSERACT_GJK_PAIR_DETECTOR_H
+#define TESSERACT_COLLISION_TESSERACT_GJK_PAIR_DETECTOR_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/NarrowPhaseCollision/btDiscreteCollisionDetectorInterface.h>
+#include <BulletCollision/CollisionShapes/btCollisionMargin.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+class btConvexShape;
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/NarrowPhaseCollision/btSimplexSolverInterface.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+class btConvexPenetrationDepthSolver;
+
+#include <tesseract_collision/core/types.h>
+
+namespace tesseract_collision
+{
+namespace tesseract_collision_bullet
+{
+/// btGjkPairDetector uses GJK to implement the btDiscreteCollisionDetectorInterface
+class TesseractGjkPairDetector : public btDiscreteCollisionDetectorInterface
+{
+  btVector3 m_cachedSeparatingAxis;
+  btConvexPenetrationDepthSolver* m_penetrationDepthSolver;
+  btSimplexSolverInterface* m_simplexSolver;
+  const btConvexShape* m_minkowskiA;
+  const btConvexShape* m_minkowskiB;
+  int m_shapeTypeA;
+  int m_shapeTypeB;
+  btScalar m_marginA;
+  btScalar m_marginB;
+
+  bool m_ignoreMargin;
+  btScalar m_cachedSeparatingDistance;
+
+  const ContactTestData* m_cdata;
+
+public:
+  // some debugging to fix degeneracy problems
+  int m_lastUsedMethod;
+  int m_curIter;
+  int m_degenerateSimplex;
+  int m_catchDegeneracies;
+  int m_fixContactNormalDirection;
+
+  TesseractGjkPairDetector(const btConvexShape* objectA,
+                           const btConvexShape* objectB,
+                           btSimplexSolverInterface* simplexSolver,
+                           btConvexPenetrationDepthSolver* penetrationDepthSolver,
+                           const ContactTestData* cdata);
+
+  TesseractGjkPairDetector(const btConvexShape* objectA,
+                           const btConvexShape* objectB,
+                           int shapeTypeA,
+                           int shapeTypeB,
+                           btScalar marginA,
+                           btScalar marginB,
+                           btSimplexSolverInterface* simplexSolver,
+                           btConvexPenetrationDepthSolver* penetrationDepthSolver,
+                           const ContactTestData* cdata);
+
+  virtual ~TesseractGjkPairDetector(){};
+
+  virtual void getClosestPoints(const ClosestPointInput& input,
+                                Result& output,
+                                class btIDebugDraw* debugDraw,
+                                bool swapResults = false);
+
+  void getClosestPointsNonVirtual(const ClosestPointInput& input, Result& output, class btIDebugDraw* debugDraw);
+
+  void setMinkowskiA(const btConvexShape* minkA) { m_minkowskiA = minkA; }
+
+  void setMinkowskiB(const btConvexShape* minkB) { m_minkowskiB = minkB; }
+  void setCachedSeparatingAxis(const btVector3& separatingAxis) { m_cachedSeparatingAxis = separatingAxis; }
+
+  const btVector3& getCachedSeparatingAxis() const { return m_cachedSeparatingAxis; }
+  btScalar getCachedSeparatingDistance() const { return m_cachedSeparatingDistance; }
+
+  void setPenetrationDepthSolver(btConvexPenetrationDepthSolver* penetrationDepthSolver)
+  {
+    m_penetrationDepthSolver = penetrationDepthSolver;
+  }
+
+  /// don't use setIgnoreMargin, it's for Bullet's internal use
+  void setIgnoreMargin(bool ignoreMargin) { m_ignoreMargin = ignoreMargin; }
+};
+}  // namespace tesseract_collision_bullet
+}  // namespace tesseract_collision
+#endif  // TESSERACT_COLLISION_TESSERACT_GJK_PAIR_DETECTOR_H

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
@@ -37,7 +37,18 @@ namespace tesseract_collision
 {
 namespace tesseract_collision_bullet
 {
-/// btGjkPairDetector uses GJK to implement the btDiscreteCollisionDetectorInterface
+/**
+ * @brief This is a modifed Convex to Convex collision algorithm
+ *
+ * This was modified to leverage the Tesseract contact request to enable and disable different parts of the algorithm.
+ * The algorithm first does a quick binary check if the two objects are in collision. If in collision it runs
+ * the penetration algorithm to get the nearest points and penetration depths. If not in collision it runs the an
+ * algorithm to get the nearest points and distance. The Tesseract contact request allow you to now decide if you need
+ * all three. Example, in the case of OMPL if you have a contact distance of zero you can get a performance increase,
+ * by disabling the penetration and distance calculation because they add no value.
+ *
+ * Note: This will not be able to be removed.
+ */
 class TesseractGjkPairDetector : public btDiscreteCollisionDetectorInterface
 {
   btVector3 m_cachedSeparatingAxis;

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
@@ -79,12 +79,10 @@ public:
                            btConvexPenetrationDepthSolver* penetrationDepthSolver,
                            const ContactTestData* cdata);
 
-  virtual ~TesseractGjkPairDetector(){};
-
-  virtual void getClosestPoints(const ClosestPointInput& input,
-                                Result& output,
-                                class btIDebugDraw* debugDraw,
-                                bool swapResults = false);
+  void getClosestPoints(const ClosestPointInput& input,
+                        Result& output,
+                        class btIDebugDraw* debugDraw,
+                        bool swapResults = false) override;
 
   void getClosestPointsNonVirtual(const ClosestPointInput& input, Result& output, class btIDebugDraw* debugDraw);
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/common.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/common.h
@@ -111,7 +111,7 @@ inline ContactResult* processResult(ContactTestData& cdata,
   if (!found)
   {
     ContactResultVector data;
-    if (cdata.type == ContactTestType::FIRST)
+    if (cdata.req.type == ContactTestType::FIRST)
     {
       data.emplace_back(contact);
       cdata.done = true;
@@ -125,15 +125,15 @@ inline ContactResult* processResult(ContactTestData& cdata,
     return &(cdata.res->insert(std::make_pair(key, data)).first->second.back());
   }
 
-  assert(cdata.type != ContactTestType::FIRST);
+  assert(cdata.req.type != ContactTestType::FIRST);
   ContactResultVector& dr = (*cdata.res)[key];
-  if (cdata.type == ContactTestType::ALL)
+  if (cdata.req.type == ContactTestType::ALL)
   {
     dr.emplace_back(contact);
     return &(dr.back());
   }
 
-  if (cdata.type == ContactTestType::CLOSEST)
+  if (cdata.req.type == ContactTestType::CLOSEST)
   {
     if (contact.distance < dr[0].distance)
     {

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/continuous_contact_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/continuous_contact_manager.h
@@ -226,7 +226,7 @@ public:
    * @param collisions The Contact results data
    * @param type The type of contact test
    */
-  virtual void contactTest(ContactResultMap& collisions, const ContactTestType& type) = 0;
+  virtual void contactTest(ContactResultMap& collisions, const ContactRequest& request) = 0;
 };
 
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/discrete_contact_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/discrete_contact_manager.h
@@ -174,9 +174,10 @@ public:
 
   /**
    * @brief Perform a contact test for all objects based
-   * @param collisions The Contact results data
+   * @param collisions The contact results data
+   * @param request The contact request data
    */
-  virtual void contactTest(ContactResultMap& collisions, const ContactTestType& type) = 0;
+  virtual void contactTest(ContactResultMap& collisions, const ContactRequest& request) = 0;
 };
 
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
@@ -115,7 +115,12 @@ struct ContactResult
   Eigen::Vector3d nearest_points_local[2];
   /** @brief The transform of link in world coordinates */
   Eigen::Isometry3d transform[2];
-  /** @brief The normal vector to move the two objects out of contact in world coordinates */
+  /**
+   * @brief The normal vector to move the two objects out of contact in world coordinates
+   *
+   * @note This points from link_name[0] to link_name[1], so it shows the direction to move link_name[1] to avoid or get
+   *       out of collision with link_name[0].
+   */
   Eigen::Vector3d normal;
   /** @brief This is between 0 and 1 indicating the point of contact */
   double cc_time[2];
@@ -127,6 +132,11 @@ struct ContactResult
    *       transform and cc_transform;
    */
   Eigen::Isometry3d cc_transform[2];
+
+  /** @brief Some collision checkers only provide a single contact point for a given pair. This is used to indicate
+   * if only one contact point is provided which means nearest_points[0] must equal nearest_points[1].
+   */
+  bool single_contact_point{ false };
 
   ContactResult() { clear(); }
 
@@ -155,6 +165,7 @@ struct ContactResult
     cc_type[1] = ContinuousCollisionType::CCType_None;
     cc_transform[0] = Eigen::Isometry3d::Identity();
     cc_transform[1] = Eigen::Isometry3d::Identity();
+    single_contact_point = false;
   }
 };
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
@@ -93,7 +93,6 @@ struct ContactRequest
   long contact_limit{ 0 };
 
   ContactRequest(ContactTestType type = ContactTestType::ALL) : type(type) {}
-  virtual ~ContactRequest() = default;
 };
 
 struct ContactResult

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
@@ -76,6 +76,26 @@ static const std::vector<std::string> ContactTestTypeStrings = {
   "LIMITED",
 };
 
+/** @brief The ContactRequest struct */
+struct ContactRequest
+{
+  /** @brief This controls the exit condition for the contact test type */
+  ContactTestType type{ ContactTestType::ALL };
+
+  /** @brief This enables the calculation of penetration contact data if two objects are in collision */
+  bool calculate_penetration{ true };
+
+  /** @brief This enables the calculation of distance data if two objects are within the contact threshold */
+  bool calculate_distance{ true };
+
+  /** @brief This is used if the ContactTestType is set to LIMITED, where the test will exit when number of contacts
+   * reach this limit */
+  long contact_limit{ 0 };
+
+  ContactRequest(ContactTestType type = ContactTestType::ALL) : type(type) {}
+  virtual ~ContactRequest() = default;
+};
+
 struct ContactResult
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -180,9 +200,9 @@ struct ContactTestData
   ContactTestData(const std::vector<std::string>& active,
                   double contact_distance,
                   IsContactAllowedFn fn,
-                  ContactTestType type,
+                  ContactRequest req,
                   ContactResultMap& res)
-    : active(&active), contact_distance(contact_distance), fn(std::move(fn)), type(type), res(&res)
+    : active(&active), contact_distance(contact_distance), fn(std::move(fn)), req(req), res(&res)
   {
   }
 
@@ -195,8 +215,8 @@ struct ContactTestData
   /** @brief The allowed collision function used to check if two links should be excluded from collision checking */
   IsContactAllowedFn fn{ nullptr };
 
-  /** @brief The type of contact test to perform */
-  ContactTestType type{ ContactTestType::ALL };
+  /** @brief The type of contact request data */
+  ContactRequest req;
 
   /** @brief Destance query results information */
   ContactResultMap* res{ nullptr };

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
@@ -39,7 +39,7 @@ namespace tesseract_collision_fcl
 /**
  * @brief This is a wrapper around FCL Collision Object Class which allows you to expand the AABB by the contact dist.
  *
- * This significantly improves when making distance requests if performing a contact tests type FIRST.
+ * This significantly improves performance when making distance requests if performing a contact tests type FIRST.
  */
 class FCLCollisionObjectWrapper : public fcl::CollisionObject<double>
 {

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
@@ -1,0 +1,78 @@
+/**
+ * @file fcl_collision_object_wrapper.h
+ * @brief Collision Object Wrapper to modify AABB with contact distance threshold
+ *
+ * @author Levi Armstrong
+ * @date April 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COLLISION_FCL_COLLISION_OBJECT_WRAPPER_H
+#define TESSERACT_COLLISION_FCL_COLLISION_OBJECT_WRAPPER_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <fcl/narrowphase/collision_object.h>
+#include <memory>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_collision
+{
+namespace tesseract_collision_fcl
+{
+/**
+ * @brief This is a wrapper around FCL Collision Object Class which allows you to expand the AABB by the contact dist.
+ *
+ * This significantly improves when making distance requests if performing a contact tests type FIRST.
+ */
+class FCLCollisionObjectWrapper : public fcl::CollisionObject<double>
+{
+public:
+  FCLCollisionObjectWrapper(const std::shared_ptr<fcl::CollisionGeometry<double>>& cgeom);
+
+  FCLCollisionObjectWrapper(const std::shared_ptr<fcl::CollisionGeometry<double>>& cgeom,
+                            const fcl::Transform3<double>& tf);
+
+  FCLCollisionObjectWrapper(const std::shared_ptr<fcl::CollisionGeometry<double>>& cgeom,
+                            const fcl::Matrix3<double>& R,
+                            const fcl::Vector3<double>& T);
+
+  /**
+   * @brief Set the collision objects contact distance threshold.
+   *
+   * This automatically calls updateAABB() which increases the AABB by the contact distance.
+   * @param contact_distance The contact distance threshold.
+   */
+  void setContactDistanceThreshold(double contact_distance);
+
+  /**
+   * @brief Update the internal AABB. This must be called instead of the base class computeAABB().
+   *
+   * After setting the collision objects transform this must be called.
+   */
+  void updateAABB();
+
+protected:
+  double contact_distance_{ 0 }; /**< @brief The contact distance threshold. */
+};
+
+}  // namespace tesseract_collision_fcl
+}  // namespace tesseract_collision
+
+#endif  // TESSERACT_COLLISION_FCL_COLLISION_OBJECT_WRAPPER_H

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
@@ -62,6 +62,12 @@ public:
   void setContactDistanceThreshold(double contact_distance);
 
   /**
+   * @brief Get the collision objects contact distance threshold.
+   * @return The contact distance threshold.
+   */
+  double getContactDistanceThreshold() const;
+
+  /**
    * @brief Update the internal AABB. This must be called instead of the base class computeAABB().
    *
    * After setting the collision objects transform this must be called.

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -128,6 +128,7 @@ private:
   std::vector<std::string> collision_objects_; /**< @brief A list of the collision objects */
   double contact_distance_;                    /**< @brief The contact distance threshold */
   IsContactAllowedFn fn_;                      /**< @brief The is allowed collision function */
+  std::size_t fcl_co_count_{ 0 };              /**< @brief The number fcl collision objects */
 
   /** @brief This is used to store static collision objects to update */
   std::vector<CollisionObjectRawPtr> static_update_;

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -108,7 +108,7 @@ public:
 
   IsContactAllowedFn getIsContactAllowedFn() const override;
 
-  void contactTest(ContactResultMap& collisions, const ContactTestType& type) override;
+  void contactTest(ContactResultMap& collisions, const ContactRequest& request) override;
 
   /**
    * @brief Add a fcl collision object to the manager
@@ -117,13 +117,23 @@ public:
   void addCollisionObject(const COW::Ptr& cow);
 
 private:
-  std::unique_ptr<fcl::BroadPhaseCollisionManagerd> manager_; /**< @brief FCL Broad Phase Collision Manager */
-  Link2COW link2cow_; /**< @brief A map of all (static and active) collision objects being managed */
+  /** @brief Broadphase Collision Manager for active collision objects */
+  std::unique_ptr<fcl::BroadPhaseCollisionManagerd> static_manager_;
 
-  std::vector<std::string> active_;            /**< @brief A list of the active collision objects */
+  /** @brief Broadphase Collision Manager for active collision objects */
+  std::unique_ptr<fcl::BroadPhaseCollisionManagerd> dynamic_manager_;
+
+  Link2COW link2cow_;               /**< @brief A map of all (static and active) collision objects being managed */
+  std::vector<std::string> active_; /**< @brief A list of the active collision objects */
   std::vector<std::string> collision_objects_; /**< @brief A list of the collision objects */
   double contact_distance_;                    /**< @brief The contact distance threshold */
   IsContactAllowedFn fn_;                      /**< @brief The is allowed collision function */
+
+  /** @brief This is used to store static collision objects to update */
+  std::vector<CollisionObjectRawPtr> static_update_;
+
+  /** @brief This is used to store dynamic collision objects to update */
+  std::vector<CollisionObjectRawPtr> dynamic_update_;
 };
 
 }  // namespace tesseract_collision_fcl

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_utils.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_utils.h
@@ -72,6 +72,10 @@ enum CollisionFilterGroups
   AllFilter = -1  // all bits sets: DefaultFilter | StaticFilter | KinematicFilter
 };
 
+/**
+ * @brief This is a Tesseract link collision object wrapper which add items specific to tesseract. It is a wrapper
+ * around a tesseract link which may contain several collision objects.
+ */
 class CollisionObjectWrapper
 {
 public:
@@ -241,6 +245,9 @@ inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
     cow->m_collisionFilterGroup = CollisionFilterGroups::KinematicFilter;
   }
 
+  // If the group is StaticFilter then the Mask is KinematicFilter, then StaticFilter groups can only collide with
+  // KinematicFilter groups. If the group is KinematicFilter then the mask is StaticFilter and KinematicFilter meaning
+  // that KinematicFilter groups can collide with both StaticFilter and KinematicFilter groups.
   if (cow->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
   {
     cow->m_collisionFilterMask = CollisionFilterGroups::KinematicFilter;

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
@@ -71,7 +71,7 @@ static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)
   for (auto _ : state)
   {
     result.clear();
-    info.contact_manager_->contactTest(result, info.contact_test_type_);
+    info.contact_manager_->contactTest(result, ContactRequest(info.contact_test_type_));
   }
 };
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
@@ -140,7 +140,7 @@ inline void runTest(ContinuousContactManager& checker)
   for (const auto& t : test_types)
   {
     ContactResultMap result;
-    checker.contactTest(result, t);
+    checker.contactTest(result, ContactRequest(t));
 
     ContactResultVector result_vector;
     flattenResults(std::move(result), result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
@@ -123,7 +123,9 @@ inline void runTest(ContinuousContactManager& checker)
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.1, 1e-5);
 
   // Set the collision object transforms
-  checker.setCollisionObjectsTransform("static_box_link", Eigen::Isometry3d::Identity());
+  std::vector<std::string> names = { "static_box_link" };
+  tesseract_common::VectorIsometry3d transforms = { Eigen::Isometry3d::Identity() };
+  checker.setCollisionObjectsTransform(names, transforms);
 
   Eigen::Isometry3d start_pos, end_pos;
   start_pos.setIdentity();

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -145,7 +145,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, test_type);
+  checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -189,7 +189,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
 
   checker.setContactDistanceThreshold(0.25);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.25, 1e-5);
-  checker.contactTest(result, test_type);
+  checker.contactTest(result, ContactRequest(test_type));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -159,8 +159,18 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], -0.3, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 1.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (-0.3)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (1.0)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], -0.3, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 1.0, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * -1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -203,8 +213,18 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 1.1, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 1.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (1.1)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (1.0)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 1.1, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 1.0, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * -1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -174,7 +174,9 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   result_vector.clear();
 
   // Use different method for setting transforms
-  checker.setCollisionObjectsTransform("box_link", location["box_link"]);
+  std::vector<std::string> names = { "box_link" };
+  tesseract_common::VectorIsometry3d transforms = { location["box_link"] };
+  checker.setCollisionObjectsTransform(names, transforms);
   checker.contactTest(result, test_type);
   flattenResults(std::move(result), result_vector);
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
@@ -122,7 +122,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -152,7 +152,7 @@ inline void runTest(DiscreteContactManager& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -166,7 +166,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.251);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.251, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
@@ -129,16 +129,25 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.55, 0.0001);
+  EXPECT_NEAR(result_vector[0].nearest_points[0][1], result_vector[0].nearest_points[1][1], 0.001);
   EXPECT_NEAR(result_vector[0].nearest_points[0][2], result_vector[0].nearest_points[1][2], 0.001);
 
   std::vector<int> idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.05)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -178,8 +187,18 @@ inline void runTest(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.625, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][2] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][2] - (0.625)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.625, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 0.0, 0.0011);  // FCL Required the bump in tolerance
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.0011);  // FCL Required the bump in tolerance
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 1.0, 0.0011);  // FCL Required the bump in tolerance

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
@@ -125,7 +125,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -157,7 +157,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   // Use different method for setting transforms
   checker.setCollisionObjectsTransform("cone_link", location["cone_link"]);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -171,7 +171,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.251);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.251, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
@@ -137,12 +137,26 @@ inline void runTest(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], -0.125, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], -0.125, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.05)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][2] - (-0.125)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][2] - (-0.125)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], -0.125, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], -0.125, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -181,12 +195,26 @@ inline void runTest(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], -0.125, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], -0.125, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (0.75)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][2] - (-0.125)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][2] - (-0.125)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], -0.125, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], -0.125, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
@@ -123,7 +123,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -154,7 +154,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   // Use different method for setting transforms
   checker.setCollisionObjectsTransform("cylinder_link", location["cylinder_link"]);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -168,7 +168,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.251);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.251, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
@@ -153,7 +153,9 @@ inline void runTest(DiscreteContactManager& checker)
   result_vector.clear();
 
   // Use different method for setting transforms
-  checker.setCollisionObjectsTransform("cylinder_link", location["cylinder_link"]);
+  std::vector<std::string> names = { "cylinder_link" };
+  tesseract_common::VectorIsometry3d transforms = { location["cylinder_link"] };
+  checker.setCollisionObjectsTransform(names, transforms);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
@@ -130,16 +130,25 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.55, 0.0001);
+  EXPECT_NEAR(result_vector[0].nearest_points[0][1], result_vector[0].nearest_points[1][1], 0.001);
   EXPECT_NEAR(result_vector[0].nearest_points[0][2], result_vector[0].nearest_points[1][2], 0.001);
 
   std::vector<int> idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.05)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -175,16 +184,25 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.25, 0.001);
+  EXPECT_NEAR(result_vector[0].nearest_points[0][1], result_vector[0].nearest_points[1][1], 0.001);
   EXPECT_NEAR(result_vector[0].nearest_points[0][2], result_vector[0].nearest_points[1][2], 0.001);
 
   idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.003);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.003);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (0.75)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
@@ -142,7 +142,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -174,7 +174,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
 
   // Use different method for setting transforms
   checker.setCollisionObjectsTransform("sphere_link", location["sphere_link"]);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -188,7 +188,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.251);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.251, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -227,7 +227,7 @@ inline void runTestConvex(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -255,7 +255,7 @@ inline void runTestConvex(DiscreteContactManager& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -269,7 +269,7 @@ inline void runTestConvex(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.27);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.27, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
@@ -154,12 +154,24 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.05)) > 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[0][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[0][2], 0.0, 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -198,12 +210,24 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (0.75)) > 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[0][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[0][2], 0.0, 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -241,8 +265,18 @@ inline void runTestConvex(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.03776, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.03776)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.03776, 0.001);
+  }
+
   EXPECT_GT((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)), 0.0);
   EXPECT_LT(std::abs(std::acos((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)))), 0.00001);
 
@@ -281,8 +315,18 @@ inline void runTestConvex(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "box_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.76224, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.5)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (0.76224)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.5, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.76224, 0.001);
+  }
+
   EXPECT_GT((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)), 0.0);
   EXPECT_LT(std::abs(std::acos((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)))), 0.00001);
 }

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_clone_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_clone_unit.hpp
@@ -126,7 +126,7 @@ runTest(DiscreteContactManager& checker, double dist_tol = 0.001, double nearest
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -139,7 +139,7 @@ runTest(DiscreteContactManager& checker, double dist_tol = 0.001, double nearest
   ContactResultMap cloned_result;
   DiscreteContactManager::Ptr cloned_checker = checker.clone();
 
-  cloned_checker->contactTest(cloned_result, ContactTestType::CLOSEST);
+  cloned_checker->contactTest(cloned_result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector cloned_result_vector;
   flattenResults(std::move(cloned_result), cloned_result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
@@ -88,7 +88,7 @@ inline void runTestCompound(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::ALL);
+  checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -119,7 +119,7 @@ inline void runTestCompound(ContinuousContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::ALL);
+  checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
@@ -15,7 +15,7 @@ namespace tesseract_collision
 {
 namespace test_suite
 {
-inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = false)
+inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = false, int num_interations = 10)
 {
   // Add Meshed Sphere to checker
   CollisionShapePtr sphere;
@@ -77,18 +77,17 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
   ContactResultVector result_vector;
 
   auto start_time = std::chrono::high_resolution_clock::now();
-  for (auto i = 0; i < 10; ++i)
+  for (auto i = 0; i < num_interations; ++i)
   {
     ContactResultMap result;
     result_vector.clear();
     checker.contactTest(result, ContactRequest(ContactTestType::ALL));
     flattenResults(std::move(result), result_vector);
+    EXPECT_TRUE(result_vector.size() == 300);
   }
   auto end_time = std::chrono::high_resolution_clock::now();
 
   CONSOLE_BRIDGE_logInform("DT: %f ms", std::chrono::duration<double, std::milli>(end_time - start_time).count());
-
-  EXPECT_TRUE(result_vector.size() == 300);
 }
 }  // namespace test_suite
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
@@ -81,7 +81,7 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
   {
     ContactResultMap result;
     result_vector.clear();
-    checker.contactTest(result, ContactTestType::ALL);
+    checker.contactTest(result, ContactRequest(ContactTestType::ALL));
     flattenResults(std::move(result), result_vector);
   }
   auto end_time = std::chrono::high_resolution_clock::now();

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
@@ -136,7 +136,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::ALL);
+  checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -152,7 +152,7 @@ inline void runTest(DiscreteContactManager& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result, ContactTestType::ALL);
+  checker.contactTest(result, ContactRequest(ContactTestType::ALL));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -166,7 +166,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.55);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.55, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -196,7 +196,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.setCollisionObjectsTransform("sphere1_link", location["sphere1_link"]);
   checker.setContactDistanceThreshold(0.55);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.55, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
@@ -101,7 +101,9 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
       {
         Eigen::Isometry3d pose = co.second;
         pose.translation()[1] += 0.1;
-        manager->setCollisionObjectsTransform(co.first, pose);
+        std::vector<std::string> names = { co.first };
+        tesseract_common::VectorIsometry3d transforms = { pose };
+        manager->setCollisionObjectsTransform(names, transforms);
       }
       else if (tn == 2)
       {
@@ -113,7 +115,9 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
       {
         Eigen::Isometry3d pose = co.second;
         pose.translation()[0] -= 0.1;
-        manager->setCollisionObjectsTransform(co.first, pose);
+        std::vector<std::string> names = { co.first };
+        tesseract_common::VectorIsometry3d transforms = { pose };
+        manager->setCollisionObjectsTransform(names, transforms);
       }
     }
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
@@ -118,7 +118,7 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
     }
 
     ContactResultMap result;
-    manager->contactTest(result, ContactTestType::ALL);
+    manager->contactTest(result, ContactRequest(ContactTestType::ALL));
     flattenResults(std::move(result), result_vector[static_cast<size_t>(tn)]);
   }
   auto end_time = std::chrono::high_resolution_clock::now();

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
@@ -86,7 +86,7 @@ inline void runTest(DiscreteContactManager& checker, const std::string& file_pat
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::ALL);
+  checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_octomap_octomap_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_octomap_octomap_unit.hpp
@@ -89,7 +89,7 @@ inline void runTestOctomap(DiscreteContactManager& checker, ContactTestType test
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, test_type);
+  checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -120,7 +120,7 @@ inline void runTestOctomap(ContinuousContactManager& checker, ContactTestType te
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, test_type);
+  checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
@@ -101,7 +101,7 @@ inline void runTestTyped(DiscreteContactManager& checker, double tol, ContactTes
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, test_type);
+  checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_sphere_sphere_cast_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_sphere_sphere_cast_unit.hpp
@@ -166,7 +166,7 @@ inline void runTestPrimitive(ContinuousContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -234,7 +234,7 @@ inline void runTestPrimitive(ContinuousContactManager& checker)
 
   // Perform collision check
   result = ContactResultMap();
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   result_vector = ContactResultVector();
   flattenResults(std::move(result), result_vector);
@@ -310,7 +310,7 @@ inline void runTestConvex(ContinuousContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -378,7 +378,7 @@ inline void runTestConvex(ContinuousContactManager& checker)
 
   // Perform collision check
   result = ContactResultMap();
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   result_vector = ContactResultVector();
   flattenResults(std::move(result), result_vector);

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
@@ -147,7 +147,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -179,7 +179,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform("sphere1_link", location["sphere1_link"]);
 
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -193,7 +193,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.52);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.52, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
@@ -232,7 +232,7 @@ inline void runTestConvex1(DiscreteContactManager& checker)
 
   // Perform collision check
   ContactResultMap result;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
   flattenResults(std::move(result), result_vector);
@@ -264,7 +264,7 @@ inline void runTestConvex1(DiscreteContactManager& checker)
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   EXPECT_TRUE(result_vector.empty());
@@ -280,7 +280,7 @@ inline void runTestConvex2(DiscreteContactManager& checker)
 
   checker.setContactDistanceThreshold(0.55);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.55, 1e-5);
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   // Bullet: 0.524565 {0.237717,0,0} {0.7622825,0,0} Using blender this appears to be the correct result
@@ -313,7 +313,7 @@ inline void runTestConvex3(DiscreteContactManager& checker)
   // Perform collision check
   ContactResultMap result;
   ContactResultVector result_vector;
-  checker.contactTest(result, ContactTestType::CLOSEST);
+  checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
   flattenResults(std::move(result), result_vector);
 
   // Bullet: -0.280223 {0.0425563,0.2308753,-0.0263040} {-0.0425563, -0.0308753, 0.0263040}

--- a/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
+++ b/tesseract/tesseract_collision/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
@@ -159,12 +159,26 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "sphere_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.25, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.25)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.05)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][2] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][2] - (0.0)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.25, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.05, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.0016);  // TODO LEVI: This was increased due to FLC
@@ -203,12 +217,26 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "sphere_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.25, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.25)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (0.75)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][2] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][2] - (0.0)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.25, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.75, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.0, 0.001);
+  }
+
   EXPECT_NEAR(result_vector[0].normal[0], idx[2] * 1.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
@@ -246,12 +274,26 @@ inline void runTestConvex1(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "sphere_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.232874, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], -0.025368, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.032874, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.025368, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.23776)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (-0.032874)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][1] - (0.0)) > 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][2] - (-0.025368)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][2] - (0.025368)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.232874, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][2], -0.025368, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], -0.032874, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], 0.0, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][2], 0.025368, 0.001);
+  }
+
   EXPECT_GT((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)), 0.0);
   EXPECT_LT(std::abs(std::acos((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)))), 0.5);
 
@@ -278,6 +320,13 @@ inline void runTestConvex2(DiscreteContactManager& checker)
   ContactResultMap result;
   ContactResultVector result_vector;
 
+  checker.setActiveCollisionObjects({ "sphere_link", "sphere1_link" });
+  tesseract_common::TransformMap location;
+  location["sphere_link"] = Eigen::Isometry3d::Identity();
+  location["sphere1_link"] = Eigen::Isometry3d::Identity();
+  location["sphere1_link"].translation() = Eigen::Vector3d(1, 0, 0);
+  checker.setCollisionObjectsTransform(location);
+
   checker.setContactDistanceThreshold(0.55);
   EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.55, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
@@ -287,15 +336,25 @@ inline void runTestConvex2(DiscreteContactManager& checker)
   // FCL:    0.546834 {0.237717,-0.0772317,0} {0.7622825,0.0772317}
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.52448, 0.001);
+  EXPECT_NEAR(result_vector[0].nearest_points[0][1], result_vector[0].nearest_points[1][1], 0.001);
+  EXPECT_NEAR(result_vector[0].nearest_points[0][2], result_vector[0].nearest_points[1][2], 0.001);
 
   std::vector<int> idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "sphere_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.23776, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.76224, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[0][1], result_vector[0].nearest_points[1][1], 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[0][2], result_vector[0].nearest_points[1][2], 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][0] - (0.23776)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][0] - (0.76224)) > 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][0], 0.23776, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][0], 0.76224, 0.001);
+  }
+
   EXPECT_GT((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)), 0.0);
   EXPECT_LT(std::abs(std::acos((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(1, 0, 0)))), 0.00001);
 }
@@ -305,6 +364,10 @@ inline void runTestConvex3(DiscreteContactManager& checker)
   //////////////////////////////////////////////////////////////////////
   // Test when object is in collision (Closest Feature face to edge)
   //////////////////////////////////////////////////////////////////////
+  checker.setActiveCollisionObjects({ "sphere_link", "sphere1_link" });
+  checker.setContactDistanceThreshold(0.1);
+  EXPECT_NEAR(checker.getContactDistanceThreshold(), 0.1, 1e-5);
+
   tesseract_common::TransformMap location;
   location["sphere1_link"] = Eigen::Isometry3d::Identity();
   location["sphere1_link"].translation()(1) = 0.2;
@@ -325,12 +388,24 @@ inline void runTestConvex3(DiscreteContactManager& checker)
   if (result_vector[0].link_names[0] != "sphere_link")
     idx = { 1, 0, -1 };
 
-  EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[0]][0]), 0.0425563, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.2308753, 0.001);
-  EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[0]][2]), 0.0263040, 0.001);
-  EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[1]][0]), 0.0425563, 0.001);
-  EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], -0.0308753, 0.001);
-  EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[1]][2]), 0.0263040, 0.001);
+  if (result_vector[0].single_contact_point)
+  {
+    EXPECT_NEAR(result_vector[0].nearest_points[0][0], result_vector[0].nearest_points[1][0], 0.001);
+    EXPECT_FALSE(std::abs(result_vector[0].nearest_points[0][1] - (0.2308753)) > 0.001 &&
+                 std::abs(result_vector[0].nearest_points[0][1] - (-0.0308753)) > 0.001);
+    EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[0]][0]), 0.0425563, 0.001);
+    EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[0]][2]), 0.0263040, 0.001);
+  }
+  else
+  {
+    EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[0]][0]), 0.0425563, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[0]][1], 0.2308753, 0.001);
+    EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[0]][2]), 0.0263040, 0.001);
+    EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[1]][0]), 0.0425563, 0.001);
+    EXPECT_NEAR(result_vector[0].nearest_points[idx[1]][1], -0.0308753, 0.001);
+    EXPECT_NEAR(std::abs(result_vector[0].nearest_points[idx[1]][2]), 0.0263040, 0.001);
+  }
+
   EXPECT_NEAR(std::abs(idx[2] * result_vector[0].normal[0]), 0.3037316, 0.001);
   EXPECT_NEAR(idx[2] * result_vector[0].normal[1], 0.9340783, 0.001);
   EXPECT_NEAR(std::abs(idx[2] * result_vector[0].normal[2]), 0.1877358, 0.001);

--- a/tesseract/tesseract_collision/src/bullet/bullet_cast_bvh_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_cast_bvh_manager.cpp
@@ -166,11 +166,19 @@ bool BulletCastBVHManager::enableCollisionObject(const std::string& name)
   if (it != link2cow_.end())
   {
     it->second->m_enabled = true;
+
+    // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+    // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+    // this must be called or contacts between shapes will be missed.
     if (it->second->getBroadphaseHandle())
       broadphase_->getOverlappingPairCache()->cleanProxyFromPairs(it->second->getBroadphaseHandle(), dispatcher_.get());
 
     auto cast_cow = link2castcow_[name];
     cast_cow->m_enabled = true;
+
+    // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+    // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+    // this must be called or contacts between shapes will be missed.
     if (cast_cow->getBroadphaseHandle())
       broadphase_->getOverlappingPairCache()->cleanProxyFromPairs(cast_cow->getBroadphaseHandle(), dispatcher_.get());
 
@@ -186,11 +194,19 @@ bool BulletCastBVHManager::disableCollisionObject(const std::string& name)
   if (it != link2cow_.end())
   {
     it->second->m_enabled = false;
+
+    // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+    // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+    // this must be called or contacts between shapes will be missed.
     if (it->second->getBroadphaseHandle())
       broadphase_->getOverlappingPairCache()->cleanProxyFromPairs(it->second->getBroadphaseHandle(), dispatcher_.get());
 
     auto cast_cow = link2castcow_[name];
     cast_cow->m_enabled = false;
+
+    // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+    // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+    // this must be called or contacts between shapes will be missed.
     if (cast_cow->getBroadphaseHandle())
       broadphase_->getOverlappingPairCache()->cleanProxyFromPairs(cast_cow->getBroadphaseHandle(), dispatcher_.get());
 

--- a/tesseract/tesseract_collision/src/bullet/bullet_cast_simple_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_cast_simple_manager.cpp
@@ -303,13 +303,13 @@ void BulletCastSimpleManager::setActiveCollisionObjects(const std::vector<std::s
     COW::Ptr& cow = co.second;
 
     // Update with request
-    updateCollisionObjectFilters(active_, *cow);
+    updateCollisionObjectFilters(active_, cow);
 
     // Get the cast collision object
     COW::Ptr cast_cow = link2castcow_[cow->getName()];
 
     // Update with request
-    updateCollisionObjectFilters(active_, *cast_cow);
+    updateCollisionObjectFilters(active_, cast_cow);
 
     // Add to collision object vector
     if (cow->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
@@ -338,10 +338,10 @@ void BulletCastSimpleManager::setContactDistanceThreshold(double contact_distanc
 double BulletCastSimpleManager::getContactDistanceThreshold() const { return contact_test_data_.contact_distance; }
 void BulletCastSimpleManager::setIsContactAllowedFn(IsContactAllowedFn fn) { contact_test_data_.fn = fn; }
 IsContactAllowedFn BulletCastSimpleManager::getIsContactAllowedFn() const { return contact_test_data_.fn; }
-void BulletCastSimpleManager::contactTest(ContactResultMap& collisions, const ContactTestType& type)
+void BulletCastSimpleManager::contactTest(ContactResultMap& collisions, const ContactRequest& request)
 {
   contact_test_data_.res = &collisions;
-  contact_test_data_.type = type;
+  contact_test_data_.req = request;
   contact_test_data_.done = false;
 
   for (auto cow1_iter = cows_.begin(); cow1_iter != (cows_.end() - 1); cow1_iter++)

--- a/tesseract/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
@@ -156,6 +156,10 @@ bool BulletDiscreteBVHManager::enableCollisionObject(const std::string& name)
   if (it != link2cow_.end())
   {
     it->second->m_enabled = true;
+
+    // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+    // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+    // this must be called or contacts between shapes will be missed.
     broadphase_->getOverlappingPairCache()->cleanProxyFromPairs(it->second->getBroadphaseHandle(), dispatcher_.get());
     return true;
   }
@@ -168,6 +172,10 @@ bool BulletDiscreteBVHManager::disableCollisionObject(const std::string& name)
   if (it != link2cow_.end())
   {
     it->second->m_enabled = false;
+
+    // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+    // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+    // this must be called or contacts between shapes will be missed.
     broadphase_->getOverlappingPairCache()->cleanProxyFromPairs(it->second->getBroadphaseHandle(), dispatcher_.get());
     return true;
   }

--- a/tesseract/tesseract_collision/src/bullet/bullet_discrete_simple_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_discrete_simple_manager.cpp
@@ -198,7 +198,7 @@ void BulletDiscreteSimpleManager::setActiveCollisionObjects(const std::vector<st
   {
     COW::Ptr& cow = co.second;
 
-    updateCollisionObjectFilters(active_, *cow);
+    updateCollisionObjectFilters(active_, cow);
 
     // Update collision object vector
     if (cow->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
@@ -220,10 +220,10 @@ void BulletDiscreteSimpleManager::setContactDistanceThreshold(double contact_dis
 double BulletDiscreteSimpleManager::getContactDistanceThreshold() const { return contact_test_data_.contact_distance; }
 void BulletDiscreteSimpleManager::setIsContactAllowedFn(IsContactAllowedFn fn) { contact_test_data_.fn = fn; }
 IsContactAllowedFn BulletDiscreteSimpleManager::getIsContactAllowedFn() const { return contact_test_data_.fn; }
-void BulletDiscreteSimpleManager::contactTest(ContactResultMap& collisions, const ContactTestType& type)
+void BulletDiscreteSimpleManager::contactTest(ContactResultMap& collisions, const ContactRequest& request)
 {
   contact_test_data_.res = &collisions;
-  contact_test_data_.type = type;
+  contact_test_data_.req = request;
   contact_test_data_.done = false;
 
   for (auto cow1_iter = cows_.begin(); cow1_iter != (cows_.end() - 1); cow1_iter++)

--- a/tesseract/tesseract_collision/src/bullet/bullet_utils.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_utils.cpp
@@ -52,6 +52,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <octomap/octomap.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+// Bullet adds a margin of 5cm to which is an extern variable, so we set it to zero.
 btScalar gDbvtMargin = 0;
 
 namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/bullet/bullet_utils.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_utils.cpp
@@ -52,6 +52,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <octomap/octomap.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+btScalar gDbvtMargin = 0;
+
 namespace tesseract_collision
 {
 namespace tesseract_collision_bullet

--- a/tesseract/tesseract_collision/src/bullet/tesseract_collision_configuration.cpp
+++ b/tesseract/tesseract_collision/src/bullet/tesseract_collision_configuration.cpp
@@ -41,7 +41,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <BulletCollision/CollisionDispatch/btConvexConvexAlgorithm.h>
 #include <BulletCollision/CollisionDispatch/btConvexConcaveCollisionAlgorithm.h>
 #include <LinearMath/btPoolAllocator.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -49,6 +48,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/bullet/tesseract_collision_configuration.h>
 #include <tesseract_collision/bullet/tesseract_compound_collision_algorithm.h>
 #include <tesseract_collision/bullet/tesseract_compound_compound_collision_algorithm.h>
+#include <tesseract_collision/bullet/tesseract_convex_convex_algorithm.h>
 
 namespace tesseract_collision
 {
@@ -69,6 +69,9 @@ TesseractCollisionConfiguration::TesseractCollisionConfiguration(
   m_swappedCompoundCreateFunc->~btCollisionAlgorithmCreateFunc();
   btAlignedFree(m_swappedCompoundCreateFunc);
 
+  m_convexConvexCreateFunc->~btCollisionAlgorithmCreateFunc();
+  btAlignedFree(m_convexConvexCreateFunc);
+
   if (m_ownsCollisionAlgorithmPool)
   {
     m_collisionAlgorithmPool->~btPoolAllocator();
@@ -80,6 +83,9 @@ TesseractCollisionConfiguration::TesseractCollisionConfiguration(
     btAlignedFree(m_persistentManifoldPool);
   }
 
+  mem = btAlignedAlloc(sizeof(TesseractConvexConvexAlgorithm::CreateFunc), 16);
+  m_convexConvexCreateFunc = new (mem) TesseractConvexConvexAlgorithm::CreateFunc(m_pdSolver);
+
   mem = btAlignedAlloc(sizeof(TesseractCompoundCollisionAlgorithm::CreateFunc), 16);
   m_compoundCreateFunc = new (mem) TesseractCompoundCollisionAlgorithm::CreateFunc;
 
@@ -90,7 +96,7 @@ TesseractCollisionConfiguration::TesseractCollisionConfiguration(
   m_swappedCompoundCreateFunc = new (mem) TesseractCompoundCollisionAlgorithm::SwappedCreateFunc;
 
   /// calculate maximum element size, big enough to fit any collision algorithm in the memory pool
-  int maxSize = sizeof(btConvexConvexAlgorithm);
+  int maxSize = sizeof(TesseractConvexConvexAlgorithm);
   int maxSize2 = sizeof(btConvexConcaveCollisionAlgorithm);
   int maxSize3 = sizeof(TesseractCompoundCollisionAlgorithm);
   int maxSize4 = sizeof(TesseractCompoundCompoundCollisionAlgorithm);

--- a/tesseract/tesseract_collision/src/bullet/tesseract_convex_convex_algorithm.cpp
+++ b/tesseract/tesseract_collision/src/bullet/tesseract_convex_convex_algorithm.cpp
@@ -1,0 +1,963 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If
+you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not
+required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original
+software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+/// Specialized capsule-capsule collision algorithm has been added for Bullet 2.75 release to increase ragdoll
+/// performance If you experience problems with capsule-capsule collision, try to define
+/// BT_DISABLE_CAPSULE_CAPSULE_COLLIDER and report it in the Bullet forums with reproduction case
+//#define BT_DISABLE_CAPSULE_CAPSULE_COLLIDER 1
+//#define ZERO_MARGIN
+
+#include <tesseract_collision/bullet/tesseract_convex_convex_algorithm.h>
+#include <tesseract_collision/bullet/tesseract_gjk_pair_detector.h>
+
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/NarrowPhaseCollision/btDiscreteCollisionDetectorInterface.h>
+#include <BulletCollision/BroadphaseCollision/btBroadphaseInterface.h>
+#include <BulletCollision/CollisionDispatch/btCollisionObject.h>
+#include <BulletCollision/CollisionShapes/btConvexShape.h>
+#include <BulletCollision/CollisionShapes/btCapsuleShape.h>
+#include <BulletCollision/CollisionShapes/btTriangleShape.h>
+#include <BulletCollision/CollisionShapes/btConvexPolyhedron.h>
+
+//#include <BulletCollision/NarrowPhaseCollision/btGjkPairDetector.h>
+#include <BulletCollision/BroadphaseCollision/btBroadphaseProxy.h>
+#include <BulletCollision/CollisionDispatch/btCollisionDispatcher.h>
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionDispatch/btManifoldResult.h>
+
+#include <BulletCollision/NarrowPhaseCollision/btConvexPenetrationDepthSolver.h>
+#include <BulletCollision/NarrowPhaseCollision/btContinuousConvexCollision.h>
+#include <BulletCollision/NarrowPhaseCollision/btSubSimplexConvexCast.h>
+#include <BulletCollision/NarrowPhaseCollision/btGjkConvexCast.h>
+
+#include <BulletCollision/NarrowPhaseCollision/btVoronoiSimplexSolver.h>
+#include <BulletCollision/CollisionShapes/btSphereShape.h>
+
+#include <BulletCollision/NarrowPhaseCollision/btMinkowskiPenetrationDepthSolver.h>
+
+#include <BulletCollision/NarrowPhaseCollision/btGjkEpa2.h>
+#include <BulletCollision/NarrowPhaseCollision/btGjkEpaPenetrationDepthSolver.h>
+#include <BulletCollision/NarrowPhaseCollision/btPolyhedralContactClipping.h>
+#include <BulletCollision/CollisionDispatch/btCollisionObjectWrapper.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+///////////
+extern btScalar gContactBreakingThreshold;
+
+namespace tesseract_collision
+{
+namespace tesseract_collision_bullet
+{
+static SIMD_FORCE_INLINE void segmentsClosestPoints(btVector3& ptsVector,
+                                                    btVector3& offsetA,
+                                                    btVector3& offsetB,
+                                                    btScalar& tA,
+                                                    btScalar& tB,
+                                                    const btVector3& translation,
+                                                    const btVector3& dirA,
+                                                    btScalar hlenA,
+                                                    const btVector3& dirB,
+                                                    btScalar hlenB)
+{
+  // compute the parameters of the closest points on each line segment
+
+  btScalar dirA_dot_dirB = btDot(dirA, dirB);
+  btScalar dirA_dot_trans = btDot(dirA, translation);
+  btScalar dirB_dot_trans = btDot(dirB, translation);
+
+  btScalar denom = 1.0f - dirA_dot_dirB * dirA_dot_dirB;
+
+  if (denom == 0.0f)
+  {
+    tA = 0.0f;
+  }
+  else
+  {
+    tA = (dirA_dot_trans - dirB_dot_trans * dirA_dot_dirB) / denom;
+    if (tA < -hlenA)
+      tA = -hlenA;
+    else if (tA > hlenA)
+      tA = hlenA;
+  }
+
+  tB = tA * dirA_dot_dirB - dirB_dot_trans;
+
+  if (tB < -hlenB)
+  {
+    tB = -hlenB;
+    tA = tB * dirA_dot_dirB + dirA_dot_trans;
+
+    if (tA < -hlenA)
+      tA = -hlenA;
+    else if (tA > hlenA)
+      tA = hlenA;
+  }
+  else if (tB > hlenB)
+  {
+    tB = hlenB;
+    tA = tB * dirA_dot_dirB + dirA_dot_trans;
+
+    if (tA < -hlenA)
+      tA = -hlenA;
+    else if (tA > hlenA)
+      tA = hlenA;
+  }
+
+  // compute the closest points relative to segment centers.
+
+  offsetA = dirA * tA;
+  offsetB = dirB * tB;
+
+  ptsVector = translation - offsetA + offsetB;
+}
+
+static SIMD_FORCE_INLINE btScalar capsuleCapsuleDistance(btVector3& normalOnB,
+                                                         btVector3& pointOnB,
+                                                         btScalar capsuleLengthA,
+                                                         btScalar capsuleRadiusA,
+                                                         btScalar capsuleLengthB,
+                                                         btScalar capsuleRadiusB,
+                                                         int capsuleAxisA,
+                                                         int capsuleAxisB,
+                                                         const btTransform& transformA,
+                                                         const btTransform& transformB,
+                                                         btScalar distanceThreshold)
+{
+  btVector3 directionA = transformA.getBasis().getColumn(capsuleAxisA);
+  btVector3 translationA = transformA.getOrigin();
+  btVector3 directionB = transformB.getBasis().getColumn(capsuleAxisB);
+  btVector3 translationB = transformB.getOrigin();
+
+  // translation between centers
+
+  btVector3 translation = translationB - translationA;
+
+  // compute the closest points of the capsule line segments
+
+  btVector3 ptsVector;  // the vector between the closest points
+
+  btVector3 offsetA, offsetB;  // offsets from segment centers to their closest points
+  btScalar tA, tB;             // parameters on line segment
+
+  segmentsClosestPoints(
+      ptsVector, offsetA, offsetB, tA, tB, translation, directionA, capsuleLengthA, directionB, capsuleLengthB);
+
+  btScalar distance = ptsVector.length() - capsuleRadiusA - capsuleRadiusB;
+
+  if (distance > distanceThreshold)
+    return distance;
+
+  btScalar lenSqr = ptsVector.length2();
+  if (lenSqr <= (SIMD_EPSILON * SIMD_EPSILON))
+  {
+    // degenerate case where 2 capsules are likely at the same location: take a vector tangential to 'directionA'
+    btVector3 q;
+    btPlaneSpace1(directionA, normalOnB, q);
+  }
+  else
+  {
+    // compute the contact normal
+    normalOnB = ptsVector * -btRecipSqrt(lenSqr);
+  }
+  pointOnB = transformB.getOrigin() + offsetB + normalOnB * capsuleRadiusB;
+
+  return distance;
+}
+
+//////////
+
+TesseractConvexConvexAlgorithm::CreateFunc::CreateFunc(btConvexPenetrationDepthSolver* pdSolver)
+{
+  m_numPerturbationIterations = 0;
+  m_minimumPointsPerturbationThreshold = 3;
+  m_pdSolver = pdSolver;
+}
+
+TesseractConvexConvexAlgorithm::CreateFunc::~CreateFunc() {}
+
+TesseractConvexConvexAlgorithm::TesseractConvexConvexAlgorithm(btPersistentManifold* mf,
+                                                               const btCollisionAlgorithmConstructionInfo& ci,
+                                                               const btCollisionObjectWrapper* body0Wrap,
+                                                               const btCollisionObjectWrapper* body1Wrap,
+                                                               btConvexPenetrationDepthSolver* pdSolver,
+                                                               int numPerturbationIterations,
+                                                               int minimumPointsPerturbationThreshold)
+  : btActivatingCollisionAlgorithm(ci, body0Wrap, body1Wrap)
+  , m_pdSolver(pdSolver)
+  , m_ownManifold(false)
+  , m_manifoldPtr(mf)
+  , m_lowLevelOfDetail(false)
+  ,
+#ifdef USE_SEPDISTANCE_UTIL2
+  m_sepDistance((static_cast<btConvexShape*>(body0->getCollisionShape()))->getAngularMotionDisc(),
+                (static_cast<btConvexShape*>(body1->getCollisionShape()))->getAngularMotionDisc())
+  ,
+#endif
+  m_numPerturbationIterations(numPerturbationIterations)
+  , m_minimumPointsPerturbationThreshold(minimumPointsPerturbationThreshold)
+  , m_cdata(static_cast<ContactTestData*>(body0Wrap->m_collisionObject->getUserPointer()))
+{
+  (void)body0Wrap;
+  (void)body1Wrap;
+  assert(m_cdata != nullptr);
+}
+
+TesseractConvexConvexAlgorithm::~TesseractConvexConvexAlgorithm()
+{
+  if (m_ownManifold)
+  {
+    if (m_manifoldPtr)
+      m_dispatcher->releaseManifold(m_manifoldPtr);
+  }
+}
+
+void TesseractConvexConvexAlgorithm::setLowLevelOfDetail(bool useLowLevel) { m_lowLevelOfDetail = useLowLevel; }
+
+struct btPerturbedContactResult : public btManifoldResult
+{
+  btManifoldResult* m_originalManifoldResult;
+  btTransform m_transformA;
+  btTransform m_transformB;
+  btTransform m_unPerturbedTransform;
+  bool m_perturbA;
+  btIDebugDraw* m_debugDrawer;
+
+  btPerturbedContactResult(btManifoldResult* originalResult,
+                           const btTransform& transformA,
+                           const btTransform& transformB,
+                           const btTransform& unPerturbedTransform,
+                           bool perturbA,
+                           btIDebugDraw* debugDrawer)
+    : m_originalManifoldResult(originalResult)
+    , m_transformA(transformA)
+    , m_transformB(transformB)
+    , m_unPerturbedTransform(unPerturbedTransform)
+    , m_perturbA(perturbA)
+    , m_debugDrawer(debugDrawer)
+  {
+  }
+  virtual ~btPerturbedContactResult() {}
+
+  virtual void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar orgDepth)
+  {
+    btVector3 endPt, startPt;
+    btScalar newDepth;
+    btVector3 newNormal;
+
+    if (m_perturbA)
+    {
+      btVector3 endPtOrg = pointInWorld + normalOnBInWorld * orgDepth;
+      endPt = (m_unPerturbedTransform * m_transformA.inverse())(endPtOrg);
+      newDepth = (endPt - pointInWorld).dot(normalOnBInWorld);
+      startPt = endPt - normalOnBInWorld * newDepth;
+    }
+    else
+    {
+      endPt = pointInWorld + normalOnBInWorld * orgDepth;
+      startPt = (m_unPerturbedTransform * m_transformB.inverse())(pointInWorld);
+      newDepth = (endPt - startPt).dot(normalOnBInWorld);
+    }
+
+//#define DEBUG_CONTACTS 1
+#ifdef DEBUG_CONTACTS
+    m_debugDrawer->drawLine(startPt, endPt, btVector3(1, 0, 0));
+    m_debugDrawer->drawSphere(startPt, 0.05, btVector3(0, 1, 0));
+    m_debugDrawer->drawSphere(endPt, 0.05, btVector3(0, 0, 1));
+#endif  // DEBUG_CONTACTS
+
+    m_originalManifoldResult->addContactPoint(normalOnBInWorld, startPt, newDepth);
+  }
+};
+
+//
+// Convex-Convex collision algorithm
+//
+void TesseractConvexConvexAlgorithm::processCollision(const btCollisionObjectWrapper* body0Wrap,
+                                                      const btCollisionObjectWrapper* body1Wrap,
+                                                      const btDispatcherInfo& dispatchInfo,
+                                                      btManifoldResult* resultOut)
+{
+  if (!m_manifoldPtr)
+  {
+    // swapped?
+    m_manifoldPtr = m_dispatcher->getNewManifold(body0Wrap->getCollisionObject(), body1Wrap->getCollisionObject());
+    m_ownManifold = true;
+  }
+  resultOut->setPersistentManifold(m_manifoldPtr);
+
+  // comment-out next line to test multi-contact generation
+  // resultOut->getPersistentManifold()->clearManifold();
+
+  const btConvexShape* min0 = static_cast<const btConvexShape*>(body0Wrap->getCollisionShape());
+  const btConvexShape* min1 = static_cast<const btConvexShape*>(body1Wrap->getCollisionShape());
+
+  btVector3 normalOnB;
+  btVector3 pointOnBWorld;
+#ifndef BT_DISABLE_CAPSULE_CAPSULE_COLLIDER
+  if ((min0->getShapeType() == CAPSULE_SHAPE_PROXYTYPE) && (min1->getShapeType() == CAPSULE_SHAPE_PROXYTYPE))
+  {
+    // m_manifoldPtr->clearManifold();
+
+    btCapsuleShape* capsuleA = (btCapsuleShape*)min0;
+    btCapsuleShape* capsuleB = (btCapsuleShape*)min1;
+
+    btScalar threshold = m_manifoldPtr->getContactBreakingThreshold() + resultOut->m_closestPointDistanceThreshold;
+
+    btScalar dist = capsuleCapsuleDistance(normalOnB,
+                                           pointOnBWorld,
+                                           capsuleA->getHalfHeight(),
+                                           capsuleA->getRadius(),
+                                           capsuleB->getHalfHeight(),
+                                           capsuleB->getRadius(),
+                                           capsuleA->getUpAxis(),
+                                           capsuleB->getUpAxis(),
+                                           body0Wrap->getWorldTransform(),
+                                           body1Wrap->getWorldTransform(),
+                                           threshold);
+
+    if (dist < threshold)
+    {
+      btAssert(normalOnB.length2() >= (SIMD_EPSILON * SIMD_EPSILON));
+      resultOut->addContactPoint(normalOnB, pointOnBWorld, dist);
+    }
+    resultOut->refreshContactPoints();
+    return;
+  }
+
+  if ((min0->getShapeType() == CAPSULE_SHAPE_PROXYTYPE) && (min1->getShapeType() == SPHERE_SHAPE_PROXYTYPE))
+  {
+    // m_manifoldPtr->clearManifold();
+
+    btCapsuleShape* capsuleA = (btCapsuleShape*)min0;
+    btSphereShape* capsuleB = (btSphereShape*)min1;
+
+    btScalar threshold = m_manifoldPtr->getContactBreakingThreshold() + resultOut->m_closestPointDistanceThreshold;
+
+    btScalar dist = capsuleCapsuleDistance(normalOnB,
+                                           pointOnBWorld,
+                                           capsuleA->getHalfHeight(),
+                                           capsuleA->getRadius(),
+                                           0.,
+                                           capsuleB->getRadius(),
+                                           capsuleA->getUpAxis(),
+                                           1,
+                                           body0Wrap->getWorldTransform(),
+                                           body1Wrap->getWorldTransform(),
+                                           threshold);
+
+    if (dist < threshold)
+    {
+      btAssert(normalOnB.length2() >= (SIMD_EPSILON * SIMD_EPSILON));
+      resultOut->addContactPoint(normalOnB, pointOnBWorld, dist);
+    }
+    resultOut->refreshContactPoints();
+    return;
+  }
+
+  if ((min0->getShapeType() == SPHERE_SHAPE_PROXYTYPE) && (min1->getShapeType() == CAPSULE_SHAPE_PROXYTYPE))
+  {
+    // m_manifoldPtr->clearManifold();
+
+    btSphereShape* capsuleA = (btSphereShape*)min0;
+    btCapsuleShape* capsuleB = (btCapsuleShape*)min1;
+
+    btScalar threshold = m_manifoldPtr->getContactBreakingThreshold() + resultOut->m_closestPointDistanceThreshold;
+
+    btScalar dist = capsuleCapsuleDistance(normalOnB,
+                                           pointOnBWorld,
+                                           0.,
+                                           capsuleA->getRadius(),
+                                           capsuleB->getHalfHeight(),
+                                           capsuleB->getRadius(),
+                                           1,
+                                           capsuleB->getUpAxis(),
+                                           body0Wrap->getWorldTransform(),
+                                           body1Wrap->getWorldTransform(),
+                                           threshold);
+
+    if (dist < threshold)
+    {
+      btAssert(normalOnB.length2() >= (SIMD_EPSILON * SIMD_EPSILON));
+      resultOut->addContactPoint(normalOnB, pointOnBWorld, dist);
+    }
+    resultOut->refreshContactPoints();
+    return;
+  }
+#endif  // BT_DISABLE_CAPSULE_CAPSULE_COLLIDER
+
+#ifdef USE_SEPDISTANCE_UTIL2
+  if (dispatchInfo.m_useConvexConservativeDistanceUtil)
+  {
+    m_sepDistance.updateSeparatingDistance(body0->getWorldTransform(), body1->getWorldTransform());
+  }
+
+  if (!dispatchInfo.m_useConvexConservativeDistanceUtil || m_sepDistance.getConservativeSeparatingDistance() <= 0.f)
+#endif  // USE_SEPDISTANCE_UTIL2
+
+  {
+    //    btGjkPairDetector::ClosestPointInput input;
+    //    btVoronoiSimplexSolver simplexSolver;
+    //    btGjkPairDetector gjkPairDetector(min0, min1, &simplexSolver, nullptr); // m_pdSolver);
+    TesseractGjkPairDetector::ClosestPointInput input;
+    btVoronoiSimplexSolver simplexSolver;
+    TesseractGjkPairDetector gjkPairDetector(min0, min1, &simplexSolver, m_pdSolver, m_cdata);
+    // TODO: if (dispatchInfo.m_useContinuous)
+    gjkPairDetector.setMinkowskiA(min0);
+    gjkPairDetector.setMinkowskiB(min1);
+
+#ifdef USE_SEPDISTANCE_UTIL2
+    if (dispatchInfo.m_useConvexConservativeDistanceUtil)
+    {
+      input.m_maximumDistanceSquared = BT_LARGE_FLOAT;
+    }
+    else
+#endif  // USE_SEPDISTANCE_UTIL2
+    {
+      // if (dispatchInfo.m_convexMaxDistanceUseCPT)
+      //{
+      //	input.m_maximumDistanceSquared = min0->getMargin() + min1->getMargin() +
+      // m_manifoldPtr->getContactProcessingThreshold(); } else
+      //{
+      input.m_maximumDistanceSquared = min0->getMargin() + min1->getMargin() +
+                                       m_manifoldPtr->getContactBreakingThreshold() +
+                                       resultOut->m_closestPointDistanceThreshold;
+      //		}
+
+      input.m_maximumDistanceSquared *= input.m_maximumDistanceSquared;
+    }
+
+    input.m_transformA = body0Wrap->getWorldTransform();
+    input.m_transformB = body1Wrap->getWorldTransform();
+
+#ifdef USE_SEPDISTANCE_UTIL2
+    btScalar sepDist = 0.f;
+    if (dispatchInfo.m_useConvexConservativeDistanceUtil)
+    {
+      sepDist = gjkPairDetector.getCachedSeparatingDistance();
+      if (sepDist > SIMD_EPSILON)
+      {
+        sepDist += dispatchInfo.m_convexConservativeDistanceThreshold;
+        // now perturbe directions to get multiple contact points
+      }
+    }
+#endif  // USE_SEPDISTANCE_UTIL2
+
+    if (min0->isPolyhedral() && min1->isPolyhedral())
+    {
+      struct btDummyResult : public btDiscreteCollisionDetectorInterface::Result
+      {
+        btVector3 m_normalOnBInWorld;
+        btVector3 m_pointInWorld;
+        btScalar m_depth;
+        bool m_hasContact;
+
+        btDummyResult() : m_hasContact(false) {}
+
+        virtual void setShapeIdentifiersA(int /*partId0*/, int /*index0*/) {}
+        virtual void setShapeIdentifiersB(int /*partId1*/, int /*index1*/) {}
+        virtual void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth)
+        {
+          m_hasContact = true;
+          m_normalOnBInWorld = normalOnBInWorld;
+          m_pointInWorld = pointInWorld;
+          m_depth = depth;
+        }
+      };
+
+      struct btWithoutMarginResult : public btDiscreteCollisionDetectorInterface::Result
+      {
+        btDiscreteCollisionDetectorInterface::Result* m_originalResult;
+        btVector3 m_reportedNormalOnWorld;
+        btScalar m_marginOnA;
+        btScalar m_marginOnB;
+        btScalar m_reportedDistance;
+
+        bool m_foundResult;
+        btWithoutMarginResult(btDiscreteCollisionDetectorInterface::Result* result,
+                              btScalar marginOnA,
+                              btScalar marginOnB)
+          : m_originalResult(result), m_marginOnA(marginOnA), m_marginOnB(marginOnB), m_foundResult(false)
+        {
+        }
+
+        virtual void setShapeIdentifiersA(int /*partId0*/, int /*index0*/) {}
+        virtual void setShapeIdentifiersB(int /*partId1*/, int /*index1*/) {}
+        virtual void addContactPoint(const btVector3& normalOnBInWorld,
+                                     const btVector3& pointInWorldOrg,
+                                     btScalar depthOrg)
+        {
+          m_reportedDistance = depthOrg;
+          m_reportedNormalOnWorld = normalOnBInWorld;
+
+          btVector3 adjustedPointB = pointInWorldOrg - normalOnBInWorld * m_marginOnB;
+          m_reportedDistance = depthOrg + (m_marginOnA + m_marginOnB);
+          if (m_reportedDistance < 0.f)
+          {
+            m_foundResult = true;
+          }
+          m_originalResult->addContactPoint(normalOnBInWorld, adjustedPointB, m_reportedDistance);
+        }
+      };
+
+      btDummyResult dummy;
+
+      /// btBoxShape is an exception: its vertices are created WITH margin so don't subtract it
+
+      btScalar min0Margin = min0->getShapeType() == BOX_SHAPE_PROXYTYPE ? 0.f : min0->getMargin();
+      btScalar min1Margin = min1->getShapeType() == BOX_SHAPE_PROXYTYPE ? 0.f : min1->getMargin();
+
+      btWithoutMarginResult withoutMargin(resultOut, min0Margin, min1Margin);
+
+      btPolyhedralConvexShape* polyhedronA = (btPolyhedralConvexShape*)min0;
+      btPolyhedralConvexShape* polyhedronB = (btPolyhedralConvexShape*)min1;
+      if (polyhedronA->getConvexPolyhedron() && polyhedronB->getConvexPolyhedron())
+      {
+        btScalar threshold = m_manifoldPtr->getContactBreakingThreshold() + resultOut->m_closestPointDistanceThreshold;
+
+        btScalar minDist = -1e30f;
+        btVector3 sepNormalWorldSpace;
+        bool foundSepAxis = true;
+
+        if (dispatchInfo.m_enableSatConvex)
+        {
+          foundSepAxis = btPolyhedralContactClipping::findSeparatingAxis(*polyhedronA->getConvexPolyhedron(),
+                                                                         *polyhedronB->getConvexPolyhedron(),
+                                                                         body0Wrap->getWorldTransform(),
+                                                                         body1Wrap->getWorldTransform(),
+                                                                         sepNormalWorldSpace,
+                                                                         *resultOut);
+        }
+        else
+        {
+#ifdef ZERO_MARGIN
+          gjkPairDetector.setIgnoreMargin(true);
+          gjkPairDetector.getClosestPoints(input, *resultOut, dispatchInfo.m_debugDraw);
+#else
+
+          gjkPairDetector.getClosestPoints(input, withoutMargin, dispatchInfo.m_debugDraw);
+          // gjkPairDetector.getClosestPoints(input,dummy,dispatchInfo.m_debugDraw);
+#endif  // ZERO_MARGIN
+        // btScalar l2 = gjkPairDetector.getCachedSeparatingAxis().length2();
+        // if (l2>SIMD_EPSILON)
+          {
+            sepNormalWorldSpace =
+                withoutMargin.m_reportedNormalOnWorld;  // gjkPairDetector.getCachedSeparatingAxis()*(1.f/l2);
+            // minDist = -1e30f;//gjkPairDetector.getCachedSeparatingDistance();
+            minDist =
+                withoutMargin
+                    .m_reportedDistance;  // gjkPairDetector.getCachedSeparatingDistance()+min0->getMargin()+min1->getMargin();
+
+#ifdef ZERO_MARGIN
+            foundSepAxis = true;  // gjkPairDetector.getCachedSeparatingDistance()<0.f;
+#else
+            foundSepAxis = withoutMargin.m_foundResult && minDist < 0;  //-(min0->getMargin()+min1->getMargin());
+#endif
+          }
+        }
+        if (foundSepAxis)
+        {
+          //				printf("sepNormalWorldSpace=%f,%f,%f\n",sepNormalWorldSpace.getX(),sepNormalWorldSpace.getY(),sepNormalWorldSpace.getZ());
+
+          worldVertsB1.resize(0);
+          btPolyhedralContactClipping::clipHullAgainstHull(sepNormalWorldSpace,
+                                                           *polyhedronA->getConvexPolyhedron(),
+                                                           *polyhedronB->getConvexPolyhedron(),
+                                                           body0Wrap->getWorldTransform(),
+                                                           body1Wrap->getWorldTransform(),
+                                                           minDist - threshold,
+                                                           threshold,
+                                                           worldVertsB1,
+                                                           worldVertsB2,
+                                                           *resultOut);
+        }
+        if (m_ownManifold)
+        {
+          resultOut->refreshContactPoints();
+        }
+        return;
+      }
+      else
+      {
+        // we can also deal with convex versus triangle (without connectivity data)
+        if (dispatchInfo.m_enableSatConvex && polyhedronA->getConvexPolyhedron() &&
+            polyhedronB->getShapeType() == TRIANGLE_SHAPE_PROXYTYPE)
+        {
+          btVertexArray worldSpaceVertices;
+          btTriangleShape* tri = (btTriangleShape*)polyhedronB;
+          worldSpaceVertices.push_back(body1Wrap->getWorldTransform() * tri->m_vertices1[0]);
+          worldSpaceVertices.push_back(body1Wrap->getWorldTransform() * tri->m_vertices1[1]);
+          worldSpaceVertices.push_back(body1Wrap->getWorldTransform() * tri->m_vertices1[2]);
+
+          // tri->initializePolyhedralFeatures();
+
+          btScalar threshold =
+              m_manifoldPtr->getContactBreakingThreshold() + resultOut->m_closestPointDistanceThreshold;
+
+          btVector3 sepNormalWorldSpace;
+          btScalar minDist = -1e30f;
+          btScalar maxDist = threshold;
+
+          bool foundSepAxis = false;
+          bool useSatSepNormal = true;
+
+          if (useSatSepNormal)
+          {
+#if 0
+          if (0)
+          {
+            //initializePolyhedralFeatures performs a convex hull computation, not needed for a single triangle
+            polyhedronB->initializePolyhedralFeatures();
+          } else
+#endif
+            {
+              btVector3 uniqueEdges[3] = { tri->m_vertices1[1] - tri->m_vertices1[0],
+                                           tri->m_vertices1[2] - tri->m_vertices1[1],
+                                           tri->m_vertices1[0] - tri->m_vertices1[2] };
+
+              uniqueEdges[0].normalize();
+              uniqueEdges[1].normalize();
+              uniqueEdges[2].normalize();
+
+              btConvexPolyhedron polyhedron;
+              polyhedron.m_vertices.push_back(tri->m_vertices1[2]);
+              polyhedron.m_vertices.push_back(tri->m_vertices1[0]);
+              polyhedron.m_vertices.push_back(tri->m_vertices1[1]);
+
+              {
+                btFace combinedFaceA;
+                combinedFaceA.m_indices.push_back(0);
+                combinedFaceA.m_indices.push_back(1);
+                combinedFaceA.m_indices.push_back(2);
+                btVector3 faceNormal = uniqueEdges[0].cross(uniqueEdges[1]);
+                faceNormal.normalize();
+                btScalar planeEq = 1e30f;
+                for (int v = 0; v < combinedFaceA.m_indices.size(); v++)
+                {
+                  btScalar eq = tri->m_vertices1[combinedFaceA.m_indices[v]].dot(faceNormal);
+                  if (planeEq > eq)
+                  {
+                    planeEq = eq;
+                  }
+                }
+                combinedFaceA.m_plane[0] = faceNormal[0];
+                combinedFaceA.m_plane[1] = faceNormal[1];
+                combinedFaceA.m_plane[2] = faceNormal[2];
+                combinedFaceA.m_plane[3] = -planeEq;
+                polyhedron.m_faces.push_back(combinedFaceA);
+              }
+              {
+                btFace combinedFaceB;
+                combinedFaceB.m_indices.push_back(0);
+                combinedFaceB.m_indices.push_back(2);
+                combinedFaceB.m_indices.push_back(1);
+                btVector3 faceNormal = -uniqueEdges[0].cross(uniqueEdges[1]);
+                faceNormal.normalize();
+                btScalar planeEq = 1e30f;
+                for (int v = 0; v < combinedFaceB.m_indices.size(); v++)
+                {
+                  btScalar eq = tri->m_vertices1[combinedFaceB.m_indices[v]].dot(faceNormal);
+                  if (planeEq > eq)
+                  {
+                    planeEq = eq;
+                  }
+                }
+
+                combinedFaceB.m_plane[0] = faceNormal[0];
+                combinedFaceB.m_plane[1] = faceNormal[1];
+                combinedFaceB.m_plane[2] = faceNormal[2];
+                combinedFaceB.m_plane[3] = -planeEq;
+                polyhedron.m_faces.push_back(combinedFaceB);
+              }
+
+              polyhedron.m_uniqueEdges.push_back(uniqueEdges[0]);
+              polyhedron.m_uniqueEdges.push_back(uniqueEdges[1]);
+              polyhedron.m_uniqueEdges.push_back(uniqueEdges[2]);
+              polyhedron.initialize2();
+
+              polyhedronB->setPolyhedralFeatures(polyhedron);
+            }
+
+            foundSepAxis = btPolyhedralContactClipping::findSeparatingAxis(*polyhedronA->getConvexPolyhedron(),
+                                                                           *polyhedronB->getConvexPolyhedron(),
+                                                                           body0Wrap->getWorldTransform(),
+                                                                           body1Wrap->getWorldTransform(),
+                                                                           sepNormalWorldSpace,
+                                                                           *resultOut);
+            //	 printf("sepNormalWorldSpace=%f,%f,%f\n",sepNormalWorldSpace.getX(),sepNormalWorldSpace.getY(),sepNormalWorldSpace.getZ());
+          }
+          else
+          {
+#ifdef ZERO_MARGIN
+            gjkPairDetector.setIgnoreMargin(true);
+            gjkPairDetector.getClosestPoints(input, *resultOut, dispatchInfo.m_debugDraw);
+#else
+            gjkPairDetector.getClosestPoints(input, dummy, dispatchInfo.m_debugDraw);
+#endif  // ZERO_MARGIN
+
+            if (dummy.m_hasContact && dummy.m_depth < 0)
+            {
+              if (foundSepAxis)
+              {
+                if (dummy.m_normalOnBInWorld.dot(sepNormalWorldSpace) < 0.99)
+                {
+                  printf("?\n");
+                }
+              }
+              else
+              {
+                printf("!\n");
+              }
+              sepNormalWorldSpace.setValue(0, 0, 1);  // = dummy.m_normalOnBInWorld;
+              // minDist = dummy.m_depth;
+              foundSepAxis = true;
+            }
+#if 0
+          btScalar l2 = gjkPairDetector.getCachedSeparatingAxis().length2();
+          if (l2>SIMD_EPSILON)
+          {
+            sepNormalWorldSpace = gjkPairDetector.getCachedSeparatingAxis()*(1.f/l2);
+            //minDist = gjkPairDetector.getCachedSeparatingDistance();
+            //maxDist = threshold;
+            minDist = gjkPairDetector.getCachedSeparatingDistance()-min0->getMargin()-min1->getMargin();
+            foundSepAxis = true;
+          }
+#endif
+          }
+
+          if (foundSepAxis)
+          {
+            worldVertsB2.resize(0);
+            btPolyhedralContactClipping::clipFaceAgainstHull(sepNormalWorldSpace,
+                                                             *polyhedronA->getConvexPolyhedron(),
+                                                             body0Wrap->getWorldTransform(),
+                                                             worldSpaceVertices,
+                                                             worldVertsB2,
+                                                             minDist - threshold,
+                                                             maxDist,
+                                                             *resultOut);
+          }
+
+          if (m_ownManifold)
+          {
+            resultOut->refreshContactPoints();
+          }
+
+          return;
+        }
+      }
+    }
+
+    gjkPairDetector.getClosestPoints(input, *resultOut, dispatchInfo.m_debugDraw);
+
+    // now perform 'm_numPerturbationIterations' collision queries with the perturbated collision objects
+
+    // perform perturbation when more then 'm_minimumPointsPerturbationThreshold' points
+    if (m_numPerturbationIterations &&
+        resultOut->getPersistentManifold()->getNumContacts() < m_minimumPointsPerturbationThreshold)
+    {
+      int i;
+      btVector3 v0, v1;
+      btVector3 sepNormalWorldSpace;
+      btScalar l2 = gjkPairDetector.getCachedSeparatingAxis().length2();
+
+      if (l2 > SIMD_EPSILON)
+      {
+        sepNormalWorldSpace = gjkPairDetector.getCachedSeparatingAxis() * (1.f / l2);
+
+        btPlaneSpace1(sepNormalWorldSpace, v0, v1);
+
+        bool perturbeA = true;
+        const btScalar angleLimit = 0.125f * SIMD_PI;
+        btScalar perturbeAngle;
+        btScalar radiusA = min0->getAngularMotionDisc();
+        btScalar radiusB = min1->getAngularMotionDisc();
+        if (radiusA < radiusB)
+        {
+          perturbeAngle = gContactBreakingThreshold / radiusA;
+          perturbeA = true;
+        }
+        else
+        {
+          perturbeAngle = gContactBreakingThreshold / radiusB;
+          perturbeA = false;
+        }
+        if (perturbeAngle > angleLimit)
+          perturbeAngle = angleLimit;
+
+        btTransform unPerturbedTransform;
+        if (perturbeA)
+        {
+          unPerturbedTransform = input.m_transformA;
+        }
+        else
+        {
+          unPerturbedTransform = input.m_transformB;
+        }
+
+        for (i = 0; i < m_numPerturbationIterations; i++)
+        {
+          if (v0.length2() > SIMD_EPSILON)
+          {
+            btQuaternion perturbeRot(v0, perturbeAngle);
+            btScalar iterationAngle = i * (SIMD_2_PI / btScalar(m_numPerturbationIterations));
+            btQuaternion rotq(sepNormalWorldSpace, iterationAngle);
+
+            if (perturbeA)
+            {
+              input.m_transformA.setBasis(btMatrix3x3(rotq.inverse() * perturbeRot * rotq) *
+                                          body0Wrap->getWorldTransform().getBasis());
+              input.m_transformB = body1Wrap->getWorldTransform();
+#ifdef DEBUG_CONTACTS
+              dispatchInfo.m_debugDraw->drawTransform(input.m_transformA, 10.0);
+#endif  // DEBUG_CONTACTS
+            }
+            else
+            {
+              input.m_transformA = body0Wrap->getWorldTransform();
+              input.m_transformB.setBasis(btMatrix3x3(rotq.inverse() * perturbeRot * rotq) *
+                                          body1Wrap->getWorldTransform().getBasis());
+#ifdef DEBUG_CONTACTS
+              dispatchInfo.m_debugDraw->drawTransform(input.m_transformB, 10.0);
+#endif
+            }
+
+            btPerturbedContactResult perturbedResultOut(resultOut,
+                                                        input.m_transformA,
+                                                        input.m_transformB,
+                                                        unPerturbedTransform,
+                                                        perturbeA,
+                                                        dispatchInfo.m_debugDraw);
+            gjkPairDetector.getClosestPoints(input, perturbedResultOut, dispatchInfo.m_debugDraw);
+          }
+        }
+      }
+    }
+
+#ifdef USE_SEPDISTANCE_UTIL2
+    if (dispatchInfo.m_useConvexConservativeDistanceUtil && (sepDist > SIMD_EPSILON))
+    {
+      m_sepDistance.initSeparatingDistance(
+          gjkPairDetector.getCachedSeparatingAxis(), sepDist, body0->getWorldTransform(), body1->getWorldTransform());
+    }
+#endif  // USE_SEPDISTANCE_UTIL2
+  }
+
+  if (m_ownManifold)
+  {
+    resultOut->refreshContactPoints();
+  }
+}
+
+bool disableCcd = false;
+btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject* col0,
+                                                               btCollisionObject* col1,
+                                                               const btDispatcherInfo& dispatchInfo,
+                                                               btManifoldResult* resultOut)
+{
+  (void)resultOut;
+  (void)dispatchInfo;
+  /// Rather then checking ALL pairs, only calculate TOI when motion exceeds threshold
+
+  /// Linear motion for one of objects needs to exceed m_ccdSquareMotionThreshold
+  /// col0->m_worldTransform,
+  btScalar resultFraction = btScalar(1.);
+
+  btScalar squareMot0 =
+      (col0->getInterpolationWorldTransform().getOrigin() - col0->getWorldTransform().getOrigin()).length2();
+  btScalar squareMot1 =
+      (col1->getInterpolationWorldTransform().getOrigin() - col1->getWorldTransform().getOrigin()).length2();
+
+  if (squareMot0 < col0->getCcdSquareMotionThreshold() && squareMot1 < col1->getCcdSquareMotionThreshold())
+    return resultFraction;
+
+  if (disableCcd)
+    return btScalar(1.);
+
+  // An adhoc way of testing the Continuous Collision Detection algorithms
+  // One object is approximated as a sphere, to simplify things
+  // Starting in penetration should report no time of impact
+  // For proper CCD, better accuracy and handling of 'allowed' penetration should be added
+  // also the mainloop of the physics should have a kind of toi queue (something like Brian Mirtich's application of
+  // Timewarp for Rigidbodies)
+
+  /// Convex0 against sphere for Convex1
+  {
+    btConvexShape* convex0 = static_cast<btConvexShape*>(col0->getCollisionShape());
+
+    btSphereShape sphere1(col1->getCcdSweptSphereRadius());  // todo: allow non-zero sphere sizes, for better
+                                                             // approximation
+    btConvexCast::CastResult result;
+    btVoronoiSimplexSolver voronoiSimplex;
+    // SubsimplexConvexCast ccd0(&sphere,min0,&voronoiSimplex);
+    /// Simplification, one object is simplified as a sphere
+    btGjkConvexCast ccd1(convex0, &sphere1, &voronoiSimplex);
+    // ContinuousConvexCollision ccd(min0,min1,&voronoiSimplex,0);
+    if (ccd1.calcTimeOfImpact(col0->getWorldTransform(),
+                              col0->getInterpolationWorldTransform(),
+                              col1->getWorldTransform(),
+                              col1->getInterpolationWorldTransform(),
+                              result))
+    {
+      // store result.m_fraction in both bodies
+
+      if (col0->getHitFraction() > result.m_fraction)
+        col0->setHitFraction(result.m_fraction);
+
+      if (col1->getHitFraction() > result.m_fraction)
+        col1->setHitFraction(result.m_fraction);
+
+      if (resultFraction > result.m_fraction)
+        resultFraction = result.m_fraction;
+    }
+  }
+
+  /// Sphere (for convex0) against Convex1
+  {
+    btConvexShape* convex1 = static_cast<btConvexShape*>(col1->getCollisionShape());
+
+    btSphereShape sphere0(col0->getCcdSweptSphereRadius());  // todo: allow non-zero sphere sizes, for better
+                                                             // approximation
+    btConvexCast::CastResult result;
+    btVoronoiSimplexSolver voronoiSimplex;
+    // SubsimplexConvexCast ccd0(&sphere,min0,&voronoiSimplex);
+    /// Simplification, one object is simplified as a sphere
+    btGjkConvexCast ccd1(&sphere0, convex1, &voronoiSimplex);
+    // ContinuousConvexCollision ccd(min0,min1,&voronoiSimplex,0);
+    if (ccd1.calcTimeOfImpact(col0->getWorldTransform(),
+                              col0->getInterpolationWorldTransform(),
+                              col1->getWorldTransform(),
+                              col1->getInterpolationWorldTransform(),
+                              result))
+    {
+      // store result.m_fraction in both bodies
+
+      if (col0->getHitFraction() > result.m_fraction)
+        col0->setHitFraction(result.m_fraction);
+
+      if (col1->getHitFraction() > result.m_fraction)
+        col1->setHitFraction(result.m_fraction);
+
+      if (resultFraction > result.m_fraction)
+        resultFraction = result.m_fraction;
+    }
+  }
+
+  return resultFraction;
+}
+}  // namespace tesseract_collision_bullet
+}  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/bullet/tesseract_convex_convex_algorithm.cpp
+++ b/tesseract/tesseract_collision/src/bullet/tesseract_convex_convex_algorithm.cpp
@@ -59,6 +59,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 ///////////
 extern btScalar gContactBreakingThreshold;
 
+// LCOV_EXCL_START
 namespace tesseract_collision
 {
 namespace tesseract_collision_bullet
@@ -959,3 +960,4 @@ btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject
 }
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision
+// LCOV_EXCL_STOP

--- a/tesseract/tesseract_collision/src/bullet/tesseract_convex_convex_algorithm.cpp
+++ b/tesseract/tesseract_collision/src/bullet/tesseract_convex_convex_algorithm.cpp
@@ -188,8 +188,6 @@ TesseractConvexConvexAlgorithm::CreateFunc::CreateFunc(btConvexPenetrationDepthS
   m_pdSolver = pdSolver;
 }
 
-TesseractConvexConvexAlgorithm::CreateFunc::~CreateFunc() {}
-
 TesseractConvexConvexAlgorithm::TesseractConvexConvexAlgorithm(btPersistentManifold* mf,
                                                                const btCollisionAlgorithmConstructionInfo& ci,
                                                                const btCollisionObjectWrapper* body0Wrap,
@@ -864,8 +862,8 @@ void TesseractConvexConvexAlgorithm::processCollision(const btCollisionObjectWra
 }
 
 bool disableCcd = false;
-btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject* col0,
-                                                               btCollisionObject* col1,
+btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject* body0,
+                                                               btCollisionObject* body1,
                                                                const btDispatcherInfo& dispatchInfo,
                                                                btManifoldResult* resultOut)
 {
@@ -878,11 +876,11 @@ btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject
   btScalar resultFraction = btScalar(1.);
 
   btScalar squareMot0 =
-      (col0->getInterpolationWorldTransform().getOrigin() - col0->getWorldTransform().getOrigin()).length2();
+      (body0->getInterpolationWorldTransform().getOrigin() - body0->getWorldTransform().getOrigin()).length2();
   btScalar squareMot1 =
-      (col1->getInterpolationWorldTransform().getOrigin() - col1->getWorldTransform().getOrigin()).length2();
+      (body1->getInterpolationWorldTransform().getOrigin() - body1->getWorldTransform().getOrigin()).length2();
 
-  if (squareMot0 < col0->getCcdSquareMotionThreshold() && squareMot1 < col1->getCcdSquareMotionThreshold())
+  if (squareMot0 < body0->getCcdSquareMotionThreshold() && squareMot1 < body1->getCcdSquareMotionThreshold())
     return resultFraction;
 
   if (disableCcd)
@@ -897,29 +895,29 @@ btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject
 
   /// Convex0 against sphere for Convex1
   {
-    btConvexShape* convex0 = static_cast<btConvexShape*>(col0->getCollisionShape());
+    btConvexShape* convex0 = static_cast<btConvexShape*>(body0->getCollisionShape());
 
-    btSphereShape sphere1(col1->getCcdSweptSphereRadius());  // todo: allow non-zero sphere sizes, for better
-                                                             // approximation
+    btSphereShape sphere1(body1->getCcdSweptSphereRadius());  // todo: allow non-zero sphere sizes, for better
+                                                              // approximation
     btConvexCast::CastResult result;
     btVoronoiSimplexSolver voronoiSimplex;
     // SubsimplexConvexCast ccd0(&sphere,min0,&voronoiSimplex);
     /// Simplification, one object is simplified as a sphere
     btGjkConvexCast ccd1(convex0, &sphere1, &voronoiSimplex);
     // ContinuousConvexCollision ccd(min0,min1,&voronoiSimplex,0);
-    if (ccd1.calcTimeOfImpact(col0->getWorldTransform(),
-                              col0->getInterpolationWorldTransform(),
-                              col1->getWorldTransform(),
-                              col1->getInterpolationWorldTransform(),
+    if (ccd1.calcTimeOfImpact(body0->getWorldTransform(),
+                              body0->getInterpolationWorldTransform(),
+                              body1->getWorldTransform(),
+                              body1->getInterpolationWorldTransform(),
                               result))
     {
       // store result.m_fraction in both bodies
 
-      if (col0->getHitFraction() > result.m_fraction)
-        col0->setHitFraction(result.m_fraction);
+      if (body0->getHitFraction() > result.m_fraction)
+        body0->setHitFraction(result.m_fraction);
 
-      if (col1->getHitFraction() > result.m_fraction)
-        col1->setHitFraction(result.m_fraction);
+      if (body1->getHitFraction() > result.m_fraction)
+        body1->setHitFraction(result.m_fraction);
 
       if (resultFraction > result.m_fraction)
         resultFraction = result.m_fraction;
@@ -928,29 +926,29 @@ btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject
 
   /// Sphere (for convex0) against Convex1
   {
-    btConvexShape* convex1 = static_cast<btConvexShape*>(col1->getCollisionShape());
+    btConvexShape* convex1 = static_cast<btConvexShape*>(body1->getCollisionShape());
 
-    btSphereShape sphere0(col0->getCcdSweptSphereRadius());  // todo: allow non-zero sphere sizes, for better
-                                                             // approximation
+    btSphereShape sphere0(body0->getCcdSweptSphereRadius());  // todo: allow non-zero sphere sizes, for better
+                                                              // approximation
     btConvexCast::CastResult result;
     btVoronoiSimplexSolver voronoiSimplex;
     // SubsimplexConvexCast ccd0(&sphere,min0,&voronoiSimplex);
     /// Simplification, one object is simplified as a sphere
     btGjkConvexCast ccd1(&sphere0, convex1, &voronoiSimplex);
     // ContinuousConvexCollision ccd(min0,min1,&voronoiSimplex,0);
-    if (ccd1.calcTimeOfImpact(col0->getWorldTransform(),
-                              col0->getInterpolationWorldTransform(),
-                              col1->getWorldTransform(),
-                              col1->getInterpolationWorldTransform(),
+    if (ccd1.calcTimeOfImpact(body0->getWorldTransform(),
+                              body0->getInterpolationWorldTransform(),
+                              body1->getWorldTransform(),
+                              body1->getInterpolationWorldTransform(),
                               result))
     {
       // store result.m_fraction in both bodies
 
-      if (col0->getHitFraction() > result.m_fraction)
-        col0->setHitFraction(result.m_fraction);
+      if (body0->getHitFraction() > result.m_fraction)
+        body0->setHitFraction(result.m_fraction);
 
-      if (col1->getHitFraction() > result.m_fraction)
-        col1->setHitFraction(result.m_fraction);
+      if (body1->getHitFraction() > result.m_fraction)
+        body1->setHitFraction(result.m_fraction);
 
       if (resultFraction > result.m_fraction)
         resultFraction = result.m_fraction;

--- a/tesseract/tesseract_collision/src/bullet/tesseract_gjk_pair_detector.cpp
+++ b/tesseract/tesseract_collision/src/bullet/tesseract_gjk_pair_detector.cpp
@@ -1031,7 +1031,7 @@ void TesseractGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInpu
                                                                tmpPointOnB,
                                                                debugDraw);
 
-        if (m_cachedSeparatingAxis.length2())
+        if (m_cachedSeparatingAxis.length2() > 0)
         {
           if (isValid2)
           {
@@ -1166,7 +1166,7 @@ void TesseractGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInpu
         normalInB *= -1;
       }
 
-      if (orgNormalInB.length2())
+      if (orgNormalInB.length2() > 0)
       {
         if (d2 > d0 && d2 > d1 && d2 > distance)
         {

--- a/tesseract/tesseract_collision/src/bullet/tesseract_gjk_pair_detector.cpp
+++ b/tesseract/tesseract_collision/src/bullet/tesseract_gjk_pair_detector.cpp
@@ -1,0 +1,1187 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  http://continuousphysics.com/Bullet/
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If
+you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not
+required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original
+software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <tesseract_collision/bullet/tesseract_gjk_pair_detector.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/CollisionShapes/btConvexShape.h>
+#include <BulletCollision/NarrowPhaseCollision/btSimplexSolverInterface.h>
+#include <BulletCollision/NarrowPhaseCollision/btConvexPenetrationDepthSolver.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#if defined(DEBUG) || defined(_DEBUG)
+//#define TEST_NON_VIRTUAL 1
+#include <stdio.h>  //for debug printf
+#ifdef __SPU__
+#include <spu_printf.h>
+#define printf spu_printf
+#endif  //__SPU__
+#endif
+
+// must be above the machine epsilon
+#ifdef BT_USE_DOUBLE_PRECISION
+#define REL_ERROR2 btScalar(1.0e-12)
+btScalar gGjkEpaPenetrationTolerance = 1.0e-12;
+#else
+#define REL_ERROR2 btScalar(1.0e-6)
+btScalar gGjkEpaPenetrationTolerance = 0.001;
+#endif
+
+namespace tesseract_collision
+{
+namespace tesseract_collision_bullet
+{
+TesseractGjkPairDetector::TesseractGjkPairDetector(const btConvexShape* objectA,
+                                                   const btConvexShape* objectB,
+                                                   btSimplexSolverInterface* simplexSolver,
+                                                   btConvexPenetrationDepthSolver* penetrationDepthSolver,
+                                                   const ContactTestData* cdata)
+  : m_cachedSeparatingAxis(btScalar(0.), btScalar(1.), btScalar(0.))
+  , m_penetrationDepthSolver(penetrationDepthSolver)
+  , m_simplexSolver(simplexSolver)
+  , m_minkowskiA(objectA)
+  , m_minkowskiB(objectB)
+  , m_shapeTypeA(objectA->getShapeType())
+  , m_shapeTypeB(objectB->getShapeType())
+  , m_marginA(objectA->getMargin())
+  , m_marginB(objectB->getMargin())
+  , m_ignoreMargin(false)
+  , m_cdata(cdata)
+  , m_lastUsedMethod(-1)
+  , m_catchDegeneracies(1)
+  , m_fixContactNormalDirection(1)
+{
+}
+TesseractGjkPairDetector::TesseractGjkPairDetector(const btConvexShape* objectA,
+                                                   const btConvexShape* objectB,
+                                                   int shapeTypeA,
+                                                   int shapeTypeB,
+                                                   btScalar marginA,
+                                                   btScalar marginB,
+                                                   btSimplexSolverInterface* simplexSolver,
+                                                   btConvexPenetrationDepthSolver* penetrationDepthSolver,
+                                                   const ContactTestData* cdata)
+  : m_cachedSeparatingAxis(btScalar(0.), btScalar(1.), btScalar(0.))
+  , m_penetrationDepthSolver(penetrationDepthSolver)
+  , m_simplexSolver(simplexSolver)
+  , m_minkowskiA(objectA)
+  , m_minkowskiB(objectB)
+  , m_shapeTypeA(shapeTypeA)
+  , m_shapeTypeB(shapeTypeB)
+  , m_marginA(marginA)
+  , m_marginB(marginB)
+  , m_ignoreMargin(false)
+  , m_cdata(cdata)
+  , m_lastUsedMethod(-1)
+  , m_catchDegeneracies(1)
+  , m_fixContactNormalDirection(1)
+{
+}
+
+void TesseractGjkPairDetector::getClosestPoints(const ClosestPointInput& input,
+                                                Result& output,
+                                                class btIDebugDraw* debugDraw,
+                                                bool swapResults)
+{
+  (void)swapResults;
+
+  getClosestPointsNonVirtual(input, output, debugDraw);
+}
+
+static void btComputeSupport(const btConvexShape* convexA,
+                             const btTransform& localTransA,
+                             const btConvexShape* convexB,
+                             const btTransform& localTransB,
+                             const btVector3& dir,
+                             bool check2d,
+                             btVector3& supAworld,
+                             btVector3& supBworld,
+                             btVector3& aMinb)
+{
+  btVector3 separatingAxisInA = (dir)*localTransA.getBasis();
+  btVector3 separatingAxisInB = (-dir) * localTransB.getBasis();
+
+  btVector3 pInANoMargin = convexA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+  btVector3 qInBNoMargin = convexB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
+
+  btVector3 pInA = pInANoMargin;
+  btVector3 qInB = qInBNoMargin;
+
+  supAworld = localTransA(pInA);
+  supBworld = localTransB(qInB);
+
+  if (check2d)
+  {
+    supAworld[2] = 0.f;
+    supBworld[2] = 0.f;
+  }
+
+  aMinb = supAworld - supBworld;
+}
+
+struct btSupportVector
+{
+  btVector3 v;   //!< Support point in minkowski sum
+  btVector3 v1;  //!< Support point in obj1
+  btVector3 v2;  //!< Support point in obj2
+};
+
+struct btSimplex
+{
+  btSupportVector ps[4];
+  int last;  //!< index of last added point
+};
+
+static btVector3 ccd_vec3_origin(0, 0, 0);
+
+inline void btSimplexInit(btSimplex* s) { s->last = -1; }
+
+inline int btSimplexSize(const btSimplex* s) { return s->last + 1; }
+
+inline const btSupportVector* btSimplexPoint(const btSimplex* s, int idx)
+{
+  // here is no check on boundaries
+  return &s->ps[idx];
+}
+inline void btSupportCopy(btSupportVector* d, const btSupportVector* s) { *d = *s; }
+
+inline void btVec3Copy(btVector3* v, const btVector3* w) { *v = *w; }
+
+inline void ccdVec3Add(btVector3* v, const btVector3* w)
+{
+  v->m_floats[0] += w->m_floats[0];
+  v->m_floats[1] += w->m_floats[1];
+  v->m_floats[2] += w->m_floats[2];
+}
+
+inline void ccdVec3Sub(btVector3* v, const btVector3* w) { *v -= *w; }
+inline void btVec3Sub2(btVector3* d, const btVector3* v, const btVector3* w) { *d = (*v) - (*w); }
+inline btScalar btVec3Dot(const btVector3* a, const btVector3* b)
+{
+  btScalar dot;
+  dot = a->dot(*b);
+
+  return dot;
+}
+
+inline btScalar ccdVec3Dist2(const btVector3* a, const btVector3* b)
+{
+  btVector3 ab;
+  btVec3Sub2(&ab, a, b);
+  return btVec3Dot(&ab, &ab);
+}
+
+inline void btVec3Scale(btVector3* d, btScalar k)
+{
+  d->m_floats[0] *= k;
+  d->m_floats[1] *= k;
+  d->m_floats[2] *= k;
+}
+
+inline void btVec3Cross(btVector3* d, const btVector3* a, const btVector3* b)
+{
+  d->m_floats[0] = (a->m_floats[1] * b->m_floats[2]) - (a->m_floats[2] * b->m_floats[1]);
+  d->m_floats[1] = (a->m_floats[2] * b->m_floats[0]) - (a->m_floats[0] * b->m_floats[2]);
+  d->m_floats[2] = (a->m_floats[0] * b->m_floats[1]) - (a->m_floats[1] * b->m_floats[0]);
+}
+
+inline void btTripleCross(const btVector3* a, const btVector3* b, const btVector3* c, btVector3* d)
+{
+  btVector3 e;
+  btVec3Cross(&e, a, b);
+  btVec3Cross(d, &e, c);
+}
+
+inline int ccdEq(btScalar _a, btScalar _b)
+{
+  btScalar ab;
+  btScalar a, b;
+
+  ab = btFabs(_a - _b);
+  if (btFabs(ab) < SIMD_EPSILON)
+    return 1;
+
+  a = btFabs(_a);
+  b = btFabs(_b);
+  if (b > a)
+  {
+    return ab < SIMD_EPSILON * b;
+  }
+  else
+  {
+    return ab < SIMD_EPSILON * a;
+  }
+}
+
+btScalar ccdVec3X(const btVector3* v) { return v->x(); }
+
+btScalar ccdVec3Y(const btVector3* v) { return v->y(); }
+
+btScalar ccdVec3Z(const btVector3* v) { return v->z(); }
+inline int btVec3Eq(const btVector3* a, const btVector3* b)
+{
+  return ccdEq(ccdVec3X(a), ccdVec3X(b)) && ccdEq(ccdVec3Y(a), ccdVec3Y(b)) && ccdEq(ccdVec3Z(a), ccdVec3Z(b));
+}
+
+inline void btSimplexAdd(btSimplex* s, const btSupportVector* v)
+{
+  // here is no check on boundaries in sake of speed
+  ++s->last;
+  btSupportCopy(s->ps + s->last, v);
+}
+
+inline void btSimplexSet(btSimplex* s, size_t pos, const btSupportVector* a) { btSupportCopy(s->ps + pos, a); }
+
+inline void btSimplexSetSize(btSimplex* s, int size) { s->last = size - 1; }
+
+inline const btSupportVector* ccdSimplexLast(const btSimplex* s) { return btSimplexPoint(s, s->last); }
+
+inline int ccdSign(btScalar val)
+{
+  if (btFuzzyZero(val))
+  {
+    return 0;
+  }
+  else if (val < btScalar(0))
+  {
+    return -1;
+  }
+  return 1;
+}
+
+inline btScalar btVec3PointSegmentDist2(const btVector3* P, const btVector3* x0, const btVector3* b, btVector3* witness)
+{
+  // The computation comes from solving equation of segment:
+  //      S(t) = x0 + t.d
+  //          where - x0 is initial point of segment
+  //                - d is direction of segment from x0 (|d| > 0)
+  //                - t belongs to <0, 1> interval
+  //
+  // Than, distance from a segment to some point P can be expressed:
+  //      D(t) = |x0 + t.d - P|^2
+  //          which is distance from any point on segment. Minimization
+  //          of this function brings distance from P to segment.
+  // Minimization of D(t) leads to simple quadratic equation that's
+  // solving is straightforward.
+  //
+  // Bonus of this method is witness point for free.
+
+  btScalar dist, t;
+  btVector3 d, a;
+
+  // direction of segment
+  btVec3Sub2(&d, b, x0);
+
+  // precompute vector from P to x0
+  btVec3Sub2(&a, x0, P);
+
+  t = -btScalar(1.) * btVec3Dot(&a, &d);
+  t /= btVec3Dot(&d, &d);
+
+  if (t < btScalar(0) || btFuzzyZero(t))
+  {
+    dist = ccdVec3Dist2(x0, P);
+    if (witness)
+      btVec3Copy(witness, x0);
+  }
+  else if (t > btScalar(1) || ccdEq(t, btScalar(1)))
+  {
+    dist = ccdVec3Dist2(b, P);
+    if (witness)
+      btVec3Copy(witness, b);
+  }
+  else
+  {
+    if (witness)
+    {
+      btVec3Copy(witness, &d);
+      btVec3Scale(witness, t);
+      ccdVec3Add(witness, x0);
+      dist = ccdVec3Dist2(witness, P);
+    }
+    else
+    {
+      // recycling variables
+      btVec3Scale(&d, t);
+      ccdVec3Add(&d, &a);
+      dist = btVec3Dot(&d, &d);
+    }
+  }
+
+  return dist;
+}
+
+btScalar
+btVec3PointTriDist2(const btVector3* P, const btVector3* x0, const btVector3* B, const btVector3* C, btVector3* witness)
+{
+  // Computation comes from analytic expression for triangle (x0, B, C)
+  //      T(s, t) = x0 + s.d1 + t.d2, where d1 = B - x0 and d2 = C - x0 and
+  // Then equation for distance is:
+  //      D(s, t) = | T(s, t) - P |^2
+  // This leads to minimization of quadratic function of two variables.
+  // The solution from is taken only if s is between 0 and 1, t is
+  // between 0 and 1 and t + s < 1, otherwise distance from segment is
+  // computed.
+
+  btVector3 d1, d2, a;
+  double u, v, w, p, q, r;
+  double s, t, dist, dist2;
+  btVector3 witness2;
+
+  btVec3Sub2(&d1, B, x0);
+  btVec3Sub2(&d2, C, x0);
+  btVec3Sub2(&a, x0, P);
+
+  u = btVec3Dot(&a, &a);
+  v = btVec3Dot(&d1, &d1);
+  w = btVec3Dot(&d2, &d2);
+  p = btVec3Dot(&a, &d1);
+  q = btVec3Dot(&a, &d2);
+  r = btVec3Dot(&d1, &d2);
+
+  s = (q * r - w * p) / (w * v - r * r);
+  t = (-s * r - q) / w;
+
+  if ((btFuzzyZero(s) || s > btScalar(0)) && (ccdEq(s, btScalar(1)) || s < btScalar(1)) &&
+      (btFuzzyZero(t) || t > btScalar(0)) && (ccdEq(t, btScalar(1)) || t < btScalar(1)) &&
+      (ccdEq(t + s, btScalar(1)) || t + s < btScalar(1)))
+  {
+    if (witness)
+    {
+      btVec3Scale(&d1, s);
+      btVec3Scale(&d2, t);
+      btVec3Copy(witness, x0);
+      ccdVec3Add(witness, &d1);
+      ccdVec3Add(witness, &d2);
+
+      dist = ccdVec3Dist2(witness, P);
+    }
+    else
+    {
+      dist = s * s * v;
+      dist += t * t * w;
+      dist += btScalar(2.) * s * t * r;
+      dist += btScalar(2.) * s * p;
+      dist += btScalar(2.) * t * q;
+      dist += u;
+    }
+  }
+  else
+  {
+    dist = btVec3PointSegmentDist2(P, x0, B, witness);
+
+    dist2 = btVec3PointSegmentDist2(P, x0, C, &witness2);
+    if (dist2 < dist)
+    {
+      dist = dist2;
+      if (witness)
+        btVec3Copy(witness, &witness2);
+    }
+
+    dist2 = btVec3PointSegmentDist2(P, B, C, &witness2);
+    if (dist2 < dist)
+    {
+      dist = dist2;
+      if (witness)
+        btVec3Copy(witness, &witness2);
+    }
+  }
+
+  return dist;
+}
+
+static int btDoSimplex2(btSimplex* simplex, btVector3* dir)
+{
+  const btSupportVector *A, *B;
+  btVector3 AB, AO, tmp;
+  btScalar dot;
+
+  // get last added as A
+  A = ccdSimplexLast(simplex);
+  // get the other point
+  B = btSimplexPoint(simplex, 0);
+  // compute AB oriented segment
+  btVec3Sub2(&AB, &B->v, &A->v);
+  // compute AO vector
+  btVec3Copy(&AO, &A->v);
+  btVec3Scale(&AO, -btScalar(1));
+
+  // dot product AB . AO
+  dot = btVec3Dot(&AB, &AO);
+
+  // check if origin doesn't lie on AB segment
+  btVec3Cross(&tmp, &AB, &AO);
+  if (btFuzzyZero(btVec3Dot(&tmp, &tmp)) && dot > btScalar(0))
+  {
+    return 1;
+  }
+
+  // check if origin is in area where AB segment is
+  if (btFuzzyZero(dot) || dot < btScalar(0))
+  {
+    // origin is in outside are of A
+    btSimplexSet(simplex, 0, A);
+    btSimplexSetSize(simplex, 1);
+    btVec3Copy(dir, &AO);
+  }
+  else
+  {
+    // origin is in area where AB segment is
+
+    // keep simplex untouched and set direction to
+    // AB x AO x AB
+    btTripleCross(&AB, &AO, &AB, dir);
+  }
+
+  return 0;
+}
+
+static int btDoSimplex3(btSimplex* simplex, btVector3* dir)
+{
+  const btSupportVector *A, *B, *C;
+  btVector3 AO, AB, AC, ABC, tmp;
+  btScalar dot, dist;
+
+  // get last added as A
+  A = ccdSimplexLast(simplex);
+  // get the other points
+  B = btSimplexPoint(simplex, 1);
+  C = btSimplexPoint(simplex, 0);
+
+  // check touching contact
+  dist = btVec3PointTriDist2(&ccd_vec3_origin, &A->v, &B->v, &C->v, 0);
+  if (btFuzzyZero(dist))
+  {
+    return 1;
+  }
+
+  // check if triangle is really triangle (has area > 0)
+  // if not simplex can't be expanded and thus no itersection is found
+  if (btVec3Eq(&A->v, &B->v) || btVec3Eq(&A->v, &C->v))
+  {
+    return -1;
+  }
+
+  // compute AO vector
+  btVec3Copy(&AO, &A->v);
+  btVec3Scale(&AO, -btScalar(1));
+
+  // compute AB and AC segments and ABC vector (perpendircular to triangle)
+  btVec3Sub2(&AB, &B->v, &A->v);
+  btVec3Sub2(&AC, &C->v, &A->v);
+  btVec3Cross(&ABC, &AB, &AC);
+
+  btVec3Cross(&tmp, &ABC, &AC);
+  dot = btVec3Dot(&tmp, &AO);
+  if (btFuzzyZero(dot) || dot > btScalar(0))
+  {
+    dot = btVec3Dot(&AC, &AO);
+    if (btFuzzyZero(dot) || dot > btScalar(0))
+    {
+      // C is already in place
+      btSimplexSet(simplex, 1, A);
+      btSimplexSetSize(simplex, 2);
+      btTripleCross(&AC, &AO, &AC, dir);
+    }
+    else
+    {
+      dot = btVec3Dot(&AB, &AO);
+      if (btFuzzyZero(dot) || dot > btScalar(0))
+      {
+        btSimplexSet(simplex, 0, B);
+        btSimplexSet(simplex, 1, A);
+        btSimplexSetSize(simplex, 2);
+        btTripleCross(&AB, &AO, &AB, dir);
+      }
+      else
+      {
+        btSimplexSet(simplex, 0, A);
+        btSimplexSetSize(simplex, 1);
+        btVec3Copy(dir, &AO);
+      }
+    }
+  }
+  else
+  {
+    btVec3Cross(&tmp, &AB, &ABC);
+    dot = btVec3Dot(&tmp, &AO);
+    if (btFuzzyZero(dot) || dot > btScalar(0))
+    {
+      dot = btVec3Dot(&AB, &AO);
+      if (btFuzzyZero(dot) || dot > btScalar(0))
+      {
+        btSimplexSet(simplex, 0, B);
+        btSimplexSet(simplex, 1, A);
+        btSimplexSetSize(simplex, 2);
+        btTripleCross(&AB, &AO, &AB, dir);
+      }
+      else
+      {
+        btSimplexSet(simplex, 0, A);
+        btSimplexSetSize(simplex, 1);
+        btVec3Copy(dir, &AO);
+      }
+    }
+    else
+    {
+      dot = btVec3Dot(&ABC, &AO);
+      if (btFuzzyZero(dot) || dot > btScalar(0))
+      {
+        btVec3Copy(dir, &ABC);
+      }
+      else
+      {
+        btSupportVector tmp;
+        btSupportCopy(&tmp, C);
+        btSimplexSet(simplex, 0, B);
+        btSimplexSet(simplex, 1, &tmp);
+
+        btVec3Copy(dir, &ABC);
+        btVec3Scale(dir, -btScalar(1));
+      }
+    }
+  }
+
+  return 0;
+}
+
+static int btDoSimplex4(btSimplex* simplex, btVector3* dir)
+{
+  const btSupportVector *A, *B, *C, *D;
+  btVector3 AO, AB, AC, AD, ABC, ACD, ADB;
+  int B_on_ACD, C_on_ADB, D_on_ABC;
+  int AB_O, AC_O, AD_O;
+  btScalar dist;
+
+  // get last added as A
+  A = ccdSimplexLast(simplex);
+  // get the other points
+  B = btSimplexPoint(simplex, 2);
+  C = btSimplexPoint(simplex, 1);
+  D = btSimplexPoint(simplex, 0);
+
+  // check if tetrahedron is really tetrahedron (has volume > 0)
+  // if it is not simplex can't be expanded and thus no intersection is
+  // found
+  dist = btVec3PointTriDist2(&A->v, &B->v, &C->v, &D->v, 0);
+  if (btFuzzyZero(dist))
+  {
+    return -1;
+  }
+
+  // check if origin lies on some of tetrahedron's face - if so objects
+  // intersect
+  dist = btVec3PointTriDist2(&ccd_vec3_origin, &A->v, &B->v, &C->v, 0);
+  if (btFuzzyZero(dist))
+    return 1;
+  dist = btVec3PointTriDist2(&ccd_vec3_origin, &A->v, &C->v, &D->v, 0);
+  if (btFuzzyZero(dist))
+    return 1;
+  dist = btVec3PointTriDist2(&ccd_vec3_origin, &A->v, &B->v, &D->v, 0);
+  if (btFuzzyZero(dist))
+    return 1;
+  dist = btVec3PointTriDist2(&ccd_vec3_origin, &B->v, &C->v, &D->v, 0);
+  if (btFuzzyZero(dist))
+    return 1;
+
+  // compute AO, AB, AC, AD segments and ABC, ACD, ADB normal vectors
+  btVec3Copy(&AO, &A->v);
+  btVec3Scale(&AO, -btScalar(1));
+  btVec3Sub2(&AB, &B->v, &A->v);
+  btVec3Sub2(&AC, &C->v, &A->v);
+  btVec3Sub2(&AD, &D->v, &A->v);
+  btVec3Cross(&ABC, &AB, &AC);
+  btVec3Cross(&ACD, &AC, &AD);
+  btVec3Cross(&ADB, &AD, &AB);
+
+  // side (positive or negative) of B, C, D relative to planes ACD, ADB
+  // and ABC respectively
+  B_on_ACD = ccdSign(btVec3Dot(&ACD, &AB));
+  C_on_ADB = ccdSign(btVec3Dot(&ADB, &AC));
+  D_on_ABC = ccdSign(btVec3Dot(&ABC, &AD));
+
+  // whether origin is on same side of ACD, ADB, ABC as B, C, D
+  // respectively
+  AB_O = ccdSign(btVec3Dot(&ACD, &AO)) == B_on_ACD;
+  AC_O = ccdSign(btVec3Dot(&ADB, &AO)) == C_on_ADB;
+  AD_O = ccdSign(btVec3Dot(&ABC, &AO)) == D_on_ABC;
+
+  if (AB_O && AC_O && AD_O)
+  {
+    // origin is in tetrahedron
+    return 1;
+    // rearrange simplex to triangle and call btDoSimplex3()
+  }
+  else if (!AB_O)
+  {
+    // B is farthest from the origin among all of the tetrahedron's
+    // points, so remove it from the list and go on with the triangle
+    // case
+
+    // D and C are in place
+    btSimplexSet(simplex, 2, A);
+    btSimplexSetSize(simplex, 3);
+  }
+  else if (!AC_O)
+  {
+    // C is farthest
+    btSimplexSet(simplex, 1, D);
+    btSimplexSet(simplex, 0, B);
+    btSimplexSet(simplex, 2, A);
+    btSimplexSetSize(simplex, 3);
+  }
+  else
+  {  // (!AD_O)
+    btSimplexSet(simplex, 0, C);
+    btSimplexSet(simplex, 1, B);
+    btSimplexSet(simplex, 2, A);
+    btSimplexSetSize(simplex, 3);
+  }
+
+  return btDoSimplex3(simplex, dir);
+}
+
+static int btDoSimplex(btSimplex* simplex, btVector3* dir)
+{
+  if (btSimplexSize(simplex) == 2)
+  {
+    // simplex contains segment only one segment
+    return btDoSimplex2(simplex, dir);
+  }
+  else if (btSimplexSize(simplex) == 3)
+  {
+    // simplex contains triangle
+    return btDoSimplex3(simplex, dir);
+  }
+  else
+  {  // btSimplexSize(simplex) == 4
+    // tetrahedron - this is the only shape which can encapsule origin
+    // so btDoSimplex4() also contains test on it
+    return btDoSimplex4(simplex, dir);
+  }
+}
+
+#ifdef __SPU__
+void TesseractGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInput& input,
+                                                          Result& output,
+                                                          class btIDebugDraw* debugDraw)
+#else
+void TesseractGjkPairDetector::getClosestPointsNonVirtual(const ClosestPointInput& input,
+                                                          Result& output,
+                                                          class btIDebugDraw* debugDraw)
+#endif
+{
+  m_cachedSeparatingDistance = 0.f;
+
+  btScalar distance = btScalar(0.);
+  btVector3 normalInB(btScalar(0.), btScalar(0.), btScalar(0.));
+
+  btVector3 pointOnA, pointOnB;
+  btTransform localTransA = input.m_transformA;
+  btTransform localTransB = input.m_transformB;
+  btVector3 positionOffset = (localTransA.getOrigin() + localTransB.getOrigin()) * btScalar(0.5);
+  localTransA.getOrigin() -= positionOffset;
+  localTransB.getOrigin() -= positionOffset;
+
+  bool check2d = m_minkowskiA->isConvex2d() && m_minkowskiB->isConvex2d();
+
+  btScalar marginA = m_marginA;
+  btScalar marginB = m_marginB;
+
+  // for CCD we don't use margins
+  if (m_ignoreMargin)
+  {
+    marginA = btScalar(0.);
+    marginB = btScalar(0.);
+  }
+
+  m_curIter = 0;
+  int gGjkMaxIter = 1000;  // this is to catch invalid input, perhaps check for #NaN?
+  m_cachedSeparatingAxis.setValue(0, 1, 0);
+
+  bool isValid = false;
+  bool checkSimplex = false;
+  bool checkPenetration = true;
+  m_degenerateSimplex = 0;
+
+  m_lastUsedMethod = -1;
+  int status = -2;
+  btVector3 orgNormalInB(0, 0, 0);
+  btScalar margin = marginA + marginB;
+
+  // we add a separate implementation to check if the convex shapes intersect
+  // See also "Real-time Collision Detection with Implicit Objects" by Leif Olvang
+  // Todo: integrate the simplex penetration check directly inside the Bullet btVoronoiSimplexSolver
+  // and remove this temporary code from libCCD
+  // this fixes issue https://github.com/bulletphysics/bullet3/issues/1703
+  // note, for large differences in shapes, use double precision build!
+  {
+    btScalar squaredDistance = BT_LARGE_FLOAT;
+    btScalar delta = btScalar(0.);
+
+    btSimplex simplex1;
+    btSimplex* simplex = &simplex1;
+    btSimplexInit(simplex);
+
+    btVector3 dir(1, 0, 0);
+
+    {
+      btVector3 lastSupV;
+      btVector3 supAworld;
+      btVector3 supBworld;
+      btComputeSupport(
+          m_minkowskiA, localTransA, m_minkowskiB, localTransB, dir, check2d, supAworld, supBworld, lastSupV);
+
+      btSupportVector last;
+      last.v = lastSupV;
+      last.v1 = supAworld;
+      last.v2 = supBworld;
+
+      btSimplexAdd(simplex, &last);
+
+      dir = -lastSupV;
+
+      // start iterations
+      for (int iterations = 0; iterations < gGjkMaxIter; iterations++)
+      {
+        // obtain support point
+        btComputeSupport(
+            m_minkowskiA, localTransA, m_minkowskiB, localTransB, dir, check2d, supAworld, supBworld, lastSupV);
+
+        // check if farthest point in Minkowski difference in direction dir
+        // isn't somewhere before origin (the test on negative dot product)
+        // - because if it is, objects are not intersecting at all.
+        btScalar delta = lastSupV.dot(dir);
+        if (delta < 0)
+        {
+          // no intersection, besides margin
+          status = -1;
+          break;
+        }
+
+        // add last support vector to simplex
+        last.v = lastSupV;
+        last.v1 = supAworld;
+        last.v2 = supBworld;
+
+        btSimplexAdd(simplex, &last);
+
+        // if btDoSimplex returns 1 if objects intersect, -1 if objects don't
+        // intersect and 0 if algorithm should continue
+
+        btVector3 newDir;
+        int do_simplex_res = btDoSimplex(simplex, &dir);
+
+        if (do_simplex_res == 1)
+        {
+          status = 0;  // intersection found
+          break;
+        }
+        else if (do_simplex_res == -1)
+        {
+          // intersection not found
+          status = -1;
+          break;
+        }
+
+        if (btFuzzyZero(btVec3Dot(&dir, &dir)))
+        {
+          // intersection not found
+          status = -1;
+        }
+
+        if (dir.length2() < SIMD_EPSILON)
+        {
+          // no intersection, besides margin
+          status = -1;
+          break;
+        }
+
+        if (dir.fuzzyZero())
+        {
+          // intersection not found
+          status = -1;
+          break;
+        }
+      }
+    }
+
+    m_simplexSolver->reset();
+    if (status == 0 && !m_cdata->req.calculate_distance)
+    {
+      // The shapes intersect but penetration was not request so return empty contact
+      output.addContactPoint(normalInB, pointOnB + positionOffset, distance);
+      return;
+    }
+
+    if (status == -1 && !m_cdata->req.calculate_distance)
+    {
+      // The shapes do not intersect and we did not request distance data so return.
+      return;
+    }
+
+    // printf("dir=%f,%f,%f\n",dir[0],dir[1],dir[2]);
+    if (1)
+    {
+      for (;;)
+      // while (true)
+      {
+        btVector3 separatingAxisInA = (-m_cachedSeparatingAxis) * localTransA.getBasis();
+        btVector3 separatingAxisInB = m_cachedSeparatingAxis * localTransB.getBasis();
+
+        btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+        btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
+
+        btVector3 pWorld = localTransA(pInA);
+        btVector3 qWorld = localTransB(qInB);
+
+        if (check2d)
+        {
+          pWorld[2] = 0.f;
+          qWorld[2] = 0.f;
+        }
+
+        btVector3 w = pWorld - qWorld;
+        delta = m_cachedSeparatingAxis.dot(w);
+
+        // potential exit, they don't overlap
+        if ((delta > btScalar(0.0)) && (delta * delta > squaredDistance * input.m_maximumDistanceSquared))
+        {
+          m_degenerateSimplex = 10;
+          checkSimplex = true;
+          // checkPenetration = false;
+          break;
+        }
+
+        // exit 0: the new point is already in the simplex, or we didn't come any closer
+        if (m_simplexSolver->inSimplex(w))
+        {
+          m_degenerateSimplex = 1;
+          checkSimplex = true;
+          break;
+        }
+        // are we getting any closer ?
+        btScalar f0 = squaredDistance - delta;
+        btScalar f1 = squaredDistance * REL_ERROR2;
+
+        if (f0 <= f1)
+        {
+          if (f0 <= btScalar(0.))
+          {
+            m_degenerateSimplex = 2;
+          }
+          else
+          {
+            m_degenerateSimplex = 11;
+          }
+          checkSimplex = true;
+          break;
+        }
+
+        // add current vertex to simplex
+        m_simplexSolver->addVertex(w, pWorld, qWorld);
+        btVector3 newCachedSeparatingAxis;
+
+        // calculate the closest point to the origin (update vector v)
+        if (!m_simplexSolver->closest(newCachedSeparatingAxis))
+        {
+          m_degenerateSimplex = 3;
+          checkSimplex = true;
+          break;
+        }
+
+        if (newCachedSeparatingAxis.length2() < REL_ERROR2)
+        {
+          m_cachedSeparatingAxis = newCachedSeparatingAxis;
+          m_degenerateSimplex = 6;
+          checkSimplex = true;
+          break;
+        }
+
+        btScalar previousSquaredDistance = squaredDistance;
+        squaredDistance = newCachedSeparatingAxis.length2();
+#if 0
+        ///warning: this termination condition leads to some problems in 2d test case see Bullet/Demos/Box2dDemo
+        if (squaredDistance > previousSquaredDistance)
+        {
+          m_degenerateSimplex = 7;
+          squaredDistance = previousSquaredDistance;
+          checkSimplex = false;
+          break;
+        }
+#endif  //
+
+        // redundant m_simplexSolver->compute_points(pointOnA, pointOnB);
+
+        // are we getting any closer ?
+        if (previousSquaredDistance - squaredDistance <= SIMD_EPSILON * previousSquaredDistance)
+        {
+          //				m_simplexSolver->backup_closest(m_cachedSeparatingAxis);
+          checkSimplex = true;
+          m_degenerateSimplex = 12;
+
+          break;
+        }
+
+        m_cachedSeparatingAxis = newCachedSeparatingAxis;
+
+        // degeneracy, this is typically due to invalid/uninitialized worldtransforms for a btCollisionObject
+        if (m_curIter++ > gGjkMaxIter)
+        {
+#if defined(DEBUG) || defined(_DEBUG)
+
+          printf("btGjkPairDetector maxIter exceeded:%i\n", m_curIter);
+          printf("sepAxis=(%f,%f,%f), squaredDistance = %f, shapeTypeA=%i,shapeTypeB=%i\n",
+                 m_cachedSeparatingAxis.getX(),
+                 m_cachedSeparatingAxis.getY(),
+                 m_cachedSeparatingAxis.getZ(),
+                 squaredDistance,
+                 m_minkowskiA->getShapeType(),
+                 m_minkowskiB->getShapeType());
+
+#endif
+          break;
+        }
+
+        bool check = (!m_simplexSolver->fullSimplex());
+        // bool check = (!m_simplexSolver->fullSimplex() && squaredDistance > SIMD_EPSILON *
+        // m_simplexSolver->maxVertex());
+
+        if (!check)
+        {
+          // do we need this backup_closest here ?
+          //				m_simplexSolver->backup_closest(m_cachedSeparatingAxis);
+          m_degenerateSimplex = 13;
+          break;
+        }
+      }
+
+      if (checkSimplex)
+      {
+        m_simplexSolver->compute_points(pointOnA, pointOnB);
+        normalInB = m_cachedSeparatingAxis;
+
+        btScalar lenSqr = m_cachedSeparatingAxis.length2();
+
+        // valid normal
+        if (lenSqr < REL_ERROR2)
+        {
+          m_degenerateSimplex = 5;
+        }
+        if (lenSqr > SIMD_EPSILON * SIMD_EPSILON)
+        {
+          btScalar rlen = btScalar(1.) / btSqrt(lenSqr);
+          normalInB *= rlen;  // normalize
+
+          btScalar s = btSqrt(squaredDistance);
+
+          btAssert(s > btScalar(0.0));
+          pointOnA -= m_cachedSeparatingAxis * (marginA / s);
+          pointOnB += m_cachedSeparatingAxis * (marginB / s);
+          distance = ((btScalar(1.) / rlen) - margin);
+          isValid = true;
+          orgNormalInB = normalInB;
+
+          m_lastUsedMethod = 1;
+        }
+        else
+        {
+          m_lastUsedMethod = 2;
+        }
+      }
+    }
+
+    bool catchDegeneratePenetrationCase = (m_catchDegeneracies && m_penetrationDepthSolver && m_degenerateSimplex &&
+                                           ((distance + margin) < gGjkEpaPenetrationTolerance));
+
+    // if (checkPenetration && !isValid)
+    if ((checkPenetration && (!isValid || catchDegeneratePenetrationCase)) || (status == 0))
+    {
+      // penetration case
+
+      // if there is no way to handle penetrations, bail out
+      if (m_penetrationDepthSolver)
+      {
+        // Penetration depth case.
+        btVector3 tmpPointOnA, tmpPointOnB;
+
+        m_cachedSeparatingAxis.setZero();
+
+        bool isValid2 = m_penetrationDepthSolver->calcPenDepth(*m_simplexSolver,
+                                                               m_minkowskiA,
+                                                               m_minkowskiB,
+                                                               localTransA,
+                                                               localTransB,
+                                                               m_cachedSeparatingAxis,
+                                                               tmpPointOnA,
+                                                               tmpPointOnB,
+                                                               debugDraw);
+
+        if (m_cachedSeparatingAxis.length2())
+        {
+          if (isValid2)
+          {
+            btVector3 tmpNormalInB = tmpPointOnB - tmpPointOnA;
+            btScalar lenSqr = tmpNormalInB.length2();
+            if (lenSqr <= (SIMD_EPSILON * SIMD_EPSILON))
+            {
+              tmpNormalInB = m_cachedSeparatingAxis;
+              lenSqr = m_cachedSeparatingAxis.length2();
+            }
+
+            if (lenSqr > (SIMD_EPSILON * SIMD_EPSILON))
+            {
+              tmpNormalInB /= btSqrt(lenSqr);
+              btScalar distance2 = -(tmpPointOnA - tmpPointOnB).length();
+              m_lastUsedMethod = 3;
+              // only replace valid penetrations when the result is deeper (check)
+              if (!isValid || (distance2 < distance))
+              {
+                distance = distance2;
+                pointOnA = tmpPointOnA;
+                pointOnB = tmpPointOnB;
+                normalInB = tmpNormalInB;
+                isValid = true;
+              }
+              else
+              {
+                m_lastUsedMethod = 8;
+              }
+            }
+            else
+            {
+              m_lastUsedMethod = 9;
+            }
+          }
+          else
+
+          {
+            /// this is another degenerate case, where the initial GJK calculation reports a degenerate case
+            /// EPA reports no penetration, and the second GJK (using the supporting vector without margin)
+            /// reports a valid positive distance. Use the results of the second GJK instead of failing.
+            /// thanks to Jacob.Langford for the reproduction case
+            /// http://code.google.com/p/bullet/issues/detail?id=250
+
+            if (m_cachedSeparatingAxis.length2() > btScalar(0.))
+            {
+              btScalar distance2 = (tmpPointOnA - tmpPointOnB).length() - margin;
+              // only replace valid distances when the distance is less
+              if (!isValid || (distance2 < distance))
+              {
+                distance = distance2;
+                pointOnA = tmpPointOnA;
+                pointOnB = tmpPointOnB;
+                pointOnA -= m_cachedSeparatingAxis * marginA;
+                pointOnB += m_cachedSeparatingAxis * marginB;
+                normalInB = m_cachedSeparatingAxis;
+                normalInB.normalize();
+
+                isValid = true;
+                m_lastUsedMethod = 6;
+              }
+              else
+              {
+                m_lastUsedMethod = 5;
+              }
+            }
+          }
+        }
+        else
+        {
+          // printf("EPA didn't return a valid value\n");
+        }
+      }
+    }
+  }
+
+  if (isValid && ((distance < 0) || (distance * distance < input.m_maximumDistanceSquared)))
+  {
+    m_cachedSeparatingAxis = normalInB;
+    m_cachedSeparatingDistance = distance;
+    if (1)
+    {
+      /// todo: need to track down this EPA penetration solver degeneracy
+      /// the penetration solver reports penetration but the contact normal
+      /// connecting the contact points is pointing in the opposite direction
+      /// until then, detect the issue and revert the normal
+
+      btScalar d2 = 0.f;
+      {
+        btVector3 separatingAxisInA = (-orgNormalInB) * localTransA.getBasis();
+        btVector3 separatingAxisInB = orgNormalInB * localTransB.getBasis();
+
+        btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+        btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
+
+        btVector3 pWorld = localTransA(pInA);
+        btVector3 qWorld = localTransB(qInB);
+        btVector3 w = pWorld - qWorld;
+        d2 = orgNormalInB.dot(w) - margin;
+      }
+
+      btScalar d1 = 0;
+      {
+        btVector3 separatingAxisInA = (normalInB)*localTransA.getBasis();
+        btVector3 separatingAxisInB = -normalInB * localTransB.getBasis();
+
+        btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+        btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
+
+        btVector3 pWorld = localTransA(pInA);
+        btVector3 qWorld = localTransB(qInB);
+        btVector3 w = pWorld - qWorld;
+        d1 = (-normalInB).dot(w) - margin;
+      }
+      btScalar d0 = 0.f;
+      {
+        btVector3 separatingAxisInA = (-normalInB) * input.m_transformA.getBasis();
+        btVector3 separatingAxisInB = normalInB * input.m_transformB.getBasis();
+
+        btVector3 pInA = m_minkowskiA->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInA);
+        btVector3 qInB = m_minkowskiB->localGetSupportVertexWithoutMarginNonVirtual(separatingAxisInB);
+
+        btVector3 pWorld = localTransA(pInA);
+        btVector3 qWorld = localTransB(qInB);
+        btVector3 w = pWorld - qWorld;
+        d0 = normalInB.dot(w) - margin;
+      }
+
+      if (d1 > d0)
+      {
+        m_lastUsedMethod = 10;
+        normalInB *= -1;
+      }
+
+      if (orgNormalInB.length2())
+      {
+        if (d2 > d0 && d2 > d1 && d2 > distance)
+        {
+          normalInB = orgNormalInB;
+          distance = d2;
+        }
+      }
+    }
+
+    output.addContactPoint(normalInB, pointOnB + positionOffset, distance);
+  }
+  else
+  {
+    // printf("invalid gjk query\n");
+  }
+}
+}  // namespace tesseract_collision_bullet
+}  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/fcl/fcl_collision_object_wrapper.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_collision_object_wrapper.cpp
@@ -54,11 +54,16 @@ void FCLCollisionObjectWrapper::setContactDistanceThreshold(double contact_dista
   updateAABB();
 }
 
+double FCLCollisionObjectWrapper::getContactDistanceThreshold() const { return contact_distance_; }
+
 void FCLCollisionObjectWrapper::updateAABB()
 {
   if (t.linear().isIdentity())
   {
     aabb = translate(cgeom->aabb_local, t.translation());
+    fcl::Vector3<double> delta = fcl::Vector3<double>::Constant(contact_distance_);
+    aabb.min_ -= delta;
+    aabb.max_ += delta;
   }
   else
   {

--- a/tesseract/tesseract_collision/src/fcl/fcl_collision_object_wrapper.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_collision_object_wrapper.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file fcl_collision_object_wrapper.cpp
+ * @brief Collision Object Wrapper to modify AABB with contact distance threshold
+ *
+ * @author Levi Armstrong
+ * @date April 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_collision/fcl/fcl_collision_object_wrapper.h>
+
+namespace tesseract_collision
+{
+namespace tesseract_collision_fcl
+{
+FCLCollisionObjectWrapper::FCLCollisionObjectWrapper(const std::shared_ptr<fcl::CollisionGeometry<double>>& cgeom)
+  : fcl::CollisionObject<double>(cgeom)
+{
+}
+
+FCLCollisionObjectWrapper::FCLCollisionObjectWrapper(const std::shared_ptr<fcl::CollisionGeometry<double>>& cgeom,
+                                                     const fcl::Transform3<double>& tf)
+  : fcl::CollisionObject<double>(cgeom, tf)
+{
+}
+
+FCLCollisionObjectWrapper::FCLCollisionObjectWrapper(const std::shared_ptr<fcl::CollisionGeometry<double>>& cgeom,
+                                                     const fcl::Matrix3<double>& R,
+                                                     const fcl::Vector3<double>& T)
+  : fcl::CollisionObject<double>(cgeom, R, T)
+{
+}
+
+void FCLCollisionObjectWrapper::setContactDistanceThreshold(double contact_distance)
+{
+  contact_distance_ = contact_distance;
+  updateAABB();
+}
+
+void FCLCollisionObjectWrapper::updateAABB()
+{
+  if (t.linear().isIdentity())
+  {
+    aabb = translate(cgeom->aabb_local, t.translation());
+  }
+  else
+  {
+    fcl::Vector3<double> center = t * cgeom->aabb_center;
+    fcl::Vector3<double> delta = fcl::Vector3<double>::Constant(cgeom->aabb_radius + contact_distance_);
+    aabb.min_ = center - delta;
+    aabb.max_ = center + delta;
+  }
+}
+
+}  // namespace tesseract_collision_fcl
+}  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
@@ -60,13 +60,7 @@ DiscreteContactManager::Ptr FCLDiscreteBVHManager::clone() const
   auto manager = std::make_shared<FCLDiscreteBVHManager>();
 
   for (const auto& cow : link2cow_)
-  {
-    COW::Ptr new_cow = cow.second->clone();
-
-    // TODO LEVI: Should this happen as part of the clone?
-    new_cow->setCollisionObjectsTransform(cow.second->getCollisionObjectsTransform());
-    manager->addCollisionObject(new_cow);
-  }
+    manager->addCollisionObject(cow.second->clone());
 
   manager->setActiveCollisionObjects(active_);
   manager->setContactDistanceThreshold(contact_distance_);

--- a/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
@@ -256,6 +256,10 @@ void FCLDiscreteBVHManager::setActiveCollisionObjects(const std::vector<std::str
 
   for (auto& co : link2cow_)
     updateCollisionObjectFilters(active_, co.second, static_manager_, dynamic_manager_);
+
+  // This causes a refit on the bvh tree.
+  dynamic_manager_->update();
+  static_manager_->update();
 }
 
 const std::vector<std::string>& FCLDiscreteBVHManager::getActiveCollisionObjects() const { return active_; }
@@ -368,6 +372,10 @@ void FCLDiscreteBVHManager::addCollisionObject(const COW::Ptr& cow)
   // If active links is not empty update filters to respace the active links list
   if (!active_.empty())
     updateCollisionObjectFilters(active_, cow, static_manager_, dynamic_manager_);
+
+  // This causes a refit on the bvh tree.
+  dynamic_manager_->update();
+  static_manager_->update();
 }
 }  // namespace tesseract_collision_fcl
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
@@ -39,7 +39,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "tesseract_collision/fcl/fcl_discrete_managers.h"
+#include <tesseract_collision/fcl/fcl_discrete_managers.h>
 
 namespace tesseract_collision
 {
@@ -50,13 +50,14 @@ static const tesseract_common::VectorIsometry3d EMPTY_COLLISION_SHAPES_TRANSFORM
 
 FCLDiscreteBVHManager::FCLDiscreteBVHManager()
 {
-  manager_ = std::unique_ptr<fcl::BroadPhaseCollisionManagerd>(new fcl::DynamicAABBTreeCollisionManagerd());
+  static_manager_ = std::unique_ptr<fcl::BroadPhaseCollisionManagerd>(new fcl::DynamicAABBTreeCollisionManagerd());
+  dynamic_manager_ = std::unique_ptr<fcl::BroadPhaseCollisionManagerd>(new fcl::DynamicAABBTreeCollisionManagerd());
   contact_distance_ = 0;
 }
 
 DiscreteContactManager::Ptr FCLDiscreteBVHManager::clone() const
 {
-  FCLDiscreteBVHManager::Ptr manager(new FCLDiscreteBVHManager());
+  auto manager = std::make_shared<FCLDiscreteBVHManager>();
 
   for (const auto& cow : link2cow_)
   {
@@ -120,7 +121,10 @@ bool FCLDiscreteBVHManager::removeCollisionObject(const std::string& name)
   {
     std::vector<CollisionObjectPtr>& objects = it->second->getCollisionObjects();
     for (auto& co : objects)
-      manager_->unregisterObject(co.get());
+    {
+      static_manager_->unregisterObject(co.get());
+      dynamic_manager_->unregisterObject(co.get());
+    }
 
     collision_objects_.erase(std::find(collision_objects_.begin(), collision_objects_.end(), name));
     link2cow_.erase(name);
@@ -155,21 +159,98 @@ void FCLDiscreteBVHManager::setCollisionObjectsTransform(const std::string& name
 {
   auto it = link2cow_.find(name);
   if (it != link2cow_.end())
-    it->second->setCollisionObjectsTransform(pose);
+  {
+    const Eigen::Isometry3d& cur_tf = it->second->getCollisionObjectsTransform();
+    // Note: If the transform has not changed do not updated to prevent unnecessary rebalancing of the BVH tree
+    if (!cur_tf.translation().isApprox(pose.translation(), 1e-8) || !cur_tf.rotation().isApprox(pose.rotation(), 1e-8))
+    {
+      it->second->setCollisionObjectsTransform(pose);
+      if (it->second->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
+      {
+        // Note: Calling update causes a rebalance of the AABB tree, which is expensive
+        static_manager_->update(it->second->getCollisionObjectsRaw());
+      }
+      else
+      {
+        // Note: Calling update causes a rebalance of the AABB tree, which is expensive
+        dynamic_manager_->update(it->second->getCollisionObjectsRaw());
+      }
+    }
+  }
 }
 
 void FCLDiscreteBVHManager::setCollisionObjectsTransform(const std::vector<std::string>& names,
                                                          const tesseract_common::VectorIsometry3d& poses)
 {
   assert(names.size() == poses.size());
+  static_update_.clear();
+  dynamic_update_.clear();
   for (auto i = 0u; i < names.size(); ++i)
-    setCollisionObjectsTransform(names[i], poses[i]);
+  {
+    auto it = link2cow_.find(names[i]);
+    if (it != link2cow_.end())
+    {
+      const Eigen::Isometry3d& cur_tf = it->second->getCollisionObjectsTransform();
+      // Note: If the transform has not changed do not updated to prevent unnecessary rebalancing of the BVH tree
+      if (!cur_tf.translation().isApprox(poses[i].translation(), 1e-8) ||
+          !cur_tf.rotation().isApprox(poses[i].rotation(), 1e-8))
+      {
+        it->second->setCollisionObjectsTransform(poses[i]);
+        std::vector<CollisionObjectRawPtr>& co = it->second->getCollisionObjectsRaw();
+        if (it->second->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
+        {
+          static_update_.insert(static_update_.end(), co.begin(), co.end());
+        }
+        else
+        {
+          dynamic_update_.insert(dynamic_update_.end(), co.begin(), co.end());
+        }
+      }
+    }
+  }
+
+  // This is because FCL supports batch update which only rebalances the tree once
+  if (!static_update_.empty())
+    static_manager_->update(static_update_);
+
+  if (!dynamic_update_.empty())
+    dynamic_manager_->update(dynamic_update_);
 }
 
 void FCLDiscreteBVHManager::setCollisionObjectsTransform(const tesseract_common::TransformMap& transforms)
 {
+  static_update_.clear();
+  dynamic_update_.clear();
   for (const auto& transform : transforms)
-    setCollisionObjectsTransform(transform.first, transform.second);
+  {
+    auto it = link2cow_.find(transform.first);
+    if (it != link2cow_.end())
+    {
+      const Eigen::Isometry3d& cur_tf = it->second->getCollisionObjectsTransform();
+      // Note: If the transform has not changed do not updated to prevent unnecessary rebalancing of the BVH tree
+      if (!cur_tf.translation().isApprox(transform.second.translation(), 1e-8) ||
+          !cur_tf.rotation().isApprox(transform.second.rotation(), 1e-8))
+      {
+        it->second->setCollisionObjectsTransform(transform.second);
+        std::vector<CollisionObjectRawPtr>& co = it->second->getCollisionObjectsRaw();
+        if (it->second->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
+        {
+          static_update_.insert(static_update_.end(), co.begin(), co.end());
+        }
+        else
+        {
+          dynamic_update_.insert(dynamic_update_.end(), co.begin(), co.end());
+        }
+      }
+    }
+  }
+
+  // This is because FCL supports batch update which only rebalances the tree once
+  if (!static_update_.empty())
+    static_manager_->update(static_update_);
+
+  if (!dynamic_update_.empty())
+    dynamic_manager_->update(dynamic_update_);
 }
 
 const std::vector<std::string>& FCLDiscreteBVHManager::getCollisionObjects() const { return collision_objects_; }
@@ -179,11 +260,7 @@ void FCLDiscreteBVHManager::setActiveCollisionObjects(const std::vector<std::str
   active_ = names;
 
   for (auto& co : link2cow_)
-  {
-    COW::Ptr& cow = co.second;
-
-    updateCollisionObjectFilters(active_, *cow);
-  }
+    updateCollisionObjectFilters(active_, co.second, static_manager_, dynamic_manager_);
 }
 
 const std::vector<std::string>& FCLDiscreteBVHManager::getActiveCollisionObjects() const { return active_; }
@@ -195,27 +272,115 @@ void FCLDiscreteBVHManager::setContactDistanceThreshold(double contact_distance)
 double FCLDiscreteBVHManager::getContactDistanceThreshold() const { return contact_distance_; }
 void FCLDiscreteBVHManager::setIsContactAllowedFn(IsContactAllowedFn fn) { fn_ = fn; }
 IsContactAllowedFn FCLDiscreteBVHManager::getIsContactAllowedFn() const { return fn_; }
-void FCLDiscreteBVHManager::contactTest(ContactResultMap& collisions, const ContactTestType& type)
+
+/**
+ * @brief This is used to perform self check for fcl. The AABB Tree self check is N^2 which is slow and it is faster
+ *        to loop over the shapes and check bounding boxes.
+ * @param cdata The contact test data passed to the callback
+ * @param dynamic_manager The dynamics manager to perform self check on
+ * @param callback The callback function to call if bounding boxes overlap
+ */
+void selfCollisionContactTest(ContactTestData& cdata,
+                              const std::unique_ptr<fcl::BroadPhaseCollisionManagerd>& dynamic_manager,
+                              fcl::CollisionCallBack<double> callback)
 {
-  ContactTestData cdata(active_, contact_distance_, fn_, type, collisions);
-  if (contact_distance_ > 0)
+  std::vector<fcl::CollisionObjectd*> co;
+  dynamic_manager->getObjects(co);
+  for (std::vector<fcl::CollisionObjectd*>::const_iterator it1 = co.begin(), end = co.end(); it1 != end; ++it1)
   {
-    manager_->distance(&cdata, &distanceCallback);
+    std::vector<fcl::CollisionObjectd*>::const_iterator it2 = it1;
+    it2++;
+    for (; it2 != end; ++it2)
+    {
+      if ((*it1)->getAABB().overlap((*it2)->getAABB()))
+      {
+        if (callback(*it1, *it2, &cdata))
+          return;
+      }
+    }
+  }
+}
+
+/**
+ * @brief This is used to perform self check for fcl. The AABB Tree self check is N^2 which is slow and it is faster
+ *        to loop over the shapes and check bounding boxes.
+ * @param cdata The contact test data passed to the callback
+ * @param dynamic_manager The dynamics manager to perform self check on
+ * @param callback The callback function to call if bounding boxes overlap
+ * @param min_dist The minimum distance that triggers the callback
+ */
+void selfDistanceContactTest(ContactTestData& cdata,
+                             const std::unique_ptr<fcl::BroadPhaseCollisionManagerd>& dynamic_manager,
+                             fcl::DistanceCallBack<double> callback,
+                             double& min_dist)
+{
+  std::vector<fcl::CollisionObjectd*> co;
+  dynamic_manager->getObjects(co);
+  for (std::vector<fcl::CollisionObjectd*>::const_iterator it1 = co.begin(), end = co.end(); it1 != end; ++it1)
+  {
+    std::vector<fcl::CollisionObjectd*>::const_iterator it2 = it1;
+    it2++;
+    for (; it2 != end; ++it2)
+    {
+      if ((*it1)->getAABB().overlap((*it2)->getAABB()))
+      {
+        if (callback(*it1, *it2, &cdata, min_dist))
+          return;
+      }
+    }
+  }
+}
+
+void FCLDiscreteBVHManager::contactTest(ContactResultMap& collisions, const ContactRequest& request)
+{
+  ContactTestData cdata(active_, contact_distance_, fn_, request, collisions);
+  if (contact_distance_ > 0 && request.calculate_distance)
+  {
+    // TODO: Should the order be flipped?
+    if (!static_manager_->empty())
+      static_manager_->distance(dynamic_manager_.get(), &cdata, &distanceCallback);
+
+    // It looks like the self check is as fast as selfDistanceContactTest even though it is N^2
+    if (!cdata.done && !dynamic_manager_->empty())
+      dynamic_manager_->distance(&cdata, &distanceCallback);  // selfDistanceContactTest(cdata, dynamic_manager_,
+                                                              // &distanceCallback, contact_distance_);
   }
   else
   {
-    manager_->collide(&cdata, &collisionCallback);
+    // TODO: Should the order be flipped?
+    if (!static_manager_->empty())
+      static_manager_->collide(dynamic_manager_.get(), &cdata, &collisionCallback);
+
+    // It looks like the self check is as fast as selfDistanceContactTest even though it is N^2
+    if (!cdata.done && !dynamic_manager_->empty())
+      dynamic_manager_->collide(&cdata, &collisionCallback);  // selfCollisionContactTest(cdata, dynamic_manager_,
+                                                              // &collisionCallback);
   }
 }
 
 void FCLDiscreteBVHManager::addCollisionObject(const COW::Ptr& cow)
 {
+  static_update_.reserve(link2cow_.size() + cow->getCollisionObjectsRaw().size());
+  dynamic_update_.reserve(link2cow_.size() + cow->getCollisionObjectsRaw().size());
   link2cow_[cow->getName()] = cow;
   collision_objects_.push_back(cow->getName());
 
   std::vector<CollisionObjectPtr>& objects = cow->getCollisionObjects();
-  for (auto& co : objects)
-    manager_->registerObject(co.get());
+  if (cow->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
+  {
+    // If static add to static manager
+    for (auto& co : objects)
+      static_manager_->registerObject(co.get());
+  }
+  else
+  {
+    for (auto& co : objects)
+      dynamic_manager_->registerObject(co.get());
+  }
+
+  // If active links is not empty update filters to respace the active links list
+  if (!active_.empty())
+    updateCollisionObjectFilters(active_, cow, static_manager_, dynamic_manager_);
 }
 }  // namespace tesseract_collision_fcl
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/fcl/fcl_utils.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_utils.cpp
@@ -261,10 +261,9 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
   return cdata->done;
 }
 
-bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data, double& min_dist)
+bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)
 {
   auto* cdata = reinterpret_cast<ContactTestData*>(data);
-  min_dist = cdata->contact_distance;
 
   if (cdata->done)
     return true;
@@ -343,10 +342,10 @@ CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
     if (subshape != nullptr)
     {
       collision_geometries_.push_back(subshape);
-      auto co = std::make_shared<fcl::CollisionObjectd>(subshape);
+      auto co = std::make_shared<FCLCollisionObjectWrapper>(subshape);
       co->setUserData(this);
       co->setTransform(shape_poses_[i]);
-      co->computeAABB();
+      co->updateAABB();
       collision_objects_.push_back(co);
       collision_objects_raw_.push_back(co.get());
     }
@@ -368,7 +367,7 @@ CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
   collision_objects_.reserve(collision_objects.size());
   for (const auto& co : collision_objects)
   {
-    auto collObj = std::make_shared<fcl::CollisionObjectd>(*co);
+    auto collObj = std::make_shared<FCLCollisionObjectWrapper>(*co);
     collObj->setUserData(this);
     collision_objects_.push_back(collObj);
     collision_objects_raw_.push_back(collObj.get());

--- a/tesseract/tesseract_collision/src/fcl/fcl_utils.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_utils.cpp
@@ -365,10 +365,13 @@ CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
   , collision_geometries_(std::move(collision_geometries))
 {
   collision_objects_.reserve(collision_objects.size());
+  collision_objects_raw_.reserve(collision_objects.size());
   for (const auto& co : collision_objects)
   {
     auto collObj = std::make_shared<FCLCollisionObjectWrapper>(*co);
     collObj->setUserData(this);
+    collObj->setTransform(co->getTransform());
+    collObj->updateAABB();
     collision_objects_.push_back(collObj);
     collision_objects_raw_.push_back(collObj.get());
   }


### PR DESCRIPTION
This also adds a contact request data structure that allows you to configure if contact data is required or if you only want to perform a binary collision check. 

In order to accomplish this, two of Bullets libraries were copied in and minor modification were made. 

In the case of FCL, several performance improvements were made. The first was to have two BVH structures, one for static objects and one for dynamic objects. The second was to create a modified FCL collision object wrapper which allows for the AABB to be modified to include the contact distance. This also allowed for the manager collide to be called for both distance and collision requests with modified callbacks. The distance check in FCL is inefficient for our use case. It is more efficient to increase AABB in the broadphase instead of doing a distance check between AABB.