### PR TITLE
Bugfix when OMPL simplifies down to two states 

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/hybrid/ompl_trajopt_freespace_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/hybrid/ompl_trajopt_freespace_planner.h
@@ -48,7 +48,7 @@ public:
   bool setConfiguration(OMPLPlannerConfig::Ptr ompl_config, TrajOptPlannerFreespaceConfig::Ptr trajopt_config);
 
   /**
-   * @brief Sets up the opimizer and solves a SQP problem read from json with no callbacks and dafault parameterss
+   * @brief Sets up the optimizer and solves an SQP problem read from json with no callbacks and default parameters
    * @param response The results of the optimization. Primary output is the optimized joint trajectory
    * @param check_type The type of validation check to be performed on the planned trajectory
    * @param verbose Boolean indicating whether logging information about the motion planning solution should be printed
@@ -64,7 +64,7 @@ public:
   void clear() override;
 
   /**
-   * @brief checks whether the planner is properly configure for solving a motion plan
+   * @brief checks whether the planner is properly configured for solving a motion plan
    * @return True when it is configured correctly, false otherwise
    */
   tesseract_common::StatusCode isConfigured() const override;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/hybrid/ompl_trajopt_freespace_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/hybrid/ompl_trajopt_freespace_planner.cpp
@@ -120,6 +120,14 @@ tesseract_common::StatusCode OMPLTrajOptFreespacePlanner::solve(PlannerResponse&
     return response.status;
   }
 
+  if (ompl_planning_response.joint_trajectory.trajectory.rows() == 2)
+  {
+    auto new_trajectory = tesseract_common::TrajArray(3, ompl_planning_response.joint_trajectory.trajectory.cols());
+    new_trajectory.topRows(2) = ompl_planning_response.joint_trajectory.trajectory.topRows(2);
+    new_trajectory.row(2) = new_trajectory.row(1);
+    ompl_planning_response.joint_trajectory.trajectory = new_trajectory;
+  }
+
   if (trajopt_config_)
   {
     // The trajectory from OMPL may not be the same size as the number of steps requested in the TrajOpt config

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -179,7 +179,7 @@ tesseract_common::StatusCode OMPLMotionPlanner::solve(PlannerResponse& response,
     valid = validator_->trajectoryValid(traj, check_type, *state_solver, kin_->getJointNames());
   }
 
-  // Set the contact distance back to original incase solve was called again.
+  // Set the contact distance back to original in case solve was called again.
   continuous_contact_manager_->setContactDistanceThreshold(config_->collision_safety_margin);
 
   // Send response


### PR DESCRIPTION
TrajOpt was happily copying the 2 state solution and moving on, which caused segfaults later on when > 2 states are assumed (it was indexing from -1 in places).