### PR TITLE
Tesseract planners: Make solve method const

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
@@ -61,7 +61,7 @@ public:
    */
   virtual tesseract_common::StatusCode solve(const PlannerRequest& request,
                                              PlannerResponse& response,
-                                             bool verbose = false) = 0;
+                                             bool verbose = false) const = 0;
 
   /**
    * @brief If solve() is running, terminate the computation. Return false if termination not possible. No-op if

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
@@ -52,7 +52,7 @@ public:
    */
   tesseract_common::StatusCode solve(const PlannerRequest& request,
                                      PlannerResponse& response,
-                                     bool verbose = false) override;
+                                     bool verbose = false) const override;
 
   bool checkUserInput(const PlannerRequest& request);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -61,7 +61,7 @@ DescartesMotionPlanner<FloatType>::DescartesMotionPlanner(std::string name)
 template <typename FloatType>
 tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const PlannerRequest& request,
                                                                       PlannerResponse& response,
-                                                                      const bool /*verbose*/)
+                                                                      const bool /*verbose*/) const
 {
   if (!problem_generator)
   {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
@@ -81,7 +81,7 @@ public:
    */
   tesseract_common::StatusCode solve(const PlannerRequest& request,
                                      PlannerResponse& response,
-                                     bool verbose = false) override;
+                                     bool verbose = false) const override;
 
   bool terminate() override;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
@@ -87,7 +87,7 @@ public:
    */
   tesseract_common::StatusCode solve(const PlannerRequest& request,
                                      PlannerResponse& response,
-                                     bool verbose = false) override;
+                                     bool verbose = false) const override;
 
   bool checkUserInput(const PlannerRequest& request) const;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -95,7 +95,7 @@ bool OMPLMotionPlanner::terminate()
 
 tesseract_common::StatusCode OMPLMotionPlanner::solve(const PlannerRequest& request,
                                                       PlannerResponse& response,
-                                                      bool verbose)
+                                                      bool verbose) const
 {
   std::vector<OMPLProblem::UPtr> prob = problem_generator(request, plan_profiles);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -90,7 +90,7 @@ void TrajOptMotionPlanner::clear()
 
 tesseract_common::StatusCode TrajOptMotionPlanner::solve(const PlannerRequest& request,
                                                          PlannerResponse& response,
-                                                         bool verbose)
+                                                         bool verbose) const
 {
   if (!checkUserInput(request) || !problem_generator)
   {


### PR DESCRIPTION
These should be able to be const now since the request and response hold all of the data. 