### PR TITLE
Fix descartes processing of results to handle freespace correctly

### DIFF
--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
@@ -3,7 +3,7 @@
 
 #include <tesseract_command_language/core/instruction.h>
 #include <tesseract_command_language/instruction_type.h>
-#include <tesseract_command_language/null_waypoint.h>
+#include <tesseract_command_language/null_instruction.h>
 #include <vector>
 #include <string>
 
@@ -35,10 +35,11 @@ public:
   void setProfile(const std::string& profile);
   const std::string& getProfile() const;
 
-  // TODO: May need to create a class that includes not only the waypoint but I/O, environment, etc.
-  void setStartWaypoint(Waypoint waypoint);
-  const Waypoint& getStartWaypoint() const;
-  bool hasStartWaypoint() const;
+  void setStartInstruction(Instruction instruction);
+  void resetStartInstruction();
+  const Instruction& getStartInstruction() const;
+  Instruction& getStartInstruction();
+  bool hasStartInstruction() const;
 
   void print(std::string prefix = "") const;
 
@@ -59,13 +60,12 @@ private:
   CompositeInstructionOrder order_{ CompositeInstructionOrder::ORDERED };
 
   /**
-   * @brief The start waypoint to use for composite instruction.
+   * @brief The start instruction to use for composite instruction. This should be of type PlanInstruction or
+   * MoveInstruction but is stored as type Instruction because it is not required
    *
-   * If not provided, the planner should use the current state of the robot.
+   * If not provided, the planner should use the current state of the robot is used and defined as fixed.
    */
-  Waypoint start_waypoint_{ NullWaypoint() };
-
-  void flattenHelper(CompositeInstruction& flattened, const CompositeInstruction& composite) const;
+  Instruction start_instruction_{ NullInstruction() };
 };
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/instruction_type.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/instruction_type.h
@@ -7,6 +7,9 @@ class Instruction;
 
 enum class InstructionType : int
 {
+  // Everything before must be a Null Instruction
+  NULL_INSTRUCTION,
+
   // Everything before must be a motion plan Instruction
   PLAN_INSTRUCTION,
 
@@ -45,6 +48,8 @@ bool isCompositeInstruction(const Instruction& instruction);
 bool isMoveInstruction(const Instruction& instruction);
 
 bool isPlanInstruction(const Instruction& instruction);
+
+bool isNullInstruction(const Instruction& instruction);
 
 }  // namespace tesseract_planning
 

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -12,7 +12,8 @@ enum class MoveInstructionType : int
 {
   LINEAR,
   FREESPACE,
-  CIRCULAR
+  CIRCULAR,
+  START
 };
 
 class MoveInstruction
@@ -63,6 +64,8 @@ public:
   bool isFreespace() const;
 
   bool isCircular() const;
+
+  bool isStart() const;
 
 private:
   int type_{ static_cast<int>(InstructionType::MOVE_INSTRUCTION) };

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/null_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/null_instruction.h
@@ -1,0 +1,29 @@
+#ifndef TESSERACT_COMMAND_LANGUAGE_NULL_INSTRUCTION_H
+#define TESSERACT_COMMAND_LANGUAGE_NULL_INSTRUCTION_H
+
+#include <tesseract_command_language/instruction_type.h>
+#include <iostream>
+
+namespace tesseract_planning
+{
+class NullInstruction
+{
+public:
+  int getType() const { return static_cast<int>(InstructionType::NULL_INSTRUCTION); }
+
+  const std::string& getDescription() const { return description_; }
+
+  void setDescription(const std::string& description) { description_ = description; }
+
+  void print(std::string prefix = "") const // NOLINT
+  {
+    std::cout << prefix + "Null Instruction, Type: " << getType() << "  Description: " << getDescription() << std::endl;
+  }
+
+private:
+  /** @brief The description of the instruction */
+  std::string description_{ "Tesseract Null Instruction" };
+};
+}  // namespace tesseract_planning
+
+#endif  // TESSERACT_COMMAND_LANGUAGE_NULL_INSTRUCTION_H

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
@@ -12,7 +12,9 @@ enum class PlanInstructionType : int
 {
   LINEAR,
   FREESPACE,
-  CIRCULAR
+  CIRCULAR,
+  START,
+  START_FIXED
 };
 
 class PlanInstruction
@@ -51,6 +53,10 @@ public:
   bool isFreespace() const;
 
   bool isCircular() const;
+
+  bool isStart() const;
+
+  bool isStartFixed() const;
 
 private:
   int type_{ static_cast<int>(InstructionType::PLAN_INSTRUCTION) };

--- a/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
@@ -24,15 +24,20 @@ void CompositeInstruction::setProfile(const std::string& profile)
 }
 const std::string& CompositeInstruction::getProfile() const { return profile_; }
 
-void CompositeInstruction::setStartWaypoint(Waypoint waypoint) { start_waypoint_ = waypoint; }
+void CompositeInstruction::setStartInstruction(Instruction instruction) { start_instruction_ = instruction; }
 
-const Waypoint& CompositeInstruction::getStartWaypoint() const { return start_waypoint_; }
+void CompositeInstruction::resetStartInstruction() { start_instruction_ = NullInstruction(); }
 
-bool CompositeInstruction::hasStartWaypoint() const { return (!isNullWaypoint(start_waypoint_)); }
+const Instruction& CompositeInstruction::getStartInstruction() const { return start_instruction_; }
+
+Instruction& CompositeInstruction::getStartInstruction() { return start_instruction_; }
+
+bool CompositeInstruction::hasStartInstruction() const { return (!isNullInstruction(start_instruction_)); }
 
 void CompositeInstruction::print(std::string prefix) const
 {
   std::cout << prefix + "Composite Instruction, Description: " << getDescription() << std::endl;
+  std::cout << prefix + "--- Start Instruction, Description: " << start_instruction_.getDescription() << std::endl;
   std::cout << prefix + "{" << std::endl;
   for (const auto& i : *this)
     i.print(prefix + "  ");

--- a/tesseract/tesseract_planning/tesseract_command_language/src/instruction_type.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/instruction_type.cpp
@@ -41,7 +41,13 @@ bool isMoveInstruction(const Instruction& instruction)
 
 bool isPlanInstruction(const Instruction& instruction)
 {
-  return (instruction.getType() <= static_cast<int>(InstructionType::PLAN_INSTRUCTION));
+  return (instruction.getType() <= static_cast<int>(InstructionType::PLAN_INSTRUCTION) &&
+          instruction.getType() > static_cast<int>(InstructionType::NULL_INSTRUCTION));
+}
+
+bool isNullInstruction(const Instruction& instruction)
+{
+  return (instruction.getType() <= static_cast<int>(InstructionType::NULL_INSTRUCTION));
 }
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_command_language/src/move_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/move_instruction.cpp
@@ -52,4 +52,7 @@ bool MoveInstruction::isLinear() const { return (move_type_ == MoveInstructionTy
 bool MoveInstruction::isFreespace() const { return (move_type_ == MoveInstructionType::FREESPACE); }
 
 bool MoveInstruction::isCircular() const { return (move_type_ == MoveInstructionType::CIRCULAR); }
+
+bool MoveInstruction::isStart() const { return (move_type_ == MoveInstructionType::START); }
+
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_command_language/src/plan_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/plan_instruction.cpp
@@ -43,4 +43,8 @@ bool PlanInstruction::isLinear() const { return (plan_type_ == PlanInstructionTy
 bool PlanInstruction::isFreespace() const { return (plan_type_ == PlanInstructionType::FREESPACE); }
 
 bool PlanInstruction::isCircular() const { return (plan_type_ == PlanInstructionType::CIRCULAR); }
+
+bool PlanInstruction::isStart() const { return (plan_type_ == PlanInstructionType::START); }
+
+bool PlanInstruction::isStartFixed() const { return (plan_type_ == PlanInstructionType::START_FIXED); }
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
@@ -160,18 +160,41 @@ inline CompositeInstruction generateSeed(const CompositeInstruction& instruction
   Eigen::Isometry3d world_to_base = current_state->link_transforms.at(fwd_kin->getBaseLinkName());
 
   Waypoint start_waypoint = NullWaypoint();
-  if (instructions.hasStartWaypoint())
+  if (instructions.hasStartInstruction())
   {
-    start_waypoint = instructions.getStartWaypoint();
+    assert(isPlanInstruction(instructions.getStartInstruction()));
+    const auto* start_instruction = instructions.getStartInstruction().cast_const<PlanInstruction>();
+    assert(start_instruction->isStart() || start_instruction->isStartFixed());
+    start_waypoint = start_instruction->getWaypoint();
+
+    MoveInstruction seed_start(start_waypoint, MoveInstructionType::START);
+    seed_start.setTCP(start_instruction->getTCP());
+    seed_start.setWorkingFrame(start_instruction->getWorkingFrame());
+    seed_start.setProfile(start_instruction->getProfile());
+    seed_start.setDescription(start_instruction->getDescription());
+
+    if (start_instruction->isStartFixed() && !isJointWaypoint(start_waypoint))
+      throw std::runtime_error("Plan instruction with type START_FIXED must have a joint waypoint type");
+
+    if (isJointWaypoint(start_waypoint))
+      seed_start.setPosition(*(start_waypoint.cast<JointWaypoint>()));
+    else if (isCartesianWaypoint(start_waypoint))
+      seed_start.setPosition(current_jv);
+    else
+      throw std::runtime_error("Generate Seed: Unsupported waypoint type!");
+    seed.setStartInstruction(seed_start);
   }
   else
   {
     JointWaypoint temp(current_jv);
     temp.joint_names = fwd_kin->getJointNames();
     start_waypoint = temp;
+
+    MoveInstruction seed_start(temp, MoveInstructionType::START);
+    seed_start.setPosition(current_jv);
+    seed.setStartInstruction(seed_start);
   }
 
-  bool found_plan_instruction = false;
   for (const auto& instruction : instructions)
   {
     if (isPlanInstruction(instruction))
@@ -185,20 +208,6 @@ inline CompositeInstruction generateSeed(const CompositeInstruction& instruction
         bool is_jwp1 = isJointWaypoint(start_waypoint);
         bool is_cwp2 = isCartesianWaypoint(plan_instruction->getWaypoint());
         bool is_jwp2 = isJointWaypoint(plan_instruction->getWaypoint());
-        if (!found_plan_instruction)
-        {
-          tesseract_planning::MoveInstruction move_instruction(start_waypoint, MoveInstructionType::LINEAR);
-
-          if (is_jwp1)
-            move_instruction.setPosition(*(start_waypoint.cast_const<JointWaypoint>()));
-          else
-            move_instruction.setPosition(current_jv);
-
-          move_instruction.setTCP(plan_instruction->getTCP());
-          move_instruction.setWorkingFrame(plan_instruction->getWorkingFrame());
-          move_instruction.setDescription(plan_instruction->getDescription());
-          composite.push_back(move_instruction);
-        }
 
         assert(is_cwp1 || is_jwp1);
         assert(is_cwp2 || is_jwp2);
@@ -315,20 +324,6 @@ inline CompositeInstruction generateSeed(const CompositeInstruction& instruction
         bool is_jwp1 = isJointWaypoint(start_waypoint);
         bool is_cwp2 = isCartesianWaypoint(plan_instruction->getWaypoint());
         bool is_jwp2 = isJointWaypoint(plan_instruction->getWaypoint());
-        if (!found_plan_instruction)
-        {
-          tesseract_planning::MoveInstruction move_instruction(start_waypoint, MoveInstructionType::FREESPACE);
-
-          if (is_jwp1)
-            move_instruction.setPosition(*(start_waypoint.cast_const<JointWaypoint>()));
-          else
-            move_instruction.setPosition(current_jv);
-
-          move_instruction.setTCP(plan_instruction->getTCP());
-          move_instruction.setWorkingFrame(plan_instruction->getWorkingFrame());
-          move_instruction.setDescription(plan_instruction->getDescription());
-          composite.push_back(move_instruction);
-        }
 
         assert(is_cwp1 || is_jwp1);
         assert(is_cwp2 || is_jwp2);
@@ -403,7 +398,6 @@ inline CompositeInstruction generateSeed(const CompositeInstruction& instruction
         throw std::runtime_error("Unsupported!");
       }
 
-      found_plan_instruction = true;
       start_waypoint = plan_instruction->getWaypoint();
     }
     else

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
@@ -89,7 +89,7 @@ inline tesseract_common::VectorIsometry3d interpolate(const Eigen::Isometry3d& s
  * @param steps The number of step
  * @return A matrix where columns = steps + 1
  */
-inline Eigen::MatrixXd interpolate(const Eigen::VectorXd& start, const Eigen::VectorXd& stop, int steps)
+inline Eigen::MatrixXd interpolate(const Eigen::Ref<const Eigen::VectorXd>& start, const Eigen::Ref<const Eigen::VectorXd>& stop, int steps)
 {
   assert(start.size() == stop.size());
 
@@ -108,7 +108,7 @@ inline Eigen::MatrixXd interpolate(const Eigen::VectorXd& start, const Eigen::Ve
  * @param steps The number of step
  * @return A vector of waypoints with a length = steps + 1
  */
-inline std::vector<Waypoint> interpolate(const Waypoint& start, const Waypoint& stop, int steps)
+inline std::vector<Waypoint> interpolate_waypoint(const Waypoint& start, const Waypoint& stop, int steps)
 {
   switch (start.getType())
   {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
@@ -89,7 +89,9 @@ inline tesseract_common::VectorIsometry3d interpolate(const Eigen::Isometry3d& s
  * @param steps The number of step
  * @return A matrix where columns = steps + 1
  */
-inline Eigen::MatrixXd interpolate(const Eigen::Ref<const Eigen::VectorXd>& start, const Eigen::Ref<const Eigen::VectorXd>& stop, int steps)
+inline Eigen::MatrixXd interpolate(const Eigen::Ref<const Eigen::VectorXd>& start,
+                                   const Eigen::Ref<const Eigen::VectorXd>& stop,
+                                   int steps)
 {
   assert(start.size() == stop.size());
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -137,7 +137,8 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
         auto* move_instructions = results_flattened[plan_index].get().cast<CompositeInstruction>();
         for (auto& instruction : *move_instructions)
         {
-          Eigen::Map<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>> temp(solution.data() + dof * result_index++, dof);
+          Eigen::Map<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>> temp(solution.data() + dof * result_index++,
+                                                                             dof);
           instruction.cast<MoveInstruction>()->setPosition(temp.template cast<double>());
         }
       }
@@ -153,7 +154,9 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
 
         if (!first_plan_instruction_found)
         {
-          Eigen::MatrixXd temp = interpolate(start.template cast<double>(), stop.template cast<double>(), static_cast<int>(move_instructions->size()) - 1);
+          Eigen::MatrixXd temp = interpolate(start.template cast<double>(),
+                                             stop.template cast<double>(),
+                                             static_cast<int>(move_instructions->size()) - 1);
 
           assert(temp.cols() == static_cast<long>(move_instructions->size()));
           for (std::size_t i = 0; i < move_instructions->size(); ++i)
@@ -161,7 +164,8 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
         }
         else
         {
-          Eigen::MatrixXd temp = interpolate(start.template cast<double>(), stop.template cast<double>(), static_cast<int>(move_instructions->size()));
+          Eigen::MatrixXd temp = interpolate(
+              start.template cast<double>(), stop.template cast<double>(), static_cast<int>(move_instructions->size()));
 
           assert(temp.cols() == static_cast<long>(move_instructions->size()) + 1);
           for (std::size_t i = 0; i < move_instructions->size(); ++i)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -124,7 +124,6 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
   // Loop over the flattened results and add them to response if the input was a plan instruction
   Eigen::Index dof = problem->manip_fwd_kin->numJoints();
   Eigen::Index result_index = 0;
-  bool first_plan_instruction_found = false;
   for (std::size_t plan_index = 0; plan_index < results_flattened.size(); plan_index++)
   {
     if (isPlanInstruction(instructions_flattened.at(plan_index).get()))
@@ -152,32 +151,23 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
         // This instruction corresponds to a composite. Set all results in that composite to the results
         auto* move_instructions = results_flattened[plan_index].get().cast<CompositeInstruction>();
 
-        if (!first_plan_instruction_found)
+        if (result_index == 1)
         {
-          Eigen::MatrixXd temp = interpolate(start.template cast<double>(),
-                                             stop.template cast<double>(),
-                                             static_cast<int>(move_instructions->size()) - 1);
-
-          assert(temp.cols() == static_cast<long>(move_instructions->size()));
-          for (std::size_t i = 0; i < move_instructions->size(); ++i)
-            (*move_instructions)[i].cast<MoveInstruction>()->setPosition(temp.col(static_cast<long>(i)));
+          auto* start_result = response.results.getStartInstruction().cast<MoveInstruction>();
+          start_result->setPosition(start.template cast<double>());
         }
-        else
-        {
-          Eigen::MatrixXd temp = interpolate(
+
+        Eigen::MatrixXd temp = interpolate(
               start.template cast<double>(), stop.template cast<double>(), static_cast<int>(move_instructions->size()));
 
-          assert(temp.cols() == static_cast<long>(move_instructions->size()) + 1);
-          for (std::size_t i = 0; i < move_instructions->size(); ++i)
-            (*move_instructions)[i].cast<MoveInstruction>()->setPosition(temp.col(static_cast<long>(i) + 1));
-        }
+        assert(temp.cols() == static_cast<long>(move_instructions->size()) + 1);
+        for (std::size_t i = 0; i < move_instructions->size(); ++i)
+          (*move_instructions)[i].cast<MoveInstruction>()->setPosition(temp.col(static_cast<long>(i) + 1));
       }
       else
       {
         throw std::runtime_error("Unsupported Plan Instruction Type!");
       }
-
-      first_plan_instruction_found = true;
     }
   }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -118,25 +118,62 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
 
   // Flatten the results to make them easier to process
   response.results = request.seed;
-  std::vector<std::reference_wrapper<Instruction>> results_flattened =
-      flattenToPattern(response.results, request.instructions);
-  std::vector<std::reference_wrapper<const Instruction>> instructions_flattened = flatten(request.instructions);
+  auto results_flattened = flattenToPattern(response.results, request.instructions);
+  auto instructions_flattened = flatten(request.instructions);
 
   // Loop over the flattened results and add them to response if the input was a plan instruction
   Eigen::Index dof = problem->manip_fwd_kin->numJoints();
   Eigen::Index result_index = 0;
-  for (auto& instruction : results_flattened)
+  bool first_plan_instruction_found = false;
+  for (std::size_t plan_index = 0; plan_index < results_flattened.size(); plan_index++)
   {
-    if (isPlanInstruction(instruction.get()))
+    if (isPlanInstruction(instructions_flattened.at(plan_index).get()))
     {
-      // This instruction corresponds to a composite. Set all results in that composite to the results
-      auto* move_instructions = instruction.get().cast<CompositeInstruction>();
-      for (auto& instruction : *move_instructions)
+      const auto* plan_instruction = instructions_flattened.at(plan_index).get().cast_const<PlanInstruction>();
+
+      if (plan_instruction->isLinear())
       {
-        Eigen::Map<Eigen::Matrix<FloatType, -1, 1>> temp(solution.data() + dof * result_index, dof);
-        instruction.cast<MoveInstruction>()->setPosition(temp.template cast<double>());
-        result_index++;
+        // This instruction corresponds to a composite. Set all results in that composite to the results
+        auto* move_instructions = results_flattened[plan_index].get().cast<CompositeInstruction>();
+        for (auto& instruction : *move_instructions)
+        {
+          Eigen::Map<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>> temp(solution.data() + dof * result_index++, dof);
+          instruction.cast<MoveInstruction>()->setPosition(temp.template cast<double>());
+        }
       }
+      else if (plan_instruction->isFreespace())
+      {
+        // Because descartes does not support freespace it just includes the plan instruction waypoint so we will
+        // fill out the results with a joint interpolated trajectory.
+        Eigen::Map<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>> start(solution.data() + dof * result_index, dof);
+        Eigen::Map<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>> stop(solution.data() + dof * result_index++, dof);
+
+        // This instruction corresponds to a composite. Set all results in that composite to the results
+        auto* move_instructions = results_flattened[plan_index].get().cast<CompositeInstruction>();
+
+        if (!first_plan_instruction_found)
+        {
+          Eigen::MatrixXd temp = interpolate(start.template cast<double>(), stop.template cast<double>(), static_cast<int>(move_instructions->size()) - 1);
+
+          assert(temp.cols() == static_cast<long>(move_instructions->size()));
+          for (std::size_t i = 0; i < move_instructions->size(); ++i)
+            (*move_instructions)[i].cast<MoveInstruction>()->setPosition(temp.col(static_cast<long>(i)));
+        }
+        else
+        {
+          Eigen::MatrixXd temp = interpolate(start.template cast<double>(), stop.template cast<double>(), static_cast<int>(move_instructions->size()));
+
+          assert(temp.cols() == static_cast<long>(move_instructions->size()) + 1);
+          for (std::size_t i = 0; i < move_instructions->size(); ++i)
+            (*move_instructions)[i].cast<MoveInstruction>()->setPosition(temp.col(static_cast<long>(i) + 1));
+        }
+      }
+      else
+      {
+        throw std::runtime_error("Unsupported Plan Instruction Type!");
+      }
+
+      first_plan_instruction_found = true;
     }
   }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
@@ -87,7 +87,6 @@ public:
 
   void clear() override;
 
-  bool checkUserInput(const PlannerRequest& request) const;
 
 protected:
   /** @brief The planners status codes */
@@ -98,6 +97,8 @@ protected:
 
   /** @brief The continuous contact manager */
   tesseract_collision::ContinuousContactManager::Ptr continuous_contact_manager_;
+
+  bool checkUserInput(const PlannerRequest& request) const;
 };
 
 }  // namespace tesseract_planning


### PR DESCRIPTION
I also renamed the interpolate function that handled waypoints version because I was getting issues with clang-tidy.