### PR TITLE
Add simple process manager and planner profile remapping

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/types.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/types.h
@@ -33,9 +33,18 @@
 
 namespace tesseract_planning
 {
+/**
+ * This used to store planner specific profile mapping with the request
+ *
+ * For example say you have a profile named Raster in your command language. Say you have multiple Raster profiles
+ * for descartes {Raster, Raster1, Rester2}. This allows you to remap the meaning of Raster in the command language to
+ * say Raster2 for the specific planner Descartes by Map<Descartes, Map<Raster, Raster1>>.
+ */
+using PlannerProfileRemapping = std::unordered_map<std::string, std::unordered_map<std::string, std::string>>;
+
 struct PlannerRequest
 {
-  std::string name;                                    /**< @brief The name of the planner to use */
+  std::string name;                                    /**< @brief The name of the process manager to use */
   tesseract::Tesseract::ConstPtr tesseract;            /**< @brief Tesseract */
   tesseract_environment::EnvState::ConstPtr env_state; /**< @brief The start state to use for planning */
 
@@ -49,6 +58,18 @@ struct PlannerRequest
    * CompositeInstruction of MoveInstructions.
    */
   CompositeInstruction seed;
+
+  /**
+   * @brief This allows the remapping of the Plan Profile identified in the command language to a specific profile for a
+   * given motion planner.
+   */
+  PlannerProfileRemapping plan_profile_remapping;
+
+  /**
+   * @brief This allows the remapping of the Composite Profile identified in the command language to a specific profile
+   * for a given motion planner.
+   */
+  PlannerProfileRemapping composite_profile_remapping;
 
   /**
    * @brief data Planner specific data. For planners included in Tesseract_planning this is the planner problem that

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
@@ -19,6 +19,12 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 template <typename FloatType>
+using DescartesProblemGeneratorFn =
+    std::function<std::shared_ptr<DescartesProblem<FloatType>>(const std::string&,
+                                                               const PlannerRequest&,
+                                                               const DescartesPlanProfileMap<FloatType>&)>;
+
+template <typename FloatType>
 class DescartesMotionPlanner : public MotionPlanner
 {
 public:
@@ -31,9 +37,7 @@ public:
   DescartesMotionPlanner(DescartesMotionPlanner&&) noexcept = default;
   DescartesMotionPlanner& operator=(DescartesMotionPlanner&&) noexcept = default;
 
-  std::function<std::shared_ptr<DescartesProblem<FloatType>>(const PlannerRequest&,
-                                                             const DescartesPlanProfileMap<FloatType>&)>
-      problem_generator;
+  DescartesProblemGeneratorFn<FloatType> problem_generator;
 
   /**
    * @brief The available plan profiles

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -77,7 +77,7 @@ tesseract_common::StatusCode DescartesMotionPlanner<FloatType>::solve(const Plan
           tesseract_common::StatusCode(DescartesMotionPlannerStatusCategory::ErrorInvalidInput, status_category_);
       return response.status;
     }
-    problem = problem_generator(request, plan_profiles);
+    problem = problem_generator(name_, request, plan_profiles);
     response.data = problem;
   }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
@@ -36,7 +36,9 @@ namespace tesseract_planning
 {
 template <typename FloatType>
 inline std::shared_ptr<DescartesProblem<FloatType>>
-DefaultDescartesProblemGenerator(const PlannerRequest& request, const DescartesPlanProfileMap<FloatType>& plan_profiles)
+DefaultDescartesProblemGenerator(const std::string& name,
+                                 const PlannerRequest& request,
+                                 const DescartesPlanProfileMap<FloatType>& plan_profiles)
 {
   auto prob = std::make_shared<DescartesProblem<FloatType>>();
 
@@ -124,6 +126,15 @@ DefaultDescartesProblemGenerator(const PlannerRequest& request, const DescartesP
   if (profile.empty())
     profile = "DEFAULT";
 
+  // Check for remapping of profile
+  auto remap = request.plan_profile_remapping.find(name);
+  if (remap != request.plan_profile_remapping.end())
+  {
+    auto p = remap->second.find(profile);
+    if (p != remap->second.end())
+      profile = p->second;
+  }
+
   typename DescartesPlanProfile<FloatType>::Ptr cur_plan_profile{ nullptr };
   auto it = plan_profiles.find(profile);
   if (it == plan_profiles.end())
@@ -175,6 +186,15 @@ DefaultDescartesProblemGenerator(const PlannerRequest& request, const DescartesP
       std::string profile = plan_instruction->getProfile();
       if (profile.empty())
         profile = "DEFAULT";
+
+      // Check for remapping of profile
+      auto remap = request.plan_profile_remapping.find(name);
+      if (remap != request.plan_profile_remapping.end())
+      {
+        auto p = remap->second.find(profile);
+        if (p != remap->second.end())
+          profile = p->second;
+      }
 
       typename DescartesPlanProfile<FloatType>::Ptr cur_plan_profile{ nullptr };
       auto it = plan_profiles.find(profile);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
@@ -40,6 +40,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
+using OMPLProblemGeneratorFn =
+    std::function<std::vector<OMPLProblem::Ptr>(const std::string&, const PlannerRequest&, const OMPLPlanProfileMap&)>;
 /**
  * @brief This planner is intended to provide an easy to use interface to OMPL for freespace planning. It is made to
  * take a start and end point and automate the generation of the OMPL problem.
@@ -50,7 +52,7 @@ public:
   /** @brief Construct a planner */
   OMPLMotionPlanner(std::string name = "OMPL");
 
-  std::function<std::vector<OMPLProblem::Ptr>(const PlannerRequest&, const OMPLPlanProfileMap&)> problem_generator;
+  OMPLProblemGeneratorFn problem_generator;
 
   /**
    * @brief The available plan profiles

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/problem_generators/default_problem_generator.h
@@ -36,7 +36,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const PlannerRequest& request,
+std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& name,
+                                                          const PlannerRequest& request,
                                                           const OMPLPlanProfileMap& plan_profiles);
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/problem_generators/default_problem_generator.h
@@ -39,7 +39,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const PlannerRequest& request,
+trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name,
+                                                         const PlannerRequest& request,
                                                          const TrajOptPlanProfileMap& plan_profiles,
                                                          const TrajOptCompositeProfileMap& composite_profiles);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
@@ -38,6 +38,11 @@ namespace tesseract_planning
 {
 class TrajOptMotionPlannerStatusCategory;
 
+using TrajOptProblemGeneratorFn = std::function<trajopt::TrajOptProb::Ptr(const std::string&,
+                                                                          const PlannerRequest&,
+                                                                          const TrajOptPlanProfileMap&,
+                                                                          const TrajOptCompositeProfileMap&)>;
+
 class TrajOptMotionPlanner : public MotionPlanner
 {
 public:
@@ -50,9 +55,7 @@ public:
   TrajOptMotionPlanner(TrajOptMotionPlanner&&) = default;
   TrajOptMotionPlanner& operator=(TrajOptMotionPlanner&&) = default;
 
-  std::function<
-      trajopt::TrajOptProb::Ptr(const PlannerRequest&, const TrajOptPlanProfileMap&, const TrajOptCompositeProfileMap&)>
-      problem_generator;
+  TrajOptProblemGeneratorFn problem_generator;
 
   /**
    * @brief The available composite profiles

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -117,7 +117,7 @@ tesseract_common::StatusCode OMPLMotionPlanner::solve(const PlannerRequest& requ
           tesseract_common::StatusCode(OMPLMotionPlannerStatusCategory::ErrorInvalidInput, status_category_);
       return response.status;
     }
-    problem = problem_generator(request, plan_profiles);
+    problem = problem_generator(name_, request, plan_profiles);
     response.data = std::make_shared<std::vector<OMPLProblem::Ptr>>(problem);
   }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
@@ -50,7 +50,8 @@ OMPLProblem::Ptr CreateOMPLSubProblem(const PlannerRequest& request,
   return sub_prob;
 }
 
-std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const PlannerRequest& request,
+std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& name,
+                                                          const PlannerRequest& request,
                                                           const OMPLPlanProfileMap& plan_profiles)
 {
   std::vector<OMPLProblem::Ptr> problem;
@@ -148,6 +149,15 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const PlannerRequest& 
       std::string profile = plan_instruction->getProfile();
       if (profile.empty())
         profile = "DEFAULT";
+
+      // Check for remapping of profile
+      auto remap = request.plan_profile_remapping.find(name);
+      if (remap != request.plan_profile_remapping.end())
+      {
+        auto p = remap->second.find(profile);
+        if (p != remap->second.end())
+          profile = p->second;
+      }
 
       typename OMPLPlanProfile::Ptr cur_plan_profile{ nullptr };
       auto it = plan_profiles.find(profile);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -207,6 +207,15 @@ CompositeInstruction SimpleMotionPlanner::processCompositeInstruction(const Comp
       if (profile.empty())
         profile = "DEFAULT";
 
+      // Check for remapping of profile
+      auto remap = request.plan_profile_remapping.find(name_);
+      if (remap != request.plan_profile_remapping.end())
+      {
+        auto p = remap->second.find(profile);
+        if (p != remap->second.end())
+          profile = p->second;
+      }
+
       SimplePlannerPlanProfile::Ptr start_plan_profile{ nullptr };
       auto it = plan_profiles.find(profile);
       if (it == plan_profiles.end())

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
@@ -30,7 +30,8 @@
 namespace tesseract_planning
 {
 /// @todo: Restructure this into several smaller functions that are testable and easier to understand
-trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const PlannerRequest& request,
+trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name,
+                                                         const PlannerRequest& request,
                                                          const TrajOptPlanProfileMap& plan_profiles,
                                                          const TrajOptCompositeProfileMap& composite_profiles)
 {
@@ -107,6 +108,15 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const PlannerRequest& r
   if (profile.empty())
     profile = "DEFAULT";
 
+  // Check for remapping of profile
+  auto remap = request.plan_profile_remapping.find(name);
+  if (remap != request.plan_profile_remapping.end())
+  {
+    auto p = remap->second.find(profile);
+    if (p != remap->second.end())
+      profile = p->second;
+  }
+
   TrajOptPlanProfile::Ptr start_plan_profile{ nullptr };
   auto it = plan_profiles.find(profile);
   if (it == plan_profiles.end())
@@ -164,6 +174,15 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const PlannerRequest& r
       std::string profile = plan_instruction->getProfile();
       if (profile.empty())
         profile = "DEFAULT";
+
+      // Check for remapping of profile
+      auto remap = request.plan_profile_remapping.find(name);
+      if (remap != request.plan_profile_remapping.end())
+      {
+        auto p = remap->second.find(profile);
+        if (p != remap->second.end())
+          profile = p->second;
+      }
 
       TrajOptPlanProfile::Ptr cur_plan_profile{ nullptr };
       auto it = plan_profiles.find(profile);
@@ -371,6 +390,15 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const PlannerRequest& r
   profile = request.instructions.getProfile();
   if (profile.empty())
     profile = "DEFAULT";
+
+  // Check for remapping of profile
+  remap = request.composite_profile_remapping.find(name);
+  if (remap != request.composite_profile_remapping.end())
+  {
+    auto p = remap->second.find(profile);
+    if (p != remap->second.end())
+      profile = p->second;
+  }
 
   TrajOptCompositeProfile::Ptr cur_composite_profile{ nullptr };
   auto it_composite = composite_profiles.find(profile);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -112,7 +112,7 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(const PlannerRequest& r
           tesseract_common::StatusCode(TrajOptMotionPlannerStatusCategory::ErrorInvalidInput, status_category_);
       return response.status;
     }
-    problem = problem_generator(request, plan_profiles, composite_profiles);
+    problem = problem_generator(name_, request, plan_profiles, composite_profiles);
     response.data = problem;
   }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_planner_tests.cpp
@@ -160,7 +160,8 @@ TEST_F(TesseractPlanningDescartesUnit, DescartesPlannerFixedPoses)  // NOLINT
   {
     // Test the problem generator
     {
-      auto problem = DefaultDescartesProblemGenerator<double>(request, single_descartes_planner.plan_profiles);
+      auto problem = DefaultDescartesProblemGenerator<double>(
+          single_descartes_planner.getName(), request, single_descartes_planner.plan_profiles);
       EXPECT_EQ(problem->samplers.size(), 11);
       EXPECT_EQ(problem->timing_constraints.size(), 11);
       EXPECT_EQ(problem->edge_evaluators.size(), 10);
@@ -271,7 +272,8 @@ TEST_F(TesseractPlanningDescartesUnit, DescartesPlannerAxialSymetric)  // NOLINT
   request.tesseract = tesseract_ptr_;
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
-  auto problem = DefaultDescartesProblemGenerator<double>(request, single_descartes_planner.plan_profiles);
+  auto problem = DefaultDescartesProblemGenerator<double>(
+      single_descartes_planner.getName(), request, single_descartes_planner.plan_profiles);
   problem->num_threads = 1;
   EXPECT_EQ(problem->samplers.size(), 11);
   EXPECT_EQ(problem->timing_constraints.size(), 11);
@@ -379,7 +381,8 @@ TEST_F(TesseractPlanningDescartesUnit, DescartesPlannerCollisionEdgeEvaluator)  
   single_descartes_planner.plan_profiles["TEST_PROFILE"] = plan_profile;
 
   // Test Problem size - TODO: Make dedicated unit test for DefaultDescartesProblemGenerator
-  auto problem = DefaultDescartesProblemGenerator<double>(request, single_descartes_planner.plan_profiles);
+  auto problem = DefaultDescartesProblemGenerator<double>(
+      single_descartes_planner.getName(), request, single_descartes_planner.plan_profiles);
   EXPECT_EQ(problem->samplers.size(), 3);
   EXPECT_EQ(problem->timing_constraints.size(), 3);
   EXPECT_EQ(problem->edge_evaluators.size(), 2);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
@@ -185,8 +185,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptPlannerBooleanFlagsJointJoint)  // N
     composite_profile->smooth_jerks = t3;
     composite_profile->collision_constraint_config.enabled = t4;
     composite_profile->collision_cost_config.enabled = t4;
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointVelEqCost>(problem->getCosts())), t1);
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointAccEqCost>(problem->getCosts())), t2);
@@ -244,8 +244,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointJoint)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -257,8 +257,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointJoint)  // NOLINT
   }
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -319,8 +319,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointCart)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -333,8 +333,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointCart)  // NOLINT
 
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -399,8 +399,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartJoint)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -413,8 +413,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartJoint)  // NOLINT
 
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -479,8 +479,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartCart)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -492,8 +492,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartCart)  // NOLINT
   }
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem =
-        DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -574,7 +574,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptPlannerBooleanFlagsCartCart)  // NOL
     composite_profile->collision_constraint_config.enabled = t4;
     composite_profile->collision_cost_config.enabled = t4;
 
-    problem = DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+    problem = DefaultTrajoptProblemGenerator(
+        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointVelEqCost>(problem->getCosts())), t1);
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointAccEqCost>(problem->getCosts())), t2);
@@ -645,8 +646,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayJointConstraint)  // NOLINT
   request.tesseract = tesseract_ptr_;
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
-  trajopt::TrajOptProb::Ptr problem =
-      DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+  trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+      test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
 
   EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
       problem->getConstraints())));
@@ -713,8 +714,8 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayJointCost)  // NOLINT
   request.tesseract = tesseract_ptr_;
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
-  trajopt::TrajOptProb::Ptr problem =
-      DefaultTrajoptProblemGenerator(request, test_planner.plan_profiles, test_planner.composite_profiles);
+  trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
+      test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
   EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
       problem->getConstraints())));
   EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::TrajOptConstraintFromErrFunc>(

--- a/tesseract/tesseract_planning/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract/tesseract_planning/tesseract_process_managers/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${PROJECT_NAME} SHARED
     src/process_generators/iterative_spline_parameterization_process_generator.cpp
     src/process_managers/freespace_process_manager.cpp
     src/process_managers/raster_process_manager.cpp
+    src/process_managers/simple_process_manager.cpp
     src/taskflow_generators/sequential_taskflow.cpp
     src/taskflow_generators/graph_taskflow.cpp)
 target_link_libraries(${PROJECT_NAME} PUBLIC

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/examples/raster_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/examples/raster_example_program.h
@@ -18,54 +18,87 @@ inline CompositeInstruction rasterExampleProgram()
   PlanInstruction start_instruction(swp1, PlanInstructionType::START);
   program.setStartInstruction(start_instruction);
 
-  // Define raster poses
-  Waypoint wp2 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.2, 0.8) *
-                                   Eigen::Quaterniond(0, 0, -1.0, 0));
-  Waypoint wp3 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.1, 0.8) *
-                                   Eigen::Quaterniond(0, 0, -1.0, 0));
-  Waypoint wp4 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.0, 0.8) *
-                                   Eigen::Quaterniond(0, 0, -1.0, 0));
-  Waypoint wp5 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.1, 0.8) *
-                                   Eigen::Quaterniond(0, 0, -1.0, 0));
-  Waypoint wp6 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.2, 0.8) *
-                                   Eigen::Quaterniond(0, 0, -1.0, 0));
-  Waypoint wp7 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.3, 0.8) *
+  Waypoint wp1 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.3, 0.8) *
                                    Eigen::Quaterniond(0, 0, -1.0, 0));
 
-  // Define raster move instruction
-  PlanInstruction plan_c1(wp3, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c2(wp4, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c3(wp5, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c4(wp6, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c5(wp7, PlanInstructionType::LINEAR, "RASTER");
-
-  PlanInstruction plan_f0(wp2, PlanInstructionType::FREESPACE, "freespace_profile");
+  // Define from start composite instruction
+  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
   plan_f0.setDescription("from_start_plan");
   CompositeInstruction from_start;
   from_start.setDescription("from_start");
   from_start.push_back(plan_f0);
   program.push_back(from_start);
 
+  //
+  for (int i = 0; i < 4; ++i)
   {
-    CompositeInstruction raster_segment;
-    raster_segment.setDescription("raster_segment");
-    raster_segment.push_back(plan_c1);
-    raster_segment.push_back(plan_c2);
-    raster_segment.push_back(plan_c3);
-    raster_segment.push_back(plan_c4);
-    raster_segment.push_back(plan_c5);
-    program.push_back(raster_segment);
-  }
+    double x = 0.8 + (i * 0.1);
+    Waypoint wp1 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, -0.3, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
+    Waypoint wp2 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, -0.2, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
+    Waypoint wp3 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, -0.1, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
+    Waypoint wp4 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.0, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
+    Waypoint wp5 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.1, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
+    Waypoint wp6 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.2, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
+    Waypoint wp7 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.3, 0.8) *
+                                     Eigen::Quaterniond(0, 0, -1.0, 0));
 
-  {
-    PlanInstruction plan_f1(wp2, PlanInstructionType::FREESPACE, "freespace_profile");
-    plan_f1.setDescription("transition_from_end_plan");
+    CompositeInstruction raster_segment;
+    raster_segment.setDescription("Raster #" + std::to_string(i + 1));
+    if (i == 0 || i == 3)
+    {
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "RASTER"));
+    }
+    else
+    {
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "RASTER"));
+    }
+    program.push_back(raster_segment);
+
+    // Add transition
+    Instruction tranisiton_instruction = NullInstruction();
+    if (i == 0)
+    {
+      Waypoint wp7 =
+          CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), 0.3, 0.8) *
+                            Eigen::Quaterniond(0, 0, -1.0, 0));
+
+      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, "freespace_profile");
+      plan_f1.setDescription("transition_from_end_plan");
+      tranisiton_instruction = plan_f1;
+    }
+    else if (i == 1)
+    {
+      Waypoint wp1 =
+          CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), -0.3, 0.8) *
+                            Eigen::Quaterniond(0, 0, -1.0, 0));
+
+      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+      plan_f1.setDescription("transition_from_end_plan");
+      tranisiton_instruction = plan_f1;
+    }
     CompositeInstruction transition_from_end;
     transition_from_end.setDescription("transition_from_end");
-    transition_from_end.push_back(plan_f1);
+    transition_from_end.push_back(tranisiton_instruction);
+
     CompositeInstruction transition_from_start;
     transition_from_start.setDescription("transition_from_start");
-    transition_from_start.push_back(plan_f1);
+    transition_from_start.push_back(tranisiton_instruction);
 
     CompositeInstruction transitions("DEFAULT", CompositeInstructionOrder::UNORDERED);
     transitions.setDescription("transitions");
@@ -74,46 +107,7 @@ inline CompositeInstruction rasterExampleProgram()
     program.push_back(transitions);
   }
 
-  {
-    CompositeInstruction raster_segment;
-    raster_segment.setDescription("raster_segment");
-    raster_segment.push_back(plan_c1);
-    raster_segment.push_back(plan_c2);
-    raster_segment.push_back(plan_c3);
-    raster_segment.push_back(plan_c4);
-    raster_segment.push_back(plan_c5);
-    program.push_back(raster_segment);
-  }
-
-  {
-    PlanInstruction plan_f1(wp2, PlanInstructionType::FREESPACE, "freespace_profile");
-    plan_f1.setDescription("transition_from_end_plan");
-    CompositeInstruction transition_from_end;
-    transition_from_end.setDescription("transition_from_end");
-    transition_from_end.push_back(plan_f1);
-    CompositeInstruction transition_from_start;
-    transition_from_start.setDescription("transition_from_start");
-    transition_from_start.push_back(plan_f1);
-
-    CompositeInstruction transitions("DEFAULT", CompositeInstructionOrder::UNORDERED);
-    transitions.setDescription("transitions");
-    transitions.push_back(transition_from_start);
-    transitions.push_back(transition_from_end);
-    program.push_back(transitions);
-  }
-
-  {
-    CompositeInstruction raster_segment;
-    raster_segment.setDescription("raster_segment");
-    raster_segment.push_back(plan_c1);
-    raster_segment.push_back(plan_c2);
-    raster_segment.push_back(plan_c3);
-    raster_segment.push_back(plan_c4);
-    raster_segment.push_back(plan_c5);
-    program.push_back(raster_segment);
-  }
-
-  PlanInstruction plan_f2(wp2, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, "freespace_profile");
   plan_f2.setDescription("to_end_plan");
   CompositeInstruction to_end;
   to_end.setDescription("to_end");

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_input.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_input.h
@@ -32,6 +32,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tesseract_command_language/command_language.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_motion_planners/core/types.h>
+
 namespace tesseract_planning
 {
 /**
@@ -49,6 +51,21 @@ struct ProcessInput
                const Instruction* instruction,
                const ManipulatorInfo& manip_info,
                Instruction* seed);
+
+  ProcessInput(tesseract::Tesseract::ConstPtr tesseract,
+               const Instruction* instruction,
+               const ManipulatorInfo& manip_info,
+               const PlannerProfileRemapping& plan_profile_remapping,
+               const PlannerProfileRemapping& composite_profile_remapping,
+               Instruction* seed);
+
+  ProcessInput(tesseract::Tesseract::ConstPtr tesseract,
+               const Instruction* instruction,
+               const PlannerProfileRemapping& plan_profile_remapping,
+               const PlannerProfileRemapping& composite_profile_remapping,
+               Instruction* seed);
+
+  ProcessInput(tesseract::Tesseract::ConstPtr tesseract, const Instruction* instruction, Instruction* seed);
 
   /**
    * @brief Creates a sub-ProcessInput from instruction[index] and seed[index]
@@ -72,6 +89,18 @@ struct ProcessInput
 
   /** @brief Global Manipulator Information */
   const ManipulatorInfo& manip_info;
+
+  /**
+   * @brief This allows the remapping of the Plan Profile identified in the command language to a specific profile for a
+   * given motion planner.
+   */
+  const PlannerProfileRemapping& plan_profile_remapping;
+
+  /**
+   * @brief This allows the remapping of the Composite Profile identified in the command language to a specific profile
+   * for a given motion planner.
+   */
+  const PlannerProfileRemapping& composite_profile_remapping;
 
   /** @brief Results/Seed for this process */
   Instruction* results;

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_managers/simple_process_manager.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_managers/simple_process_manager.h
@@ -1,0 +1,88 @@
+/**
+ * @file simple_process_manager.h
+ * @brief Plans simple paths aka. a single composite containing no composite instruction.
+ *
+ * @author Matthew Powelson
+ * @date July 15. 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_PROCESS_MANAGER_SIMPLE_PROCESS_MANAGER_H
+#define TESSERACT_PROCESS_MANAGER_SIMPLE_PROCESS_MANAGER_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <functional>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_process_managers/process_manager.h>
+#include <tesseract_process_managers/process_input.h>
+#include <tesseract_process_managers/process_generator.h>
+#include <tesseract_process_managers/taskflow_generators/sequential_taskflow.h>
+
+namespace tesseract_planning
+{
+/**
+ * @brief This class provides a process manager for a simple process.
+ *
+ * Given a ProcessInput in the correct format, it handles the creation of the process dependencies and uses Taskflow to
+ * execute them efficiently in a parallel based on those dependencies.
+ *
+ * The required format is below.
+ *
+ * Composite
+ * {
+ *   ... Must not contain any child composite instructions
+ * }
+ */
+class SimpleProcessManager : public ProcessManager
+{
+public:
+  using Ptr = std::shared_ptr<SimpleProcessManager>;
+  using ConstPtr = std::shared_ptr<const SimpleProcessManager>;
+
+  SimpleProcessManager(TaskflowGenerator::UPtr taskflow_generator, std::size_t n = std::thread::hardware_concurrency());
+  ~SimpleProcessManager() override = default;
+  SimpleProcessManager(const SimpleProcessManager&) = delete;
+  SimpleProcessManager& operator=(const SimpleProcessManager&) = delete;
+  SimpleProcessManager(SimpleProcessManager&&) = delete;
+  SimpleProcessManager& operator=(SimpleProcessManager&&) = delete;
+
+  bool init(ProcessInput input) override;
+
+  bool execute() override;
+
+  bool terminate() override;
+
+  bool clear() override;
+
+private:
+  void successCallback();
+  void failureCallback();
+  bool success_;
+
+  TaskflowGenerator::UPtr taskflow_generator_;
+  tf::Executor executor_;
+  tf::Taskflow taskflow_;
+  std::vector<tf::Task> simple_tasks_;
+};
+
+}  // namespace tesseract_planning
+
+#endif

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/examples/freespace_manager_graph_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/examples/freespace_manager_graph_example.cpp
@@ -99,49 +99,26 @@ GraphTaskflow::UPtr createGraphTaskflow()
   /////////////////
   /// Add Edges ///
   /////////////////
-  graph->addEdge(interpolator_idx,
-                 GraphTaskflow::SourceChannel::ON_SUCCESS,
-                 ompl_idx,
-                 GraphTaskflow::DestinationChannel::PROCESS_NODE);
+  auto ON_SUCCESS = GraphTaskflow::SourceChannel::ON_SUCCESS;
+  auto ON_FAILURE = GraphTaskflow::SourceChannel::ON_FAILURE;
+  auto PROCESS_NODE = GraphTaskflow::DestinationChannel::PROCESS_NODE;
+  auto ERROR_CALLBACK = GraphTaskflow::DestinationChannel::ERROR_CALLBACK;
+  auto DONE_CALLBACK = GraphTaskflow::DestinationChannel::DONE_CALLBACK;
 
-  graph->addEdge(interpolator_idx,
-                 GraphTaskflow::SourceChannel::ON_FAILURE,
-                 -1,
-                 GraphTaskflow::DestinationChannel::ERROR_CALLBACK);
+  graph->addEdge(interpolator_idx, ON_SUCCESS, ompl_idx, PROCESS_NODE);
+  graph->addEdge(interpolator_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
-  graph->addEdge(
-      ompl_idx, GraphTaskflow::SourceChannel::ON_SUCCESS, trajopt_idx, GraphTaskflow::DestinationChannel::PROCESS_NODE);
+  graph->addEdge(ompl_idx, ON_SUCCESS, trajopt_idx, PROCESS_NODE);
+  graph->addEdge(ompl_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
-  graph->addEdge(
-      ompl_idx, GraphTaskflow::SourceChannel::ON_FAILURE, -1, GraphTaskflow::DestinationChannel::ERROR_CALLBACK);
+  graph->addEdge(trajopt_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
+  graph->addEdge(trajopt_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
-  graph->addEdge(trajopt_idx,
-                 GraphTaskflow::SourceChannel::ON_SUCCESS,
-                 contact_check_idx,
-                 GraphTaskflow::DestinationChannel::PROCESS_NODE);
+  graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+  graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
-  graph->addEdge(
-      trajopt_idx, GraphTaskflow::SourceChannel::ON_FAILURE, -1, GraphTaskflow::DestinationChannel::ERROR_CALLBACK);
-
-  graph->addEdge(contact_check_idx,
-                 GraphTaskflow::SourceChannel::ON_SUCCESS,
-                 time_parameterization_idx,
-                 GraphTaskflow::DestinationChannel::PROCESS_NODE);
-
-  graph->addEdge(contact_check_idx,
-                 GraphTaskflow::SourceChannel::ON_FAILURE,
-                 -1,
-                 GraphTaskflow::DestinationChannel::ERROR_CALLBACK);
-
-  graph->addEdge(time_parameterization_idx,
-                 GraphTaskflow::SourceChannel::ON_SUCCESS,
-                 -1,
-                 GraphTaskflow::DestinationChannel::DONE_CALLBACK);
-
-  graph->addEdge(time_parameterization_idx,
-                 GraphTaskflow::SourceChannel::ON_FAILURE,
-                 -1,
-                 GraphTaskflow::DestinationChannel::ERROR_CALLBACK);
+  graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+  graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
   return graph;
 }

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/motion_planner_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/motion_planner_process_generator.cpp
@@ -118,6 +118,8 @@ int MotionPlannerProcessGenerator::conditionalProcess(ProcessInput input) const
   request.env_state = input.tesseract->getEnvironmentConst()->getCurrentState();
   request.tesseract = input.tesseract;
   request.instructions = instructions;
+  request.plan_profile_remapping = input.plan_profile_remapping;
+  request.composite_profile_remapping = input.composite_profile_remapping;
 
   // --------------------
   // Fill out response

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_input.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_input.cpp
@@ -38,11 +38,58 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
+static const ManipulatorInfo EMPTY_MANIPULATOR_INFO;
+static const PlannerProfileRemapping EMPTY_PROFILE_MAPPING;
+
 ProcessInput::ProcessInput(tesseract::Tesseract::ConstPtr tesseract,
                            const Instruction* instruction,
                            const ManipulatorInfo& manip_info,
                            Instruction* seed)
-  : tesseract(std::move(tesseract)), instruction(instruction), manip_info(manip_info), results(seed)
+  : tesseract(std::move(tesseract))
+  , instruction(instruction)
+  , manip_info(manip_info)
+  , plan_profile_remapping(EMPTY_PROFILE_MAPPING)
+  , composite_profile_remapping(EMPTY_PROFILE_MAPPING)
+  , results(seed)
+{
+}
+
+ProcessInput::ProcessInput(tesseract::Tesseract::ConstPtr tesseract,
+                           const Instruction* instruction,
+                           const ManipulatorInfo& manip_info,
+                           const PlannerProfileRemapping& plan_profile_remapping,
+                           const PlannerProfileRemapping& composite_profile_remapping,
+                           Instruction* seed)
+  : tesseract(std::move(tesseract))
+  , instruction(instruction)
+  , manip_info(manip_info)
+  , plan_profile_remapping(plan_profile_remapping)
+  , composite_profile_remapping(composite_profile_remapping)
+  , results(seed)
+{
+}
+
+ProcessInput::ProcessInput(tesseract::Tesseract::ConstPtr tesseract,
+                           const Instruction* instruction,
+                           const PlannerProfileRemapping& plan_profile_remapping,
+                           const PlannerProfileRemapping& composite_profile_remapping,
+                           Instruction* seed)
+  : tesseract(std::move(tesseract))
+  , instruction(instruction)
+  , manip_info(EMPTY_MANIPULATOR_INFO)
+  , plan_profile_remapping(plan_profile_remapping)
+  , composite_profile_remapping(composite_profile_remapping)
+  , results(seed)
+{
+}
+
+ProcessInput::ProcessInput(tesseract::Tesseract::ConstPtr tesseract, const Instruction* instruction, Instruction* seed)
+  : tesseract(std::move(tesseract))
+  , instruction(instruction)
+  , manip_info(EMPTY_MANIPULATOR_INFO)
+  , plan_profile_remapping(EMPTY_PROFILE_MAPPING)
+  , composite_profile_remapping(EMPTY_PROFILE_MAPPING)
+  , results(seed)
 {
 }
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_managers/simple_process_manager.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_managers/simple_process_manager.cpp
@@ -1,0 +1,89 @@
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <functional>
+#include <taskflow/taskflow.hpp>
+#include <fstream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_process_managers/process_managers/simple_process_manager.h>
+
+using namespace tesseract_planning;
+
+SimpleProcessManager::SimpleProcessManager(TaskflowGenerator::UPtr taskflow_generator, std::size_t n)
+  : taskflow_generator_(std::move(taskflow_generator)), executor_(n), taskflow_("SimpleProcessManagerTaskflow")
+{
+}
+
+bool SimpleProcessManager::init(ProcessInput input)
+{
+  // Clear the process manager
+  clear();
+
+  // Check the overall input
+  if (!isCompositeInstruction(*(input.instruction)))
+  {
+    CONSOLE_BRIDGE_logError("ProcessInput Invalid: input.instructions should be a composite");
+    return false;
+  }
+  const auto* composite = input.instruction->cast_const<CompositeInstruction>();
+
+  // Check that it has a start instruction
+  if (!composite->hasStartInstruction() && input.start_instruction_ptr == nullptr &&
+      isNullInstruction(input.start_instruction))
+  {
+    CONSOLE_BRIDGE_logError("ProcessInput Invalid: input.instructions should have a start instruction");
+    return false;
+  }
+
+  // Create the dependency graph
+  input.instruction->print("Generating Taskflow for: ");
+  auto task = taskflow_
+                  .composed_of(taskflow_generator_->generateTaskflow(
+                      input, [this]() { successCallback(); }, [this]() { failureCallback(); }))
+                  .name("Simple");
+  simple_tasks_.push_back(task);
+
+  // Dump the taskflow
+  std::ofstream out_data;
+  out_data.open("/tmp/simple_process_manager.dot");
+  taskflow_.dump(out_data);
+  out_data.close();
+
+  return true;
+}
+
+bool SimpleProcessManager::execute()
+{
+  success_ = false;
+  executor_.run(taskflow_).wait();
+  return success_;
+}
+
+bool SimpleProcessManager::terminate()
+{
+  taskflow_generator_->abort();
+  CONSOLE_BRIDGE_logError("Terminating Taskflow");
+  return false;
+}
+
+bool SimpleProcessManager::clear()
+
+{
+  taskflow_generator_->clear();
+  taskflow_.clear();
+  simple_tasks_.clear();
+  return true;
+}
+
+void SimpleProcessManager::successCallback()
+{
+  CONSOLE_BRIDGE_logInform("SimpleProcessManager Successful");
+  success_ = true;
+}
+
+void SimpleProcessManager::failureCallback()
+{
+  CONSOLE_BRIDGE_logInform("SimpleProcessManager Failure");
+  success_ = false;
+}


### PR DESCRIPTION
This PR adds two things. The first is a simple process manager which is very similar to freespace process manager which maybe deprecated in the near future. This is currently be used in the planning server to support a simple freespace process manager and simple cartesian process manager.

The second adds the ability to provide profile mapping for specific planners. This way in the command language you can have one profile for say Cartesian, then in this mapping you could provide a planner mapping to a specific profile. For example you could map the Cartesian profile for Descartes to DescartesToolZFree45 which has 45 degree sampling and for TrajOpt you could map it to a more specific or not provide a mapping. 