### PR TITLE
Improve tesseract init and add reset function

### DIFF
--- a/tesseract/tesseract/include/tesseract/tesseract.h
+++ b/tesseract/tesseract/include/tesseract/tesseract.h
@@ -81,6 +81,9 @@ public:
    * @return A Ptr to the cloned Tesseract   */
   Tesseract::Ptr clone() const;
 
+  /** @brief reset to initialized state */
+  bool reset();
+
   const tesseract_scene_graph::SRDFModel::Ptr& getSRDFModel() const;
   const tesseract_scene_graph::SRDFModel::ConstPtr& getSRDFModelConst() const;
 

--- a/tesseract/tesseract/src/tesseract.cpp
+++ b/tesseract/tesseract/src/tesseract.cpp
@@ -50,7 +50,7 @@ bool Tesseract::init(tesseract_scene_graph::SceneGraph::Ptr scene_graph)
 {
   clear();
   init_info_->type = TesseractInitType::SCENE_GRAPH;
-  init_info_->scene_graph = scene_graph;
+  init_info_->scene_graph = scene_graph->clone();
 
   // Construct Environment from Scene Graph
   environment_ = std::make_shared<tesseract_environment::Environment>();
@@ -77,8 +77,8 @@ bool Tesseract::init(tesseract_scene_graph::SceneGraph::Ptr scene_graph,
 {
   clear();
   init_info_->type = TesseractInitType::SCENE_GRAPH_SRDF_MODEL;
-  init_info_->scene_graph = scene_graph;
-  init_info_->srdf_model = srdf_model;
+  init_info_->scene_graph = scene_graph->clone();
+  init_info_->srdf_model = std::make_shared<tesseract_scene_graph::SRDFModel>(*srdf_model);
 
   srdf_model_ = std::move(srdf_model);
   srdf_model_const_ = srdf_model_;
@@ -312,6 +312,8 @@ Tesseract::Ptr Tesseract::clone() const
 
   return clone;
 }
+
+bool Tesseract::reset() { return init(init_info_); }
 
 void Tesseract::setResourceLocator(tesseract_scene_graph::ResourceLocator::Ptr locator)
 {

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/continuous_contact_manager_factory.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/continuous_contact_manager_factory.h
@@ -43,10 +43,12 @@ public:
     if (it == continuous_types.end())
     {
       continuous_types[name] = std::move(create_function);
+      keys_.push_back(name);
       return true;
     }
     return false;
   }
+
   ContinuousContactManager::Ptr create(const std::string& name) const
   {
     auto it = continuous_types.find(name);
@@ -56,8 +58,11 @@ public:
     return nullptr;
   }
 
+  const std::vector<std::string>& getAvailableManagers() const { return keys_; }
+
 private:
   std::unordered_map<std::string, CreateMethod> continuous_types;
+  std::vector<std::string> keys_;
 };
 }  // namespace tesseract_collision
 

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/discrete_contact_manager_factory.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/discrete_contact_manager_factory.h
@@ -42,6 +42,7 @@ public:
     if (it == discrete_types.end())
     {
       discrete_types[name] = std::move(create_function);
+      keys_.push_back(name);
       return true;
     }
     return false;
@@ -56,8 +57,11 @@ public:
     return nullptr;
   }
 
+  const std::vector<std::string>& getAvailableManagers() const { return keys_; }
+
 private:
   std::unordered_map<std::string, CreateMethod> discrete_types;
+  std::vector<std::string> keys_;
 };
 }  // namespace tesseract_collision
 #endif  // TESSERACT_COLLISION_DISCRETE_CONTACT_MANAGER_FACTORY_H

--- a/tesseract/tesseract_environment/src/core/environment.cpp
+++ b/tesseract/tesseract_environment/src/core/environment.cpp
@@ -512,7 +512,12 @@ bool Environment::setActiveDiscreteContactManager(const std::string& name)
   tesseract_collision::DiscreteContactManager::Ptr manager = getDiscreteContactManagerHelper(name);
   if (manager == nullptr)
   {
-    CONSOLE_BRIDGE_logError("Discrete manager with %s does not exist in factory!", name.c_str());
+    std::string msg = "\n  Discrete manager with " + name + " does not exist in factory!\n";
+    msg += "    Available Managers:\n";
+    for (const auto& m : discrete_factory_.getAvailableManagers())
+      msg += "      " + m + "\n";
+
+    CONSOLE_BRIDGE_logError(msg.c_str());
     return false;
   }
 
@@ -545,7 +550,12 @@ bool Environment::setActiveContinuousContactManager(const std::string& name)
 
   if (manager == nullptr)
   {
-    CONSOLE_BRIDGE_logError("Continuous manager with %s does not exist in factory!", name.c_str());
+    std::string msg = "\n  Continuous manager with " + name + " does not exist in factory!\n";
+    msg += "    Available Managers:\n";
+    for (const auto& m : continuous_factory_.getAvailableManagers())
+      msg += "      " + m + "\n";
+
+    CONSOLE_BRIDGE_logError(msg.c_str());
     return false;
   }
 

--- a/tesseract/tesseract_scene_graph/src/graph.cpp
+++ b/tesseract/tesseract_scene_graph/src/graph.cpp
@@ -585,13 +585,6 @@ SceneGraph::Path SceneGraph::getShortestPath(const std::string& root, const std:
   return Path(links, joints);
 }
 
-// static inline Graph copyGraph(const Graph& graph)
-//{
-//  Graph new_graph;
-//  boost::copy_graph(graph, new_graph);
-//  return new_graph;
-//}
-
 SceneGraph::Vertex SceneGraph::getVertex(const std::string& name) const
 {
   auto found = link_map_.find(name);

--- a/tesseract/tesseract_visualization/CMakeLists.txt
+++ b/tesseract/tesseract_visualization/CMakeLists.txt
@@ -9,9 +9,28 @@ find_package(tesseract REQUIRED)
 find_package(tesseract_command_language REQUIRED)
 find_package(class_loader REQUIRED)
 
+# Optional to build ignition visualization
+find_package(ignition-common3 COMPONENTS profiler events av QUIET)
+find_package(ignition-transport8 QUIET)
+find_package(ignition-msgs5 QUIET)
+
+set(IGNITION_FOUND FALSE)
+if (ignition-common3_FOUND AND ignition-transport8_FOUND AND ignition-msgs5_FOUND)
+  set(IGNITION_FOUND TRUE)
+  message(STATUS "Ignition Visualization Library will be built!")
+endif()
+
 set(COVERAGE_EXCLUDE /usr/* /opt/* ${CMAKE_CURRENT_LIST_DIR}/test/* /*/gtest/*)
 
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE})
+
+#####################################
+# Define compile-time default variables
+if(MSVC)
+  set(TESSERACT_VISUALIZATION_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
+else()
+  set(TESSERACT_VISUALIZATION_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+endif()
 
 add_library(${PROJECT_NAME} SHARED
     src/visualization_loader.cpp
@@ -21,8 +40,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC tesseract::tesseract tesseract::tes
 tesseract_target_compile_options(${PROJECT_NAME} PUBLIC)
 tesseract_clang_tidy(${PROJECT_NAME})
 tesseract_code_coverage(${PROJECT_NAME} ALL EXCLUDE ${COVERAGE_EXCLUDE})
+target_compile_definitions(${PROJECT_NAME} PRIVATE TESSERACT_VISUALIZATION_PLUGIN_PATH="${TESSERACT_VISUALIZATION_PLUGIN_PATH}")
 if(class_loader_VERSION VERSION_LESS "0.4.0")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE CLASS_LOADER_LESS_0_4_0=ON)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE CLASS_LOADER_NOT_SUPPORTED=ON)
+elseif(class_loader_VERSION VERSION_LESS "1.2.0")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE CLASS_LOADER_SHARED_INSTANCE=ON)
+else()
+  target_compile_definitions(${PROJECT_NAME} PRIVATE CLASS_LOADER_INSTANCE=ON)
 endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -31,7 +55,55 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIRS}
     ${class_loader_INCLUDE_DIRS})
 
-tesseract_configure_package(${PROJECT_NAME})
+list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME})
+if (IGNITION_FOUND)
+  add_library(${PROJECT_NAME}_ignition SHARED
+      src/ignition/entity_manager.cpp
+      src/ignition/conversions.cpp)
+  target_link_libraries(${PROJECT_NAME}_ignition PUBLIC
+    tesseract::tesseract_scene_graph
+    tesseract::tesseract_common
+    ${IGNITION-COMMON_LIBRARIES}
+    ${IGNITION-MSGS_LIBRARIES}
+    console_bridge)
+  tesseract_target_compile_options(${PROJECT_NAME}_ignition PUBLIC)
+  tesseract_clang_tidy(${PROJECT_NAME}_ignition)
+  tesseract_code_coverage(${PROJECT_NAME}_ignition ALL EXCLUDE ${COVERAGE_EXCLUDE})
+  target_include_directories(${PROJECT_NAME}_ignition PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>")
+  target_include_directories(${PROJECT_NAME}_ignition SYSTEM PUBLIC
+    ${IGNITION-COMMON_INCLUDE_DIRS}
+    ${IGNITION-MSGS_INCLUDE_DIRS})
+
+  add_library(${PROJECT_NAME}_ignition_visualization SHARED
+      src/ignition/tesseract_ignition_visualization.cpp)
+  target_link_libraries(${PROJECT_NAME}_ignition_visualization PUBLIC
+    ${PROJECT_NAME}
+    ${PROJECT_NAME}_ignition
+    tesseract::tesseract_common
+    tesseract::tesseract_command_language
+    ${IGNITION-COMMON_LIBRARIES}
+    ${IGNITION-TRANSPORT_LIBRARIES}
+    ${IGNITION-MSGS_LIBRARIES}
+    console_bridge)
+  tesseract_target_compile_options(${PROJECT_NAME}_ignition_visualization PUBLIC)
+  tesseract_clang_tidy(${PROJECT_NAME}_ignition_visualization)
+  tesseract_code_coverage(${PROJECT_NAME}_ignition_visualization ALL EXCLUDE ${COVERAGE_EXCLUDE})
+  target_include_directories(${PROJECT_NAME}_ignition_visualization PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>")
+  target_include_directories(${PROJECT_NAME}_ignition_visualization SYSTEM PUBLIC
+    ${IGNITION-COMMON_INCLUDE_DIRS}
+    ${IGNITION-TRANSPORT_INCLUDE_DIRS}
+    ${IGNITION-MSGS_INCLUDE_DIRS})
+
+  list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME}_ignition ${PROJECT_NAME}_ignition_visualization)
+else()
+  message(WARNING "Ignition Visualization Library will not be built!")
+endif()
+
+tesseract_configure_package(${PACKAGE_LIBRARIES})
 
 # Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}

--- a/tesseract/tesseract_visualization/include/tesseract_visualization/ignition/conversions.h
+++ b/tesseract/tesseract_visualization/include/tesseract_visualization/ignition/conversions.h
@@ -1,0 +1,46 @@
+/**
+ * @file conversions.h
+ * @brief A set of conversion between Tesseract and Ignition Robotics objects
+ *
+ * @author Levi Armstrong
+ * @date May 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_VISUALIZATION_IGNITION_CONVERSIONS_H
+#define TESSERACT_VISUALIZATION_IGNITION_CONVERSIONS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ignition/msgs/scene.pb.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_visualization/ignition/entity_manager.h>
+#include <tesseract_scene_graph/graph.h>
+#include <tesseract_common/types.h>
+
+namespace tesseract_visualization
+{
+bool toMsg(ignition::msgs::Scene& scene_msg,
+           EntityManager& entity_manager,
+           const tesseract_scene_graph::SceneGraph& scene_graph,
+           const tesseract_common::TransformMap& link_transforms);
+}
+
+#endif  // TESSERACT_VISUALIZATION_IGNITION_CONVERSIONS_H

--- a/tesseract/tesseract_visualization/include/tesseract_visualization/ignition/entity_manager.h
+++ b/tesseract/tesseract_visualization/include/tesseract_visualization/ignition/entity_manager.h
@@ -1,0 +1,139 @@
+/**
+ * @file entity_manager.h
+ * @brief A entity manager for Tesseract components that get added to Ignition Scene
+ *
+ * @author Levi Armstrong
+ * @date May 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_VISUALIZATION_IGNITION_ENTITY_MANAGER_H
+#define TESSERACT_VISUALIZATION_IGNITION_ENTITY_MANAGER_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <string>
+#include <unordered_map>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_visualization
+{
+static const int NULL_ENTITY_ID = -1;
+using EntityID = int;
+using EntityMap = std::unordered_map<std::string, EntityID>;
+
+class EntityManager
+{
+public:
+  /**
+   * @brief Add model name to manager and return id for model
+   * @param name Name given to the model
+   * @return The Entity ID
+   */
+  EntityID addModel(const std::string& name);
+
+  /**
+   * @brief Given the model name return the ID
+   * @param name Name of the model
+   * @return The ID of the model (if < 1000 it was not found)
+   */
+  EntityID getModel(const std::string& name) const;
+
+  /**
+   * @brief Get all models being managed
+   * @return A map of names to entity id's
+   */
+  const EntityMap& getModels() const;
+
+  /**
+   * @brief Add link name to manager and return id for link
+   * @param name Name given to the link
+   * @return The Entity ID
+   */
+  EntityID addLink(const std::string& name);
+
+  /**
+   * @brief Given the link name return the ID
+   * @param name Name of the link
+   * @return The ID of the link (if < 1000 it was not found)
+   */
+  EntityID getLink(const std::string& name) const;
+
+  /**
+   * @brief Get all links being managed
+   * @return A map of names to entity id's
+   */
+  const EntityMap& getLinks() const;
+
+  /**
+   * @brief Add visual name to manager and return id for visual
+   * @param name Name given to the visual
+   * @return The Entity ID
+   */
+  EntityID addVisual(const std::string& name);
+
+  /**
+   * @brief Given the visual name return the ID
+   * @param name Name of the visual
+   * @return The ID of the visual (if < 1000 it was not found)
+   */
+  EntityID getVisual(const std::string& name) const;
+
+  /**
+   * @brief Get all visuals being managed
+   * @return A map of names to entity id's
+   */
+  const EntityMap& getVisuals() const;
+
+  /**
+   * @brief Add sensor name to manager and return id for sensor
+   * @param name Name given to the sensor
+   * @return The Entity ID
+   */
+  EntityID addSensor(const std::string& name);
+
+  /**
+   * @brief Given the sensor name return the ID
+   * @param name Name of the sensor
+   * @return The ID of the visual (if < 1000 it was not found)
+   */
+  EntityID getSensor(const std::string& name) const;
+
+  /**
+   * @brief Get all sensors being managed
+   * @return A map of names to entity id's
+   */
+  const EntityMap& getSensors() const;
+
+  /** @brief Check if empty */
+  bool empty() const;
+
+  /** @brief Clear interanl data */
+  void clear();
+
+private:
+  EntityMap link_id_map_;           /**< Stores entity id for each link */
+  EntityMap model_id_map_;          /**< Stores entity id for each model */
+  EntityMap visual_id_map_;         /**< Stores entity id for each visual */
+  EntityMap sensor_id_map_;         /**< Stores entity id for each sensor */
+  EntityID entity_counter_{ 1000 }; /**< Start entity counter to avoid clashing with gazebo */
+};
+}  // namespace tesseract_visualization
+
+#endif  // TESSERACT_VISUALIZATION_IGNITION_ENTITY_MANAGER_H

--- a/tesseract/tesseract_visualization/include/tesseract_visualization/ignition/tesseract_ignition_visualization.h
+++ b/tesseract/tesseract_visualization/include/tesseract_visualization/ignition/tesseract_ignition_visualization.h
@@ -1,0 +1,94 @@
+/**
+ * @file tesseract_ignition_vizualization.h
+ * @brief A tesseract vizualization implementation leveraging Ignition Robotics
+ *
+ * @author Levi Armstrong
+ * @date May 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_VISUALIZATION_IGNITION_TESSERACT_IGNITION_VISUALIZATION_H
+#define TESSERACT_VISUALIZATION_IGNITION_TESSERACT_IGNITION_VISUALIZATION_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ignition/msgs/scene.pb.h>
+#include <ignition/msgs/boolean.pb.h>
+#include <ignition/transport/Node.hh>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_visualization/visualization.h>
+#include <tesseract_visualization/ignition/entity_manager.h>
+#include <tesseract/tesseract.h>
+
+namespace tesseract_visualization
+{
+/** @brief The Tesseract Ignition Vizualization class */
+class TesseractIgnitionVisualization : public tesseract_visualization::Visualization
+{
+public:
+  using Ptr = std::shared_ptr<TesseractIgnitionVisualization>;
+  using ConstPtr = std::shared_ptr<const TesseractIgnitionVisualization>;
+
+  TesseractIgnitionVisualization() = default;
+
+  bool init(tesseract::Tesseract::ConstPtr thor) override;
+
+  void plotTrajectory(const std::vector<std::string>& joint_names,
+                      const Eigen::Ref<const tesseract_common::TrajArray>& traj) override;
+
+  void plotTrajectory(const tesseract_common::JointTrajectory& traj) override;
+
+  void plotTrajectory(const tesseract_planning::Instruction& instruction) override;
+
+  void plotToolPath(const tesseract_planning::Instruction& instruction) override;
+
+  void plotContactResults(const std::vector<std::string>& link_names,
+                          const tesseract_collision::ContactResultVector& dist_results,
+                          const Eigen::Ref<const Eigen::VectorXd>& safety_distances) override;
+
+  void plotArrow(const Eigen::Ref<const Eigen::Vector3d>& pt1,
+                 const Eigen::Ref<const Eigen::Vector3d>& pt2,
+                 const Eigen::Ref<const Eigen::Vector4d>& rgba,
+                 double scale) override;
+
+  void plotAxis(const Eigen::Isometry3d& axis, double scale) override;
+
+  void clear() override;
+
+  void waitForInput() override;
+
+private:
+  tesseract::Tesseract::ConstPtr thor_;               /**< The tesseract */
+  ignition::transport::Node node_;                    /**< Ignition communication node. */
+  ignition::transport::Node::Publisher scene_pub_;    /**< Scene publisher */
+  ignition::transport::Node::Publisher pose_pub_;     /**< Pose publisher */
+  ignition::transport::Node::Publisher deletion_pub_; /**< Deletion publisher */
+  EntityManager entity_manager_;
+
+  /**
+   * @brief Helper function for sending state to visualization tool
+   * @param env_state Environment state
+   */
+  void sendEnvState(const tesseract_environment::EnvState::Ptr& env_state);
+};
+
+}  // namespace tesseract_visualization
+
+#endif  // TESSERACT_VISUALIZATION_IGNITION_TESSERACT_IGNITION_VISUALIZATION_H

--- a/tesseract/tesseract_visualization/src/ignition/conversions.cpp
+++ b/tesseract/tesseract_visualization/src/ignition/conversions.cpp
@@ -1,0 +1,250 @@
+/**
+ * @file conversions.cpp
+ * @brief A set of conversion between Tesseract and Ignition Robotics objects
+ *
+ * @author Levi Armstrong
+ * @date May 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ignition/msgs/geometry.pb.h>
+#include <ignition/msgs/material.pb.h>
+#include <ignition/msgs/inertial.pb.h>
+#include <ignition/msgs/collision.pb.h>
+#include <ignition/msgs/visual.pb.h>
+#include <ignition/msgs/link.pb.h>
+#include <ignition/msgs/Utility.hh>
+#include <ignition/math/eigen3/Conversions.hh>
+#include <ignition/common/Console.hh>
+#include <ignition/common/MeshManager.hh>
+#include <console_bridge/console.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_visualization/ignition/conversions.h>
+#include <tesseract_geometry/geometries.h>
+
+namespace tesseract_visualization
+{
+bool toMsg(ignition::msgs::Scene& scene_msg,
+           EntityManager& entity_manager,
+           const tesseract_scene_graph::SceneGraph& scene_graph,
+           const tesseract_common::TransformMap& link_transforms)
+{
+  scene_msg.set_name("scene");
+  ignition::msgs::Model* model = scene_msg.add_model();
+  model->set_name(scene_graph.getName());
+  model->set_id(static_cast<unsigned>(entity_manager.addModel(scene_graph.getName())));
+  for (const auto& link : scene_graph.getLinks())
+  {
+    ignition::msgs::Link* link_msg = model->add_link();
+    link_msg->set_name(link->getName());
+    link_msg->set_id(static_cast<unsigned>(entity_manager.addLink(link->getName())));
+    link_msg->mutable_pose()->CopyFrom(
+        ignition::msgs::Convert(ignition::math::eigen3::convert(link_transforms.at(link->getName()))));
+
+    int cnt = 0;
+    for (const auto& vs : link->visual)
+    {
+      std::string gv_name = link->getName() + std::to_string(++cnt);
+      switch (vs->geometry->getType())
+      {
+        case tesseract_geometry::GeometryType::BOX:
+        {
+          ignition::msgs::Visual* gv_msg = model->add_visual();
+          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          gv_msg->set_name(gv_name);
+          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          ignition::msgs::Geometry geometry_msg;
+          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_BOX);
+
+          auto shape = std::static_pointer_cast<const tesseract_geometry::Box>(vs->geometry);
+          ignition::msgs::BoxGeom shape_geometry_msg;
+          shape_geometry_msg.mutable_size()->CopyFrom(
+              ignition::msgs::Convert(ignition::math::Vector3d(shape->getX(), shape->getY(), shape->getZ())));
+          geometry_msg.mutable_box()->CopyFrom(shape_geometry_msg);
+          gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+          //          gv_msg.mutable_material()
+          gv_msg->set_parent_name(link->getName());
+          break;
+        }
+        case tesseract_geometry::GeometryType::SPHERE:
+        {
+          ignition::msgs::Visual* gv_msg = model->add_visual();
+          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          gv_msg->set_name(gv_name);
+          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          ignition::msgs::Geometry geometry_msg;
+          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_SPHERE);
+
+          auto shape = std::static_pointer_cast<const tesseract_geometry::Sphere>(vs->geometry);
+          ignition::msgs::SphereGeom shape_geometry_msg;
+          shape_geometry_msg.set_radius(shape->getRadius());
+          geometry_msg.mutable_sphere()->CopyFrom(shape_geometry_msg);
+          gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+          //          gv_msg.mutable_material()
+          gv_msg->set_parent_name(link->getName());
+          break;
+        }
+        case tesseract_geometry::GeometryType::CYLINDER:
+        {
+          ignition::msgs::Visual* gv_msg = model->add_visual();
+          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          gv_msg->set_name(gv_name);
+          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          ignition::msgs::Geometry geometry_msg;
+          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_CYLINDER);
+
+          auto shape = std::static_pointer_cast<const tesseract_geometry::Cylinder>(vs->geometry);
+          ignition::msgs::CylinderGeom shape_geometry_msg;
+          shape_geometry_msg.set_radius(shape->getRadius());
+          shape_geometry_msg.set_length(shape->getLength());
+          geometry_msg.mutable_cylinder()->CopyFrom(shape_geometry_msg);
+          gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+          //          gv_msg.mutable_material()
+          gv_msg->set_parent_name(link->getName());
+          break;
+        }
+          //      case tesseract_geometry::GeometryType::CONE:
+          //      {
+          //          ignition::msgs::Visual* gv_msg = model->add_visual();
+          //          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          //          gv_msg->set_name(gv_name);
+          //          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          //          ignition::msgs::Geometry geometry_msg;
+          //          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_CONE);
+
+          //          auto shape = std::static_pointer_cast<const tesseract_geometry::Cone>(vs->geometry);
+          //          ignition::msgs::ConeGeom shape_geometry_msg;
+          //          shape_geometry_msg.set_radius(shape->getRadius());
+          //          shape_geometry_msg.set_length(shape->getLength());
+          //          geometry_msg.mutable_sphere()->CopyFrom(shape_geometry_msg);
+          //          gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+          //  //          gv_msg.mutable_material()
+          //          gv_msg->set_parent_name(link->getName());
+          //          break;
+          //      }
+
+          //        case tesseract_geometry::GeometryType::CAPSULE:
+          //        {
+          //          ignition::msgs::Visual* gv_msg = model->add_visual();
+          //          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          //          gv_msg->set_name(gv_name);
+          //          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          //          ignition::msgs::Geometry geometry_msg;
+          //          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_CAPSULE);
+
+          //          auto shape = std::static_pointer_cast<const tesseract_geometry::Capsule>(vs->geometry);
+          //          ignition::msgs::CapsuleGeom shape_geometry_msg;
+          //          shape_geometry_msg.set_radius(shape->getRadius());
+          //          shape_geometry_msg.set_length(shape->getLength());
+          //          geometry_msg.mutable_sphere()->CopyFrom(shape_geometry_msg);
+          //          gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+          //  //          gv_msg.mutable_material()
+          //          gv_msg->set_parent_name(link->getName());
+          //          break;
+          //        }
+        case tesseract_geometry::GeometryType::MESH:
+        {
+          ignition::msgs::Visual* gv_msg = link_msg->add_visual();
+          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          gv_msg->set_name(gv_name);
+          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          ignition::msgs::Geometry geometry_msg;
+          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_MESH);
+
+          auto shape = std::static_pointer_cast<const tesseract_geometry::Mesh>(vs->geometry);
+          auto resource = shape->getResource();
+          if (resource)
+          {
+            ignition::msgs::MeshGeom shape_geometry_msg;
+            shape_geometry_msg.set_filename(resource->getFilePath());
+            shape_geometry_msg.mutable_scale()->CopyFrom(
+                ignition::msgs::Convert(ignition::math::eigen3::convert(shape->getScale())));
+            geometry_msg.mutable_mesh()->CopyFrom(shape_geometry_msg);
+            gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+            //          gv_msg.set_allocated_material()
+            gv_msg->mutable_scale()->CopyFrom(
+                ignition::msgs::Convert(ignition::math::eigen3::convert(shape->getScale())));
+            gv_msg->set_parent_name(link->getName());
+          }
+          else
+          {
+            assert(false);
+          }
+
+          break;
+        }
+        case tesseract_geometry::GeometryType::CONVEX_MESH:
+        {
+          ignition::msgs::Visual* gv_msg = link_msg->add_visual();
+          gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+          gv_msg->set_name(gv_name);
+          gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(vs->origin)));
+
+          ignition::msgs::Geometry geometry_msg;
+          geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_MESH);
+
+          auto shape = std::static_pointer_cast<const tesseract_geometry::ConvexMesh>(vs->geometry);
+          auto resource = shape->getResource();
+          if (resource)
+          {
+            ignition::msgs::MeshGeom shape_geometry_msg;
+            shape_geometry_msg.set_filename(resource->getFilePath());
+            geometry_msg.mutable_mesh()->CopyFrom(shape_geometry_msg);
+            gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+            //          gv_msg.set_allocated_material()
+
+            gv_msg->set_parent_name(link->getName());
+          }
+          else
+          {
+            assert(false);
+          }
+
+          break;
+        }
+          //        case tesseract_geometry::GeometryType::OCTREE:
+          //        {
+          //          auto shape = std::static_pointer_cast<const tesseract_geometry::Octree>(vs->geometry);
+
+          //          // TODO: Need to implement
+          //          assert(false);
+          //          break;
+          //        }
+        default:
+        {
+          ignerr << "This geometric shape type " << static_cast<int>(vs->geometry->getType()) << " is not supported";
+          break;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+}  // namespace tesseract_visualization

--- a/tesseract/tesseract_visualization/src/ignition/entity_manager.cpp
+++ b/tesseract/tesseract_visualization/src/ignition/entity_manager.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file entity_manager.cpp
+ * @brief A entity manager for Tesseract components that get added to Ignition Scene
+ *
+ * @author Levi Armstrong
+ * @date May 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_visualization/ignition/entity_manager.h>
+
+namespace tesseract_visualization
+{
+EntityID EntityManager::addModel(const std::string& name)
+{
+  model_id_map_[name] = ++entity_counter_;
+  return model_id_map_[name];
+}
+
+EntityID EntityManager::getModel(const std::string& name) const
+{
+  auto it = model_id_map_.find(name);
+  if (it == model_id_map_.end())
+    return NULL_ENTITY_ID;
+
+  return it->second;
+}
+
+const EntityMap& EntityManager::getModels() const { return model_id_map_; }
+
+EntityID EntityManager::addLink(const std::string& name)
+{
+  link_id_map_[name] = ++entity_counter_;
+  return link_id_map_[name];
+}
+
+EntityID EntityManager::getLink(const std::string& name) const
+{
+  auto it = link_id_map_.find(name);
+  if (it == link_id_map_.end())
+    return NULL_ENTITY_ID;
+
+  return it->second;
+}
+
+const EntityMap& EntityManager::getLinks() const { return link_id_map_; }
+
+EntityID EntityManager::addVisual(const std::string& name)
+{
+  visual_id_map_[name] = ++entity_counter_;
+  return visual_id_map_[name];
+}
+
+EntityID EntityManager::getVisual(const std::string& name) const
+{
+  auto it = visual_id_map_.find(name);
+  if (it == visual_id_map_.end())
+    return NULL_ENTITY_ID;
+
+  return it->second;
+}
+
+const EntityMap& EntityManager::getVisuals() const { return visual_id_map_; }
+
+EntityID EntityManager::addSensor(const std::string& name)
+{
+  sensor_id_map_[name] = ++entity_counter_;
+  return sensor_id_map_[name];
+}
+
+EntityID EntityManager::getSensor(const std::string& name) const
+{
+  auto it = sensor_id_map_.find(name);
+  if (it == sensor_id_map_.end())
+    return NULL_ENTITY_ID;
+
+  return it->second;
+}
+
+const EntityMap& EntityManager::getSensors() const { return sensor_id_map_; }
+
+bool EntityManager::empty() const { return (entity_counter_ == 1000); }
+
+void EntityManager::clear()
+{
+  model_id_map_.clear();
+  link_id_map_.clear();
+  visual_id_map_.clear();
+  sensor_id_map_.clear();
+  entity_counter_ = 1000;
+}
+}  // namespace tesseract_visualization

--- a/tesseract/tesseract_visualization/src/ignition/tesseract_ignition_visualization.cpp
+++ b/tesseract/tesseract_visualization/src/ignition/tesseract_ignition_visualization.cpp
@@ -1,0 +1,615 @@
+/**
+ * @file tesseract_ignition_vizualization.cpp
+ * @brief A tesseract vizualization implementation leveraging Ignition Robotics
+ *
+ * @author Levi Armstrong
+ * @date May 14, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ignition/msgs/MessageTypes.hh>
+#include <ignition/common/Console.hh>
+#include <ignition/math/eigen3/Conversions.hh>
+#include <chrono>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_visualization/ignition/tesseract_ignition_visualization.h>
+#include <tesseract_visualization/ignition/conversions.h>
+
+#include <tesseract_command_language/command_language.h>
+#include <tesseract_command_language/utils/flatten_utils.h>
+#include <tesseract_command_language/utils/filter_functions.h>
+
+static const std::string DEFAULT_SCENE_TOPIC_NAME = "/tesseract_ignition/topic/scene";  // ignition::msgs::Scene
+static const std::string DEFAULT_POSE_TOPIC_NAME = "/tesseract_ignition/topic/pose";    // ignition::msgs::Pose_V
+static const std::string DEFAULT_DELETION_TOPIC_NAME =
+    "/tesseract_ignition/topic/deletion";  // ignition::msgs::UInt32_V
+static const std::string COLLISION_RESULTS_MODEL_NAME = "tesseract_collision_results_model";
+static const std::string AXES_MODEL_NAME = "tesseract_axes_model";
+static const std::string ARROW_MODEL_NAME = "tesseract_arrow_model";
+static const std::string TOOL_PATH_MODEL_NAME = "tesseract_tool_path_model";
+
+using namespace tesseract_visualization;
+
+bool TesseractIgnitionVisualization::init(tesseract::Tesseract::ConstPtr thor)
+{
+  if (thor == nullptr)
+    return false;
+
+  thor_ = std::move(thor);
+  scene_pub_ = node_.Advertise<ignition::msgs::Scene>(DEFAULT_SCENE_TOPIC_NAME);
+  pose_pub_ = node_.Advertise<ignition::msgs::Pose_V>(DEFAULT_POSE_TOPIC_NAME);
+  deletion_pub_ = node_.Advertise<ignition::msgs::Pose_V>(DEFAULT_DELETION_TOPIC_NAME);
+
+  // Wait 10 seconds for a connection to scene topic
+  for (int i = 0; i < 10; ++i)
+    if (!scene_pub_.HasConnections())
+      sleep(1);
+    else
+      break;
+
+  if (scene_pub_.HasConnections())
+  {
+    ignition::msgs::Scene msg;
+    toMsg(msg,
+          entity_manager_,
+          *(thor_->getEnvironmentConst()->getSceneGraph()),
+          thor_->getEnvironmentConst()->getCurrentState()->link_transforms);
+
+    scene_pub_.Publish(msg);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void TesseractIgnitionVisualization::sendEnvState(const tesseract_environment::EnvState::Ptr& env_state)
+{
+  ignition::msgs::Pose_V pose_v;
+  for (const auto& pair : env_state->link_transforms)
+  {
+    ignition::msgs::Pose* pose = pose_v.add_pose();
+    pose->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(pair.second)));
+    pose->set_name(pair.first);
+    pose->set_id(static_cast<unsigned>(entity_manager_.getLink(pair.first)));
+  }
+
+  if (!pose_pub_.Publish(pose_v))
+  {
+    ignerr << "Failed to publish pose vector!" << std::endl;
+  }
+}
+
+void TesseractIgnitionVisualization::plotTrajectory(const std::vector<std::string>& joint_names,
+                                                    const Eigen::Ref<const tesseract_common::TrajArray>& traj)
+{
+  tesseract_environment::StateSolver::Ptr state_solver = thor_->getEnvironmentConst()->getStateSolver();
+
+  std::chrono::duration<double> fp_s(5.0 / static_cast<double>(traj.rows()));
+  for (long i = 0; i < traj.rows(); ++i)
+  {
+    tesseract_environment::EnvState::Ptr state = state_solver->getState(joint_names, traj.row(i));
+    sendEnvState(state);
+    std::this_thread::sleep_for(fp_s);
+  }
+}
+
+void TesseractIgnitionVisualization::plotTrajectory(const tesseract_common::JointTrajectory& traj)
+{
+  plotTrajectory(traj.joint_names, traj.trajectory);
+}
+
+void TesseractIgnitionVisualization::plotTrajectory(const tesseract_planning::Instruction& instruction)
+{
+  using namespace tesseract_planning;
+  tesseract_environment::StateSolver::Ptr state_solver = thor_->getEnvironmentConst()->getStateSolver();
+  std::chrono::duration<double> fp_s(0.1);
+  double prev_time = 0;
+  if (isCompositeInstruction(instruction))
+  {
+    const auto* ci = instruction.cast_const<CompositeInstruction>();
+
+    std::vector<std::reference_wrapper<const Instruction>> fi = tesseract_planning::flatten(*ci, moveFilter);
+    for (const auto& i : fi)
+    {
+      assert(isMoveInstruction(i.get()));
+      std::this_thread::sleep_for(fp_s);
+      const auto* mi = i.get().cast_const<MoveInstruction>();
+      if (isStateWaypoint(mi->getWaypoint()))
+      {
+        const auto* swp = mi->getWaypoint().cast_const<StateWaypoint>();
+        double dt = swp->time - prev_time;
+        if (dt > 0)
+          std::this_thread::sleep_for(std::chrono::duration<double>(dt));
+        else
+          std::this_thread::sleep_for(fp_s);
+
+        assert(static_cast<long>(swp->joint_names.size()) == swp->position.size());
+        tesseract_environment::EnvState::Ptr state = state_solver->getState(swp->joint_names, swp->position);
+        sendEnvState(state);
+      }
+      else if (isJointWaypoint(mi->getWaypoint()))
+      {
+        std::this_thread::sleep_for(fp_s);
+        const auto* jwp = mi->getWaypoint().cast_const<JointWaypoint>();
+        assert(static_cast<long>(jwp->joint_names.size()) == jwp->size());
+        tesseract_environment::EnvState::Ptr state = state_solver->getState(jwp->joint_names, *jwp);
+        sendEnvState(state);
+      }
+      else
+      {
+        ignerr << "plotTrajectoy: Unsupported Waypoint Type!" << std::endl;
+      }
+    }
+  }
+  else if (isMoveInstruction(instruction))
+  {
+    std::this_thread::sleep_for(fp_s);
+    const auto* mi = instruction.cast_const<MoveInstruction>();
+    if (isStateWaypoint(mi->getWaypoint()))
+    {
+      const auto* swp = mi->getWaypoint().cast_const<StateWaypoint>();
+      double dt = swp->time - prev_time;
+      if (dt > 0)
+        std::this_thread::sleep_for(std::chrono::duration<double>(dt));
+      else
+        std::this_thread::sleep_for(fp_s);
+
+      assert(static_cast<long>(swp->joint_names.size()) == swp->position.size());
+      tesseract_environment::EnvState::Ptr state = state_solver->getState(swp->joint_names, swp->position);
+      sendEnvState(state);
+    }
+    else if (isJointWaypoint(mi->getWaypoint()))
+    {
+      std::this_thread::sleep_for(fp_s);
+      const auto* jwp = mi->getWaypoint().cast_const<JointWaypoint>();
+      assert(static_cast<long>(jwp->joint_names.size()) == jwp->size());
+      tesseract_environment::EnvState::Ptr state = state_solver->getState(jwp->joint_names, *jwp);
+      sendEnvState(state);
+    }
+    else
+    {
+      ignerr << "plotTrajectoy: Unsupported Waypoint Type!" << std::endl;
+    }
+  }
+  else
+  {
+    ignerr << "plotTrajectoy: Unsupported Instruction Type!" << std::endl;
+  }
+}
+
+void addArrow(EntityManager& entity_manager,
+              ignition::msgs::Link& link,
+              long& sub_index,
+              const std::string& parent_name,
+              const Eigen::Ref<const Eigen::Vector3d>& pt1,
+              const Eigen::Ref<const Eigen::Vector3d>& pt2,
+              const Eigen::Ref<const Eigen::Vector4d>& rgba,
+              double radius)
+{
+  std::string gv_name = parent_name + "_" + std::to_string(++sub_index);
+  ignition::msgs::Visual* gv_msg = link.add_visual();
+  gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+  gv_msg->set_name(gv_name);
+
+  Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  Eigen::Vector3d x, y, z;
+  z = (pt2 - pt1).normalized();
+  y = z.unitOrthogonal();
+  x = (y.cross(z)).normalized();
+  Eigen::Matrix3d rot;
+  rot.col(0) = x;
+  rot.col(1) = y;
+  rot.col(2) = z;
+  pose.linear() = rot;
+  pose.translation() = pt1 + (((pt2 - pt1).norm() / 2) * z);
+
+  gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(pose)));
+
+  ignition::msgs::Geometry geometry_msg;
+  geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_CYLINDER);
+  ignition::msgs::CylinderGeom shape_geometry_msg;
+  shape_geometry_msg.set_radius(radius);
+  shape_geometry_msg.set_length((pt2 - pt1).norm());
+  geometry_msg.mutable_cylinder()->CopyFrom(shape_geometry_msg);
+  gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+  ignition::msgs::Material shape_material_msg;
+  shape_material_msg.mutable_diffuse()->set_r(static_cast<float>(rgba(0)));
+  shape_material_msg.mutable_diffuse()->set_g(static_cast<float>(rgba(1)));
+  shape_material_msg.mutable_diffuse()->set_b(static_cast<float>(rgba(2)));
+  shape_material_msg.mutable_diffuse()->set_a(static_cast<float>(rgba(3)));
+  gv_msg->mutable_material()->CopyFrom(shape_material_msg);
+  gv_msg->set_parent_name(parent_name);
+}
+
+void addCylinder(EntityManager& entity_manager,
+                 ignition::msgs::Link& link,
+                 long& sub_index,
+                 const std::string& parent_name,
+                 const Eigen::Ref<const Eigen::Vector3d>& pt1,
+                 const Eigen::Ref<const Eigen::Vector3d>& pt2,
+                 const Eigen::Ref<const Eigen::Vector4d>& rgba,
+                 double radius)
+{
+  std::string gv_name = parent_name + "_" + std::to_string(++sub_index);
+  ignition::msgs::Visual* gv_msg = link.add_visual();
+  gv_msg->set_id(static_cast<unsigned>(entity_manager.addVisual(gv_name)));
+  gv_msg->set_name(gv_name);
+
+  Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  Eigen::Vector3d x, y, z;
+  z = (pt2 - pt1).normalized();
+  y = z.unitOrthogonal();
+  x = (y.cross(z)).normalized();
+  Eigen::Matrix3d rot;
+  rot.col(0) = x;
+  rot.col(1) = y;
+  rot.col(2) = z;
+  pose.linear() = rot;
+  pose.translation() = pt1 + (((pt2 - pt1).norm() / 2) * z);
+
+  gv_msg->mutable_pose()->CopyFrom(ignition::msgs::Convert(ignition::math::eigen3::convert(pose)));
+
+  ignition::msgs::Geometry geometry_msg;
+  geometry_msg.set_type(ignition::msgs::Geometry::Type::Geometry_Type_CYLINDER);
+  ignition::msgs::CylinderGeom shape_geometry_msg;
+  shape_geometry_msg.set_radius(radius);
+  shape_geometry_msg.set_length((pt2 - pt1).norm());
+  geometry_msg.mutable_cylinder()->CopyFrom(shape_geometry_msg);
+  gv_msg->mutable_geometry()->CopyFrom(geometry_msg);
+  ignition::msgs::Material shape_material_msg;
+  shape_material_msg.mutable_diffuse()->set_r(static_cast<float>(rgba(0)));
+  shape_material_msg.mutable_diffuse()->set_g(static_cast<float>(rgba(1)));
+  shape_material_msg.mutable_diffuse()->set_b(static_cast<float>(rgba(2)));
+  shape_material_msg.mutable_diffuse()->set_a(static_cast<float>(rgba(3)));
+  gv_msg->mutable_material()->CopyFrom(shape_material_msg);
+  gv_msg->set_parent_name(parent_name);
+}
+
+void addAxis(EntityManager& entity_manager,
+             ignition::msgs::Link& link,
+             long& sub_index,
+             const std::string& parent_name,
+             const Eigen::Isometry3d& axis,
+             double scale)
+{
+  Eigen::Vector3d x_axis = axis.matrix().block<3, 1>(0, 0);
+  Eigen::Vector3d y_axis = axis.matrix().block<3, 1>(0, 1);
+  Eigen::Vector3d z_axis = axis.matrix().block<3, 1>(0, 2);
+  Eigen::Vector3d position = axis.matrix().block<3, 1>(0, 3);
+
+  std::string gv_name = parent_name + "_" + std::to_string(++sub_index);
+  addCylinder(entity_manager,
+              link,
+              sub_index,
+              parent_name,
+              position,
+              position + (scale * x_axis),
+              Eigen::Vector4d(1, 0, 0, 1),
+              scale * (1.0 / 20));
+  addCylinder(entity_manager,
+              link,
+              sub_index,
+              parent_name,
+              position,
+              position + (scale * y_axis),
+              Eigen::Vector4d(0, 1, 0, 1),
+              scale * (1.0 / 20));
+  addCylinder(entity_manager,
+              link,
+              sub_index,
+              parent_name,
+              position,
+              position + (scale * z_axis),
+              Eigen::Vector4d(0, 0, 1, 1),
+              scale * (1.0 / 20));
+}
+
+void TesseractIgnitionVisualization::plotToolPath(const tesseract_planning::Instruction& instruction)
+{
+  using namespace tesseract_planning;
+
+  ignition::msgs::Scene scene_msg;
+  scene_msg.set_name("scene");
+  ignition::msgs::Model* model = scene_msg.add_model();
+  std::string model_name = TOOL_PATH_MODEL_NAME;
+  model->set_name(model_name);
+  model->set_id(static_cast<unsigned>(entity_manager_.addModel(model_name)));
+
+  tesseract_environment::StateSolver::Ptr state_solver = thor_->getEnvironmentConst()->getStateSolver();
+  if (isCompositeInstruction(instruction))
+  {
+    const auto* ci = instruction.cast_const<CompositeInstruction>();
+
+    // Assume all the plan instructions have the same manipulator as the composite
+    assert(!ci->getManipulatorInfo().isEmpty());
+    const ManipulatorInfo& composite_mi = ci->getManipulatorInfo();
+    const std::string& manipulator = composite_mi.manipulator;
+    const Eigen::Isometry3d& tcp = composite_mi.tcp;
+    const std::string& working_frame = composite_mi.working_frame;
+
+    auto composite_mi_fwd_kin = thor_->getFwdKinematicsManagerConst()->getFwdKinematicSolver(manipulator);
+    if (composite_mi_fwd_kin == nullptr)
+    {
+      ignerr << "plotToolPath: Manipulator: " << manipulator << " does not exist!" << std::endl;
+      return;
+    }
+    const std::string& tip_link = composite_mi_fwd_kin->getTipLinkName();
+
+    std::vector<std::reference_wrapper<const Instruction>> fi = tesseract_planning::flatten(*ci, planFilter);
+    long cnt = 0;
+    for (const auto& i : fi)
+    {
+      std::string link_name = model_name + std::to_string(++cnt);
+      ignition::msgs::Link* link_msg = model->add_link();
+      link_msg->set_id(static_cast<unsigned>(entity_manager_.addVisual(link_name)));
+      link_msg->set_name(link_name);
+
+      assert(isPlanInstruction(i.get()));
+      const auto* pi = i.get().cast_const<PlanInstruction>();
+      if (isStateWaypoint(pi->getWaypoint()))
+      {
+        const auto* swp = pi->getWaypoint().cast_const<StateWaypoint>();
+        assert(static_cast<long>(swp->joint_names.size()) == swp->position.size());
+        tesseract_environment::EnvState::Ptr state = state_solver->getState(swp->joint_names, swp->position);
+        addAxis(entity_manager_, *link_msg, cnt, link_name, state->link_transforms[tip_link] * tcp, 1);
+      }
+      else if (isJointWaypoint(pi->getWaypoint()))
+      {
+        const auto* jwp = pi->getWaypoint().cast_const<JointWaypoint>();
+        assert(static_cast<long>(jwp->joint_names.size()) == jwp->size());
+        tesseract_environment::EnvState::Ptr state = state_solver->getState(jwp->joint_names, *jwp);
+        addAxis(entity_manager_, *link_msg, cnt, link_name, state->link_transforms[tip_link] * tcp, 1);
+      }
+      else if (isCartesianWaypoint(pi->getWaypoint()))
+      {
+        const auto* cwp = pi->getWaypoint().cast_const<CartesianWaypoint>();
+        if (working_frame.empty())
+        {
+          addAxis(entity_manager_, *link_msg, cnt, link_name, (*cwp) * tcp, 1);
+        }
+        else
+        {
+          tesseract_environment::EnvState::ConstPtr state = thor_->getEnvironmentConst()->getCurrentState();
+          addAxis(
+              entity_manager_, *link_msg, cnt, link_name, state->link_transforms.at(working_frame) * (*cwp) * tcp, 1);
+        }
+      }
+      else
+      {
+        ignerr << "plotTrajectoy: Unsupported Waypoint Type!" << std::endl;
+      }
+    }
+  }
+  else if (isPlanInstruction(instruction))
+  {
+    long cnt = 0;
+    std::string link_name = model_name + std::to_string(++cnt);
+    ignition::msgs::Link* link_msg = model->add_link();
+    link_msg->set_id(static_cast<unsigned>(entity_manager_.addVisual(link_name)));
+    link_msg->set_name(link_name);
+
+    assert(isPlanInstruction(instruction));
+    const auto* pi = instruction.cast_const<PlanInstruction>();
+
+    // Assume all the plan instructions have the same manipulator as the composite
+    assert(!pi->getManipulatorInfo().isEmpty());
+    const ManipulatorInfo& composite_mi = pi->getManipulatorInfo();
+    const std::string& manipulator = composite_mi.manipulator;
+    const Eigen::Isometry3d& tcp = composite_mi.tcp;
+    const std::string& working_frame = composite_mi.working_frame;
+
+    auto composite_mi_fwd_kin = thor_->getFwdKinematicsManagerConst()->getFwdKinematicSolver(manipulator);
+    if (composite_mi_fwd_kin == nullptr)
+    {
+      ignerr << "plotToolPath: Manipulator: " << manipulator << " does not exist!" << std::endl;
+      return;
+    }
+    const std::string& tip_link = composite_mi_fwd_kin->getTipLinkName();
+
+    if (isStateWaypoint(pi->getWaypoint()))
+    {
+      const auto* swp = pi->getWaypoint().cast_const<StateWaypoint>();
+      assert(static_cast<long>(swp->joint_names.size()) == swp->position.size());
+      tesseract_environment::EnvState::Ptr state = state_solver->getState(swp->joint_names, swp->position);
+      addAxis(entity_manager_, *link_msg, cnt, link_name, state->link_transforms[tip_link] * tcp, 1);
+    }
+    else if (isJointWaypoint(pi->getWaypoint()))
+    {
+      const auto* jwp = pi->getWaypoint().cast_const<JointWaypoint>();
+      assert(static_cast<long>(jwp->joint_names.size()) == jwp->size());
+      tesseract_environment::EnvState::Ptr state = state_solver->getState(jwp->joint_names, *jwp);
+      addAxis(entity_manager_, *link_msg, cnt, link_name, state->link_transforms[tip_link] * tcp, 1);
+    }
+    else if (isCartesianWaypoint(pi->getWaypoint()))
+    {
+      const auto* cwp = pi->getWaypoint().cast_const<CartesianWaypoint>();
+      if (working_frame.empty())
+      {
+        addAxis(entity_manager_, *link_msg, cnt, link_name, (*cwp) * tcp, 1);
+      }
+      else
+      {
+        tesseract_environment::EnvState::ConstPtr state = thor_->getEnvironmentConst()->getCurrentState();
+        addAxis(entity_manager_, *link_msg, cnt, link_name, state->link_transforms.at(working_frame) * (*cwp) * tcp, 1);
+      }
+    }
+    else
+    {
+      ignerr << "plotTrajectoy: Unsupported Waypoint Type!" << std::endl;
+    }
+  }
+  else
+  {
+    ignerr << "plotTrajectoy: Unsupported Instruction Type!" << std::endl;
+  }
+}
+
+void TesseractIgnitionVisualization::plotContactResults(const std::vector<std::string>& link_names,
+                                                        const tesseract_collision::ContactResultVector& dist_results,
+                                                        const Eigen::Ref<const Eigen::VectorXd>& safety_distances)
+{
+  ignition::msgs::Scene scene_msg;
+  scene_msg.set_name("scene");
+  ignition::msgs::Model* model = scene_msg.add_model();
+  std::string model_name = COLLISION_RESULTS_MODEL_NAME;
+  model->set_name(model_name);
+  model->set_id(static_cast<unsigned>(entity_manager_.addModel(model_name)));
+
+  long cnt = 0;
+  for (size_t i = 0; i < dist_results.size(); ++i)
+  {
+    const tesseract_collision::ContactResult& dist = dist_results[i];
+    const double& safety_distance = safety_distances[static_cast<long>(i)];
+
+    std::string link_name = model_name + std::to_string(++cnt);
+    ignition::msgs::Link* link_msg = model->add_link();
+    link_msg->set_id(static_cast<unsigned>(entity_manager_.addVisual(link_name)));
+    link_msg->set_name(link_name);
+
+    Eigen::Vector4d rgba;
+    if (dist.distance < 0)
+    {
+      rgba << 1.0, 0.0, 0.0, 1.0;
+    }
+    else if (dist.distance < safety_distance)
+    {
+      rgba << 1.0, 1.0, 0.0, 1.0;
+    }
+    else
+    {
+      rgba << 0.0, 1.0, 0.0, 1.0;
+    }
+
+    if (dist.cc_type[0] == tesseract_collision::ContinuousCollisionType::CCType_Between)
+    {
+      Eigen::Vector4d cc_rgba;
+      cc_rgba << 0.0, 0.0, 1.0, 1.0;
+      addArrow(entity_manager_,
+               *link_msg,
+               cnt,
+               link_name,
+               dist.transform[0] * dist.nearest_points_local[0],
+               dist.cc_transform[0] * dist.nearest_points_local[0],
+               cc_rgba,
+               0.2);
+    }
+
+    if (dist.cc_type[1] == tesseract_collision::ContinuousCollisionType::CCType_Between)
+    {
+      Eigen::Vector4d cc_rgba;
+      cc_rgba << 0.0, 0.0, 0.5, 1.0;
+      addArrow(entity_manager_,
+               *link_msg,
+               cnt,
+               link_name,
+               dist.transform[1] * dist.nearest_points_local[1],
+               dist.cc_transform[1] * dist.nearest_points_local[1],
+               cc_rgba,
+               0.2);
+    }
+
+    auto it0 = std::find(link_names.begin(), link_names.end(), dist.link_names[0]);
+    auto it1 = std::find(link_names.begin(), link_names.end(), dist.link_names[1]);
+
+    if (it0 != link_names.end() && it1 != link_names.end())
+    {
+      addArrow(entity_manager_, *link_msg, cnt, link_name, dist.nearest_points[0], dist.nearest_points[1], rgba, 0.2);
+      addArrow(entity_manager_, *link_msg, cnt, link_name, dist.nearest_points[1], dist.nearest_points[0], rgba, 0.2);
+    }
+    else if (it0 != link_names.end())
+    {
+      addArrow(entity_manager_, *link_msg, cnt, link_name, dist.nearest_points[1], dist.nearest_points[0], rgba, 0.2);
+    }
+    else
+    {
+      addArrow(entity_manager_, *link_msg, cnt, link_name, dist.nearest_points[0], dist.nearest_points[1], rgba, 0.2);
+    }
+  }
+  scene_pub_.Publish(scene_msg);
+}
+
+void TesseractIgnitionVisualization::plotArrow(const Eigen::Ref<const Eigen::Vector3d>& pt1,
+                                               const Eigen::Ref<const Eigen::Vector3d>& pt2,
+                                               const Eigen::Ref<const Eigen::Vector4d>& rgba,
+                                               double scale)
+{
+  ignition::msgs::Scene scene_msg;
+  scene_msg.set_name("scene");
+  ignition::msgs::Model* model = scene_msg.add_model();
+  std::string model_name = ARROW_MODEL_NAME;
+  model->set_name(model_name);
+  model->set_id(static_cast<unsigned>(entity_manager_.addModel(model_name)));
+
+  long cnt = 0;
+  std::string link_name = model_name + std::to_string(++cnt);
+  ignition::msgs::Link* link_msg = model->add_link();
+  link_msg->set_id(static_cast<unsigned>(entity_manager_.addVisual(link_name)));
+  link_msg->set_name(link_name);
+  addArrow(entity_manager_, *link_msg, cnt, link_name, pt1, pt2, rgba, scale * ((pt2 - pt1).norm() * (1.0 / 20)));
+  scene_pub_.Publish(scene_msg);
+}
+
+void TesseractIgnitionVisualization::plotAxis(const Eigen::Isometry3d& axis, double scale)
+{
+  ignition::msgs::Scene scene_msg;
+  scene_msg.set_name("scene");
+  ignition::msgs::Model* model = scene_msg.add_model();
+  std::string model_name = AXES_MODEL_NAME;
+  model->set_name(model_name);
+  model->set_id(static_cast<unsigned>(entity_manager_.addModel(model_name)));
+
+  long cnt = 0;
+  std::string link_name = model_name + std::to_string(++cnt);
+  ignition::msgs::Link* link_msg = model->add_link();
+  link_msg->set_id(static_cast<unsigned>(entity_manager_.addVisual(link_name)));
+  link_msg->set_name(link_name);
+  addAxis(entity_manager_, *link_msg, cnt, link_name, axis, scale);
+  scene_pub_.Publish(scene_msg);
+}
+
+void TesseractIgnitionVisualization::clear()
+{
+  ignition::msgs::UInt32_V deletion_msg;
+  long id = entity_manager_.getModel(COLLISION_RESULTS_MODEL_NAME);
+  if (id >= 1000)
+    deletion_msg.add_data(static_cast<unsigned>(id));
+
+  id = entity_manager_.getModel(ARROW_MODEL_NAME);
+  if (id >= 1000)
+    deletion_msg.add_data(static_cast<unsigned>(id));
+
+  id = entity_manager_.getModel(AXES_MODEL_NAME);
+  if (id >= 1000)
+    deletion_msg.add_data(static_cast<unsigned>(id));
+
+  deletion_pub_.Publish(deletion_msg);
+}
+
+void TesseractIgnitionVisualization::waitForInput()
+{
+  std::cout << "Hit enter key to continue!" << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+}


### PR DESCRIPTION
This also adds the tesseract ignition visualization which gets built only if ignition is found. This was moved from tesseract_ignition because dynamically loading a library was problematic, but may find a solution in the near future.