### PR TITLE
Feature/fix bounds msgs

### DIFF
--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/utils/utils.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/utils/utils.h
@@ -47,6 +47,14 @@ const Eigen::VectorXd& getJointPosition(const Waypoint& waypoint);
 bool setJointPosition(Waypoint& waypoint, const Eigen::Ref<const Eigen::VectorXd>& position);
 
 /**
+ * @brief Checks if a waypoint is
+ * @param wp Waypoint to be checked. Only checks if a JointPosition or State waypoint (otherwise returns true)
+ * @param limits Matrix2d of limits with first column being lower limits and second column being upper limits
+ * @return True if the waypoit falls within the joint limits
+ */
+bool isWithinJointLimits(const Waypoint& wp, const Eigen::Ref<const Eigen::MatrixX2d>& limits);
+
+/**
  * @brief Clamps a waypoint to be within joint limits
  * @param wp Waypoint to be adjusted. Does nothing if not a JointPosition or State waypoint
  * @param limits Matrix2d of limits with first column being lower limits and second column being upper limits

--- a/tesseract/tesseract_planning/tesseract_command_language/test/utils_test.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/test/utils_test.cpp
@@ -299,6 +299,52 @@ TEST(TesseractCommandLanguageUtilsUnit, flattenToPattern)  // NOLINT
   }
 }
 
+TEST(TesseractCommandLanguageUtilsUnit, isWithinJointLimits)
+{
+  Eigen::MatrixX2d limits(3, 2);
+  limits << 0, 2, 0, 2, 0, 2;
+  std::vector<std::string> joint_names = { "1", "2", "3" };
+  Eigen::VectorXd values(3);
+
+  // Invalid waypoint
+  {
+    JointWaypoint jp;
+    Waypoint tmp(jp);
+    EXPECT_FALSE(isWithinJointLimits(tmp, limits));
+  }
+  // Invalid limits
+  {
+    values << 1, 1, 1;
+    JointWaypoint jp(joint_names, values);
+    Waypoint tmp(jp);
+
+    Eigen::MatrixX2d invalid_limits(2, 2);
+    invalid_limits << 0, 2, 0, 2;
+    EXPECT_FALSE(isWithinJointLimits(tmp, invalid_limits));
+  }
+  // Within limits
+  {
+    values << 1, 1, 1;
+    JointWaypoint jp(joint_names, values);
+    Waypoint tmp(jp);
+    EXPECT_TRUE(isWithinJointLimits(tmp, limits));
+  }
+  // Above limits
+  {
+    values << 1, 1, 3;
+    JointWaypoint jp(joint_names, values);
+    Waypoint tmp(jp);
+    EXPECT_FALSE(isWithinJointLimits(tmp, limits));
+  }
+  // Below limits
+  {
+    values << 1, -1, 1;
+    JointWaypoint jp(joint_names, values);
+    Waypoint tmp(jp);
+    EXPECT_FALSE(isWithinJointLimits(tmp, limits));
+  }
+}
+
 TEST(TesseractCommandLanguageUtilsUnit, clampToJointLimits)
 {
   Eigen::MatrixX2d limits(3, 2);
@@ -306,11 +352,21 @@ TEST(TesseractCommandLanguageUtilsUnit, clampToJointLimits)
   std::vector<std::string> joint_names = { "1", "2", "3" };
   Eigen::VectorXd values(3);
 
-  // Invalid limits
+  // Invalid waypoint
   {
     JointWaypoint jp;
     Waypoint tmp(jp);
     EXPECT_FALSE(clampToJointLimits(tmp, limits));
+  }
+  // Invalid limits
+  {
+    values << 1, 1, 1;
+    JointWaypoint jp(joint_names, values);
+    Waypoint tmp(jp);
+
+    Eigen::MatrixX2d invalid_limits(2, 2);
+    invalid_limits << 0, 2, 0, 2;
+    EXPECT_FALSE(clampToJointLimits(tmp, invalid_limits));
   }
   // Within limits
   {

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/motion_planner_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/motion_planner_process_generator.cpp
@@ -159,7 +159,9 @@ int MotionPlannerProcessGenerator::conditionalProcess(ProcessInput input) const
   // --------------------
   PlannerResponse response;
 
-  bool verbose = true;
+  bool verbose = false;
+  if (console_bridge::getLogLevel() == console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_DEBUG)
+    verbose = true;
   auto status = planner_->solve(request, response, verbose);
 
   // --------------------


### PR DESCRIPTION
This restructures the utils used in the fix bounds state process generator in order to keep it from spamming the terminal with messages even when it isn't doing anything. It now checks upfront if the limits need fixing and only prints the message and calls clamp if necessary.