### PR TITLE
Add global raster variant

### DIFF
--- a/gh_pages/_source/tesseract_command_language_doc.rst
+++ b/gh_pages/_source/tesseract_command_language_doc.rst
@@ -1,0 +1,80 @@
+Tesseract Command Language
+==========================
+
+This is a high level programming language used throughout the Tesseract Planning Framework. The goal is to provide an abstraction between motion commands and motion planner specific configurations similar to programming on an industrial teach pendant.
+
+At the lowest level the command language is a set of instruction where on an industrial teach pendant these include move instructions, set I/O instruction and set Analog instruction. These are all included in the command language with a few additional instruction like plan instruction and environment instruction to start. These instructions are specific to motion planning and environment management.
+
+This high level language allows a novice user to create complex programs without the knowledge of planner specifics which is designed to encode the the whole process including motion planning, motion execution, environment management, sensor signals and much more.
+
+Overview
+========
+
+The command language begins by defining your waypoints. The current supported waypoints are CartesianWaypoint, JointWaypoint and StateWaypoint.
+
+  - CartesianWaypoint: This is a Cartesian pose leveraged within the Plan Instruction
+  - JointWaypoint: This is a joint space pose leveraged within the Plan Instruction
+  - StateWaypoint: This not only includes joint names and positions but also includes velocity, acceleration, and time from start. It is primarily used in the Move Instruction but may be used in the Plan Instruction.
+
+.. code-block:: c++
+
+   Waypoint wp0 = JointWaypoint(fwd_kin->getJointNames(), Eigen::VectorXd::Zero(6));
+   Waypoint wp1 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.3, 0.8));
+   Waypoint wp2 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.2, 0.8));
+   Waypoint wp3 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.1, 0.8));
+   Waypoint wp4 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.0, 0.8));
+   Waypoint wp5 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.1, 0.8));
+   Waypoint wp6 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.2, 0.8));
+   Waypoint wp7 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.3, 0.8));
+
+
+After the definitions of the waypoints, the plan instructions need to be defined. As shown below the plan instruction requires three inputs, the first is the waypoint, the second is the type of motion LINEAR, FREESPACE or START and last is the profile name. The profile name corresponds to a set of planner specific parameters on the motion planning side.
+
+.. code-block:: c++
+
+   PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "FREESPACE");
+   PlanInstruction plan_c0(wp2, PlanInstructionType::LINEAR, "RASTER");
+   PlanInstruction plan_c1(wp3, PlanInstructionType::LINEAR, "RASTER");
+   PlanInstruction plan_c2(wp4, PlanInstructionType::LINEAR, "RASTER");
+   PlanInstruction plan_c3(wp5, PlanInstructionType::LINEAR, "RASTER");
+   PlanInstruction plan_c4(wp6, PlanInstructionType::LINEAR, "RASTER");
+   PlanInstruction plan_c5(wp7, PlanInstructionType::LINEAR, "RASTER");
+
+The last component is to create the program which would be sent to the motion planning server. This involves the use of a Composite Instruction which is a vector of instructions with additional properties to be set. One of those additional parameters is the ManipulatorInfo which includes information about the manipulator along with working frame and tool center point information.
+
+.. code-block:: c++
+
+   CompositeInstruction program("raster_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+
+   PlanInstruction start_instruction(wp0, PlanInstructionType::START);
+   program.setStartInstruction(start_instruction);
+
+   program.push_back(plan_f0);
+   program.push_back(plan_c0);
+   program.push_back(plan_c1);
+   program.push_back(plan_c2);
+   program.push_back(plan_c3);
+   program.push_back(plan_c4);
+   program.push_back(plan_c5);
+
+Now that the program has been created additional utility function will be discussed.
+
+One useful feature of the Command Language, is it can be serialized to xml and de-serialized from xml.
+
+.. code-block:: c++
+
+   std::string xml_string = toXMLString(programn);
+   Instruction from_xml_string = fromXMLString(xml_string);
+
+
+The Tesseract Command Language is unique within Tesseract because it leverages Type Erasures instead of inheritance. This was chosen because Type Erasures obey copy semantics allowing for full use of the stl libraries.
+
+In addition, the Instruction and Waypoint Type Erasure provide a cast and cast_const for casting the type to the erased type leveraging the getType() method.
+
+.. code-block:: c++
+
+   if (isComposite(from_xml_string))
+   {
+    const auto* const_composite = from_xml_string.cast_const<CompositeInstruction>();
+    auto* composite = from_xml_string.const<CompositeInstruction>();
+   }

--- a/gh_pages/_source/tesseract_planning_doc.rst
+++ b/gh_pages/_source/tesseract_planning_doc.rst
@@ -1,2 +1,12 @@
 Tesseract Planning Package
 ==========================
+
+This is a meta package which contains packages related to motion planning within Tesseract.
+
+Packages
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   tesseract_command_language <_source/tesseract_command_language_doc.rst>

--- a/gh_pages/conf.py
+++ b/gh_pages/conf.py
@@ -53,8 +53,8 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.
-project = u'Industrial Training'
-copyright = u'2017, ROS-Industrial'
+project = u'Tesseract'
+copyright = u'2020, ROS-Industrial'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/tesseract/tesseract/CMakeLists.txt
+++ b/tesseract/tesseract/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(tesseract_environment REQUIRED)
 find_package(tesseract_kinematics REQUIRED)
 find_package(tesseract_common REQUIRED)
 find_package(tesseract_urdf REQUIRED)
+find_package(tesseract_command_language REQUIRED)
 find_package(cmake_common_scripts REQUIRED)
 
 set(COVERAGE_EXCLUDE /usr/* /opt/* ${CMAKE_CURRENT_LIST_DIR}/test/* /*/gtest/*)
@@ -28,6 +29,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   tesseract::tesseract_environment_ofkt
   tesseract::tesseract_kinematics_kdl
   tesseract::tesseract_kinematics_opw
+  tesseract::tesseract_command_language
   console_bridge)
 target_compile_options(${PROJECT_NAME} PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(${PROJECT_NAME} ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})

--- a/tesseract/tesseract/cmake/tesseract-config.cmake.in
+++ b/tesseract/tesseract/cmake/tesseract-config.cmake.in
@@ -18,5 +18,6 @@ find_dependency(tesseract_kinematics)
 find_dependency(tesseract_common)
 find_dependency(tesseract_urdf)
 find_dependency(console_bridge)
+find_dependency(tesseract_command_language)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/tesseract/tesseract/include/tesseract/manipulator_manager.h
+++ b/tesseract/tesseract/include/tesseract/manipulator_manager.h
@@ -82,15 +82,17 @@ public:
   const tesseract_scene_graph::LinkGroup& getLinkGroup(const std::string& group_name) const;
   const tesseract_scene_graph::LinkGroups& getLinkGroups() const;
 
-  bool addROPGroup(const std::string& group_name, const tesseract_scene_graph::ROPKinematicParameters& rop_group);
-  void removeROPGroup(const std::string& group_name);
-  const tesseract_scene_graph::ROPKinematicParameters& getROPGroup(const std::string& group_name) const;
-  const tesseract_scene_graph::ROPGroups& getROPGroups() const;
+  bool addROPKinematicsSolver(const std::string& group_name,
+                              const tesseract_scene_graph::ROPKinematicParameters& rop_group);
+  void removeROPKinematicsSolver(const std::string& group_name);
+  const tesseract_scene_graph::ROPKinematicParameters& getROPKinematicsSolver(const std::string& group_name) const;
+  const tesseract_scene_graph::GroupROPKinematics& getROPKinematicsSolvers() const;
 
-  bool addREPGroup(const std::string& group_name, const tesseract_scene_graph::REPKinematicParameters& rep_group);
-  void removeREPGroup(const std::string& group_name);
-  const tesseract_scene_graph::REPKinematicParameters& getREPGroup(const std::string& group_name) const;
-  const tesseract_scene_graph::REPGroups& getREPGroups() const;
+  bool addREPKinematicsSolver(const std::string& group_name,
+                              const tesseract_scene_graph::REPKinematicParameters& rep_group);
+  void removeREPKinematicsSolver(const std::string& group_name);
+  const tesseract_scene_graph::REPKinematicParameters& getREPKinematicsSolver(const std::string& group_name) const;
+  const tesseract_scene_graph::GroupREPKinematics& getREPKinematicsSolvers() const;
 
   bool addOPWKinematicsSolver(const std::string& group_name,
                               const tesseract_scene_graph::OPWKinematicParameters& opw_params);
@@ -112,6 +114,7 @@ public:
   const Eigen::Isometry3d& getGroupsTCP(const std::string& group_name, const std::string& tcp_name) const;
   const tesseract_scene_graph::GroupsTCPs& getGroupsTCPs(const std::string& group_name) const;
   const tesseract_scene_graph::GroupTCPs& getGroupTCPs() const;
+  bool hasGroupTCP(const std::string& group_name, const std::string& tcp_name) const;
 
   // This is exposed for the SRDF editor should not use in normal applications
   void addAllowedCollision(const std::string& link_1, const std::string& link_2, const std::string& reason);

--- a/tesseract/tesseract/include/tesseract/tesseract.h
+++ b/tesseract/tesseract/include/tesseract/tesseract.h
@@ -40,6 +40,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_scene_graph/utils.h>
 #include <tesseract_scene_graph/resource_locator.h>
 #include <tesseract/manipulator_manager.h>
+#include <tesseract_command_language/manipulator_info.h>
 
 namespace tesseract
 {
@@ -92,6 +93,13 @@ public:
 
   ManipulatorManager::Ptr getManipulatorManager();
   ManipulatorManager::ConstPtr getManipulatorManager() const;
+
+  /**
+   * @brief Find tool center point provided in the manipulator info
+   * @param manip_info The manipulator info
+   * @return The tool center point
+   */
+  Eigen::Isometry3d findTCP(const tesseract_planning::ManipulatorInfo& manip_info) const;
 
   void setResourceLocator(tesseract_scene_graph::ResourceLocator::Ptr locator);
   const tesseract_scene_graph::ResourceLocator::Ptr& getResourceLocator() const;

--- a/tesseract/tesseract/package.xml
+++ b/tesseract/tesseract/package.xml
@@ -15,6 +15,7 @@
   <depend>tesseract_kinematics</depend>
   <depend>tesseract_common</depend>
   <depend>tesseract_urdf</depend>
+  <depend>tesseract_command_language</depend>
   <depend>libconsole-bridge-dev</depend>
 
   <export>

--- a/tesseract/tesseract/src/manipulator_manager.cpp
+++ b/tesseract/tesseract/src/manipulator_manager.cpp
@@ -67,10 +67,10 @@ bool ManipulatorManager::init(tesseract_environment::Environment::ConstPtr envir
   for (const auto& group : srdf_model_->getGroupOPWKinematics())
     success &= registerOPWSolver(group.first, group.second);
 
-  for (const auto& group : srdf_model_->getROPGroups())
+  for (const auto& group : srdf_model_->getGroupROPKinematics())
     success &= registerROPSolver(group.first, group.second);
 
-  for (const auto& group : srdf_model_->getREPGroups())
+  for (const auto& group : srdf_model_->getGroupREPKinematics())
     success &= registerREPSolver(group.first, group.second);
 
   return success;
@@ -199,8 +199,8 @@ const tesseract_scene_graph::LinkGroups& ManipulatorManager::getLinkGroups() con
   return srdf_model_->getLinkGroups();
 }
 
-bool ManipulatorManager::addROPGroup(const std::string& group_name,
-                                     const tesseract_scene_graph::ROPKinematicParameters& rop_group)
+bool ManipulatorManager::addROPKinematicsSolver(const std::string& group_name,
+                                                const tesseract_scene_graph::ROPKinematicParameters& rop_group)
 {
   if (hasGroup(group_name))
   {
@@ -208,14 +208,14 @@ bool ManipulatorManager::addROPGroup(const std::string& group_name,
     return false;
   }
 
-  srdf_model_->getROPGroups()[group_name] = rop_group;
+  srdf_model_->getGroupROPKinematics()[group_name] = rop_group;
   srdf_model_->getGroupNames().push_back(group_name);
   return registerROPSolver(group_name, rop_group);
 }
 
-void ManipulatorManager::removeROPGroup(const std::string& group_name)
+void ManipulatorManager::removeROPKinematicsSolver(const std::string& group_name)
 {
-  srdf_model_->getROPGroups().erase(group_name);
+  srdf_model_->getGroupROPKinematics().erase(group_name);
   tesseract_scene_graph::GroupNames& group_names = srdf_model_->getGroupNames();
   group_names.erase(std::remove_if(
       group_names.begin(), group_names.end(), [group_name](const std::string& gn) { return gn == group_name; }));
@@ -224,15 +224,18 @@ void ManipulatorManager::removeROPGroup(const std::string& group_name)
 }
 
 const tesseract_scene_graph::ROPKinematicParameters&
-ManipulatorManager::getROPGroup(const std::string& group_name) const
+ManipulatorManager::getROPKinematicsSolver(const std::string& group_name) const
 {
-  return srdf_model_->getROPGroups().at(group_name);
+  return srdf_model_->getGroupROPKinematics().at(group_name);
 }
 
-const tesseract_scene_graph::ROPGroups& ManipulatorManager::getROPGroups() const { return srdf_model_->getROPGroups(); }
+const tesseract_scene_graph::GroupROPKinematics& ManipulatorManager::getROPKinematicsSolvers() const
+{
+  return srdf_model_->getGroupROPKinematics();
+}
 
-bool ManipulatorManager::addREPGroup(const std::string& group_name,
-                                     const tesseract_scene_graph::REPKinematicParameters& rep_group)
+bool ManipulatorManager::addREPKinematicsSolver(const std::string& group_name,
+                                                const tesseract_scene_graph::REPKinematicParameters& rep_group)
 {
   if (hasGroup(group_name))
   {
@@ -240,14 +243,14 @@ bool ManipulatorManager::addREPGroup(const std::string& group_name,
     return false;
   }
 
-  srdf_model_->getREPGroups()[group_name] = rep_group;
+  srdf_model_->getGroupREPKinematics()[group_name] = rep_group;
   srdf_model_->getGroupNames().push_back(group_name);
   return registerREPSolver(group_name, rep_group);
 }
 
-void ManipulatorManager::removeREPGroup(const std::string& group_name)
+void ManipulatorManager::removeREPKinematicsSolver(const std::string& group_name)
 {
-  srdf_model_->getREPGroups().erase(group_name);
+  srdf_model_->getGroupREPKinematics().erase(group_name);
   tesseract_scene_graph::GroupNames& group_names = srdf_model_->getGroupNames();
   group_names.erase(std::remove_if(
       group_names.begin(), group_names.end(), [group_name](const std::string& gn) { return gn == group_name; }));
@@ -256,12 +259,15 @@ void ManipulatorManager::removeREPGroup(const std::string& group_name)
 }
 
 const tesseract_scene_graph::REPKinematicParameters&
-ManipulatorManager::getREPGroup(const std::string& group_name) const
+ManipulatorManager::getREPKinematicsSolver(const std::string& group_name) const
 {
-  return srdf_model_->getREPGroups().at(group_name);
+  return srdf_model_->getGroupREPKinematics().at(group_name);
 }
 
-const tesseract_scene_graph::REPGroups& ManipulatorManager::getREPGroups() const { return srdf_model_->getREPGroups(); }
+const tesseract_scene_graph::GroupREPKinematics& ManipulatorManager::getREPKinematicsSolvers() const
+{
+  return srdf_model_->getGroupREPKinematics();
+}
 
 bool ManipulatorManager::addOPWKinematicsSolver(const std::string& group_name,
                                                 const tesseract_scene_graph::OPWKinematicParameters& opw_params)
@@ -366,6 +372,19 @@ const tesseract_scene_graph::GroupsTCPs& ManipulatorManager::getGroupsTCPs(const
 }
 
 const tesseract_scene_graph::GroupTCPs& ManipulatorManager::getGroupTCPs() const { return srdf_model_->getGroupTCPs(); }
+
+bool ManipulatorManager::hasGroupTCP(const std::string& group_name, const std::string& tcp_name) const
+{
+  auto group_it = srdf_model_->getGroupTCPs().find(group_name);
+  if (group_it == srdf_model_->getGroupTCPs().end())
+    return false;
+
+  auto tcp_it = group_it->second.find(tcp_name);
+  if (tcp_it == group_it->second.end())
+    return false;
+
+  return true;
+}
 
 // This is exposed for the SRDF editor should not use in normal applications
 void ManipulatorManager::addAllowedCollision(const std::string& link_1,
@@ -763,6 +782,14 @@ bool ManipulatorManager::registerOPWSolver(const std::string& group_name,
 bool ManipulatorManager::registerROPSolver(const std::string& group_name,
                                            const tesseract_scene_graph::ROPKinematicParameters& rop_group)
 {
+  tesseract_kinematics::ForwardKinematics::Ptr fwd_kin = getFwdKinematicSolver(group_name);
+  if (fwd_kin == nullptr)
+  {
+    CONSOLE_BRIDGE_logError("Failed to add inverse kinematic ROP solver for manipulator %s to manager!",
+                            group_name.c_str());
+    return false;
+  }
+
   tesseract_kinematics::InverseKinematics::Ptr manip_ik_solver =
       getInvKinematicSolver(rop_group.manipulator_group, rop_group.manipulator_ik_solver);
 
@@ -788,40 +815,39 @@ bool ManipulatorManager::registerROPSolver(const std::string& group_name,
     positioner_sample_resolution(static_cast<long>(i)) = it->second;
   }
 
-  auto rop_inv_kin = std::make_shared<tesseract_kinematics::RobotOnPositionerInvKin>();
-  if (!rop_inv_kin->init(scene_graph_,
-                         manip_ik_solver,
-                         rop_group.manipulator_reach,
-                         positioner_fk_solver,
-                         positioner_sample_resolution,
-                         group_name))
+  auto solver = std::make_shared<tesseract_kinematics::RobotOnPositionerInvKin>();
+  if (!solver->init(scene_graph_,
+                    manip_ik_solver,
+                    rop_group.manipulator_reach,
+                    positioner_fk_solver,
+                    positioner_sample_resolution,
+                    group_name))
     return false;
 
-  if (!addInvKinematicSolver(rop_inv_kin))
-    return false;
-
-  const tesseract_scene_graph::ChainGroups& chain_groups = srdf_model_->getChainGroups();
-  // If both are chains then create a chain forward kinematics object for the group otherwise use joint list
-  if (chain_groups.find(rop_group.manipulator_group) != chain_groups.end() &&
-      chain_groups.find(rop_group.positioner_group) != chain_groups.end())
+  if (!addInvKinematicSolver(solver))
   {
-    tesseract_scene_graph::ChainGroup chain_group;
-    chain_group.push_back(
-        std::make_pair(positioner_fk_solver->getBaseLinkName(), positioner_fk_solver->getTipLinkName()));
-    chain_group.push_back(std::make_pair(manip_ik_solver->getBaseLinkName(), manip_ik_solver->getTipLinkName()));
-
-    return registerDefaultChainSolver(group_name, chain_group);
+    CONSOLE_BRIDGE_logError("Failed to add inverse kinematic ROP solver for manipulator %s to manager!",
+                            group_name.c_str());
+    return false;
   }
 
-  const std::vector<std::string>& manip_joints = manip_ik_solver->getJointNames();
-  tesseract_scene_graph::JointGroup joint_group = positioner_fk_solver->getJointNames();
-  joint_group.insert(joint_group.end(), manip_joints.begin(), manip_joints.end());
-  return registerDefaultJointSolver(group_name, joint_group);
+  // Automatically set ROP Inverse Kinematics as the default for the manipulator
+  setDefaultInvKinematicSolver(solver->getName(), solver->getSolverName());
+
+  return true;
 }
 
 bool ManipulatorManager::registerREPSolver(const std::string& group_name,
                                            const tesseract_scene_graph::REPKinematicParameters& rep_group)
 {
+  tesseract_kinematics::ForwardKinematics::Ptr fwd_kin = getFwdKinematicSolver(group_name);
+  if (fwd_kin == nullptr)
+  {
+    CONSOLE_BRIDGE_logError("Failed to add inverse kinematic REP solver for manipulator %s to manager!",
+                            group_name.c_str());
+    return false;
+  }
+
   tesseract_kinematics::InverseKinematics::Ptr manip_ik_solver =
       getInvKinematicSolver(rep_group.manipulator_group, rep_group.manipulator_ik_solver);
 
@@ -847,36 +873,27 @@ bool ManipulatorManager::registerREPSolver(const std::string& group_name,
     positioner_sample_resolution(static_cast<long>(i)) = it->second;
   }
 
-  auto rep_inv_kin = std::make_shared<tesseract_kinematics::RobotWithExternalPositionerInvKin>();
-  if (!rep_inv_kin->init(scene_graph_,
-                         manip_ik_solver,
-                         rep_group.manipulator_reach,
-                         positioner_fk_solver,
-                         positioner_sample_resolution,
-                         env_->getCurrentState()->link_transforms,
-                         group_name))
+  auto solver = std::make_shared<tesseract_kinematics::RobotWithExternalPositionerInvKin>();
+  if (!solver->init(scene_graph_,
+                    manip_ik_solver,
+                    rep_group.manipulator_reach,
+                    positioner_fk_solver,
+                    positioner_sample_resolution,
+                    env_->getCurrentState()->link_transforms,
+                    group_name))
     return false;
 
-  if (!addInvKinematicSolver(rep_inv_kin))
-    return false;
-
-  const tesseract_scene_graph::ChainGroups& chain_groups = srdf_model_->getChainGroups();
-  // If both are chains then create a chain forward kinematics object for the group otherwise use joint list
-  if (chain_groups.find(rep_group.manipulator_group) != chain_groups.end() &&
-      chain_groups.find(rep_group.positioner_group) != chain_groups.end())
+  if (!addInvKinematicSolver(solver))
   {
-    tesseract_scene_graph::ChainGroup chain_group;
-    chain_group.push_back(
-        std::make_pair(positioner_fk_solver->getTipLinkName(), positioner_fk_solver->getBaseLinkName()));
-    chain_group.push_back(std::make_pair(manip_ik_solver->getBaseLinkName(), manip_ik_solver->getTipLinkName()));
-
-    return registerDefaultChainSolver(group_name, chain_group);
+    CONSOLE_BRIDGE_logError("Failed to add inverse kinematic REP solver for manipulator %s to manager!",
+                            group_name.c_str());
+    return false;
   }
 
-  const std::vector<std::string>& manip_joints = manip_ik_solver->getJointNames();
-  tesseract_scene_graph::JointGroup joint_group = positioner_fk_solver->getJointNames();
-  joint_group.insert(joint_group.end(), manip_joints.begin(), manip_joints.end());
-  return registerDefaultJointSolver(group_name, joint_group);
+  // Automatically set ROP Inverse Kinematics as the default for the manipulator
+  setDefaultInvKinematicSolver(solver->getName(), solver->getSolverName());
+
+  return true;
 }
 
 }  // namespace tesseract

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/ikfast_inv_kin.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/ikfast_inv_kin.h
@@ -110,7 +110,7 @@ public:
   const std::vector<std::string>& getJointNames() const override;
   const std::vector<std::string>& getLinkNames() const override;
   const std::vector<std::string>& getActiveLinkNames() const;
-  const KinematicLimits& getLimits() const override;
+  const tesseract_common::KinematicLimits& getLimits() const override;
   const std::string& getBaseLinkName() const override;
   const std::string& getTipLinkName() const override;
   const std::string& getName() const override;
@@ -127,13 +127,13 @@ public:
    * @param joint_limits The joint limits for the kinematic chain
    * @return True if successful
    */
-  bool init(const std::string name,
-            const std::string base_link_name,
-            const std::string tip_link_name,
-            const std::vector<std::string> joint_names,
-            const std::vector<std::string> link_names,
-            const std::vector<std::string> active_link_names,
-            const Eigen::MatrixX2d& joint_limits);
+  bool init(std::string name,
+            std::string base_link_name,
+            std::string tip_link_name,
+            std::vector<std::string> joint_names,
+            std::vector<std::string> link_names,
+            std::vector<std::string> active_link_names,
+            tesseract_common::KinematicLimits limits);
 
   /**
    * @brief Checks if kinematics has been initialized
@@ -145,7 +145,7 @@ protected:
   bool initialized_ = false;                   /**< @brief Identifies if the object has been initialized */
   std::string base_link_name_;                 /**< @brief Kinematic base link name */
   std::string tip_link_name_;                  /**< @brief Kinematic tip link name */
-  Eigen::MatrixX2d joint_limits_;              /**< @brief Joint Limits */
+  tesseract_common::KinematicLimits limits_;   /**< @brief Limits */
   std::vector<std::string> joint_names_;       /**< @brief joint names */
   std::vector<std::string> link_names_;        /**< @brief link names */
   std::vector<std::string> active_link_names_; /**< @brief active link names */

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
@@ -98,11 +98,11 @@ bool IKFastInvKin::calcInvKin(Eigen::VectorXd& solutions,
       harmonizeTowardZero<double>(sol, ikfast_dof);  // Modifies 'sol' in place
 
       // Add solution
-      if (isWithinLimits<double>(Eigen::Map<Eigen::VectorXd>(sol, ikfast_dof), joint_limits_))
+      if (isWithinLimits<double>(Eigen::Map<Eigen::VectorXd>(sol, ikfast_dof), limits_.joint_limits))
         solution_set.insert(end(solution_set), sol, sol + ikfast_dof);
 
       // Add redundant solutions
-      std::vector<double> redundant_sols = getRedundantSolutions(sol, joint_limits_);
+      std::vector<double> redundant_sols = getRedundantSolutions(sol, limits_.joint_limits);
       if (!redundant_sols.empty())
       {
         int num_sol = redundant_sols.size() / ikfast_dof;
@@ -139,7 +139,7 @@ bool IKFastInvKin::checkJoints(const Eigen::Ref<const Eigen::VectorXd>& vec) con
     return false;
   }
 
-  if (!isWithinLimits<double>(vec, joint_limits_))
+  if (!isWithinLimits<double>(vec, limits_.joint_limits))
     return false;
 
   return true;
@@ -147,13 +147,13 @@ bool IKFastInvKin::checkJoints(const Eigen::Ref<const Eigen::VectorXd>& vec) con
 
 unsigned int IKFastInvKin::numJoints() const { return GetNumJoints(); }
 
-bool IKFastInvKin::init(const std::string name,
-                        const std::string base_link_name,
-                        const std::string tip_link_name,
-                        const std::vector<std::string> joint_names,
-                        const std::vector<std::string> link_names,
-                        const std::vector<std::string> active_link_names,
-                        const Eigen::MatrixX2d& joint_limits)
+bool IKFastInvKin::init(std::string name,
+                        std::string base_link_name,
+                        std::string tip_link_name,
+                        std::vector<std::string> joint_names,
+                        std::vector<std::string> link_names,
+                        std::vector<std::string> active_link_names,
+                        tesseract_common::KinematicLimits limits)
 {
   name_ = std::move(name);
   base_link_name_ = std::move(base_link_name);
@@ -161,7 +161,7 @@ bool IKFastInvKin::init(const std::string name,
   joint_names_ = std::move(joint_names);
   link_names_ = std::move(link_names);
   active_link_names_ = std::move(active_link_names);
-  joint_limits_ = joint_limits;
+  limits_ = limits;
   initialized_ = true;
 
   return initialized_;
@@ -177,7 +177,7 @@ bool IKFastInvKin::init(const IKFastInvKin& kin)
   joint_names_ = kin.joint_names_;
   link_names_ = kin.link_names_;
   active_link_names_ = kin.active_link_names_;
-  joint_limits_ = kin.joint_limits_;
+  limits_ = kin.limits_;
 
   return initialized_;
 }
@@ -185,7 +185,7 @@ bool IKFastInvKin::init(const IKFastInvKin& kin)
 const std::vector<std::string>& IKFastInvKin::getJointNames() const { return joint_names_; }
 const std::vector<std::string>& IKFastInvKin::getLinkNames() const { return link_names_; }
 const std::vector<std::string>& IKFastInvKin::getActiveLinkNames() const { return active_link_names_; }
-const Eigen::MatrixX2d& IKFastInvKin::getLimits() const { return joint_limits_; }
+const tesseract_common::KinematicLimits& IKFastInvKin::getLimits() const { return limits_; }
 const std::string& IKFastInvKin::getBaseLinkName() const { return base_link_name_; }
 const std::string& IKFastInvKin::getTipLinkName() const { return tip_link_name_; }
 const std::string& IKFastInvKin::getName() const { return name_; }

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
@@ -153,7 +153,7 @@ public:
 
   tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const
   {
-    Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+    Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
     tinyxml2::XMLElement* xml_waypoint = doc.NewElement("Waypoint");
     xml_waypoint->SetAttribute("type", std::to_string(getType()).c_str());
 

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
@@ -104,7 +104,7 @@ public:
 
   tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const
   {
-    Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+    Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
     tinyxml2::XMLElement* xml_waypoint = doc.NewElement("Waypoint");
     xml_waypoint->SetAttribute("type", std::to_string(getType()).c_str());
 

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/manipulator_info.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/manipulator_info.h
@@ -31,7 +31,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <vector>
 #include <Eigen/Geometry>
 #include <tinyxml2.h>
-#include <boost/algorithm/string.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/core/waypoint.h>
@@ -40,11 +39,69 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
+/** @brief Manipulator Info Tool Center Point Definition */
+class ToolCenterPoint
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ToolCenterPoint() = default;
+
+  /**
+   * @brief Tool Center Point Defined by name
+   * @param name The tool center point name
+   */
+  ToolCenterPoint(const std::string& name);
+
+  /**
+   * @brief Tool Center Point Defined by transform
+   * @param transform The tool center point transform
+   */
+  ToolCenterPoint(const Eigen::Isometry3d& transform);
+
+  /**
+   * @brief The Tool Center Point is empty
+   * @return True if empty otherwise false
+   */
+  bool empty() const;
+
+  /**
+   * @brief Check if tool center point is defined by name
+   * @return True if constructed with name otherwise false
+   */
+  bool isString() const;
+
+  /**
+   * @brief Check if tool center point is defined by transform
+   * @return True if constructed with transform otherwise false
+   */
+  bool isTransform() const;
+
+  /**
+   * @brief Get the tool center point name
+   * @return Name
+   */
+  const std::string& getString() const;
+
+  /**
+   * @brief Get the tool center point transform
+   * @return Transform
+   */
+  const Eigen::Isometry3d& getTransform() const;
+
+protected:
+  int type_{ 0 };
+  std::string name_;
+  Eigen::Isometry3d transform_;
+};
+
 /**
  * @brief Contains information about a robot manipulator
  */
 struct ManipulatorInfo
 {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   ManipulatorInfo() = default;
   ManipulatorInfo(std::string manipulator);
   ManipulatorInfo(const tinyxml2::XMLElement& xml_element);
@@ -55,18 +112,26 @@ struct ManipulatorInfo
   /** @brief (Optional) IK Solver to be used */
   std::string manipulator_ik_solver;
 
-  /** @brief (Optional) The tool center point */
-  Eigen::Isometry3d tcp{ Eigen::Isometry3d::Identity() };
+  /** @brief (Optional) The tool center point, if of type bool it is empty */
+  ToolCenterPoint tcp;
 
   /** @brief (Optional) The working frame to which waypoints are relative. If empty the base link of the environment is
    * used*/
   std::string working_frame;
 
   /**
-   * @brief Returns true if required members are filled out
-   * @return Returns true if required members are filled out
+   * @brief If the provided manipulator information member is not empty it will override this and return a
+   * new manipualtor information with the combined results
+   * @param manip_info_override The manipulator information to check for overrides
+   * @return The combined manipulator information
    */
-  bool isEmpty() const;
+  ManipulatorInfo getCombined(const ManipulatorInfo& manip_info_override) const;
+
+  /**
+   * @brief Check if any data is current being stored
+   * @return True if empty otherwise false
+   */
+  bool empty() const;
 
   tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const;
 };

--- a/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
@@ -96,7 +96,7 @@ tinyxml2::XMLElement* CompositeInstruction::toXML(tinyxml2::XMLDocument& doc) co
   xml_profile->SetText(getProfile().c_str());
   xml_composite_instruction->InsertEndChild(xml_profile);
 
-  if (!getManipulatorInfo().isEmpty())
+  if (!getManipulatorInfo().empty())
   {
     tinyxml2::XMLElement* xml_manip_info = getManipulatorInfo().toXML(doc);
     xml_composite_instruction->InsertEndChild(xml_manip_info);

--- a/tesseract/tesseract_planning/tesseract_command_language/src/manipulator_info.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/manipulator_info.cpp
@@ -28,6 +28,7 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <stdexcept>
 #include <iostream>
+#include <boost/algorithm/string.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/manipulator_info.h>
@@ -35,6 +36,25 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
+ToolCenterPoint::ToolCenterPoint(const std::string& name) : type_(1), name_(name) {}
+
+ToolCenterPoint::ToolCenterPoint(const Eigen::Isometry3d& transform) : type_(2), transform_(transform) {}
+
+bool ToolCenterPoint::empty() const { return (type_ == 0); }
+bool ToolCenterPoint::isString() const { return (type_ == 1); }
+bool ToolCenterPoint::isTransform() const { return (type_ == 2); }
+
+const std::string& ToolCenterPoint::getString() const
+{
+  assert(type_ == 1);
+  return name_;
+}
+const Eigen::Isometry3d& ToolCenterPoint::getTransform() const
+{
+  assert(type_ == 2);
+  return transform_;
+}
+
 ManipulatorInfo::ManipulatorInfo(std::string manipulator) : manipulator(std::move(manipulator)) {}
 ManipulatorInfo::ManipulatorInfo(const tinyxml2::XMLElement& xml_element)
 {
@@ -67,92 +87,140 @@ ManipulatorInfo::ManipulatorInfo(const tinyxml2::XMLElement& xml_element)
   if (tcp_element != nullptr)
   {
     if (tcp_element->Attribute("xyz") == nullptr && tcp_element->Attribute("rpy") == nullptr &&
-        tcp_element->Attribute("wxyz") == nullptr)
+        tcp_element->Attribute("wxyz") == nullptr && tcp_element->Attribute("name") == nullptr)
       throw std::runtime_error("ManipulatorInfo: TCP Missing Required Attributes");
 
-    std::string xyz_string, rpy_string, wxyz_string;
-    tinyxml2::XMLError status = tesseract_common::QueryStringAttribute(tcp_element, "xyz", xyz_string);
-    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-      throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute xyz.");
-
-    if (status != tinyxml2::XML_NO_ATTRIBUTE)
+    if (tcp_element->Attribute("name") == nullptr)
     {
-      std::vector<std::string> tokens;
-      boost::split(tokens, xyz_string, boost::is_any_of(" "), boost::token_compress_on);
-      if (tokens.size() != 3 || !tesseract_common::isNumeric(tokens))
-        throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute xyz string.");
-
-      double x{ 0 }, y{ 0 }, z{ 0 };
-      // No need to check return values because the tokens are verified above
-      tesseract_common::toNumeric<double>(tokens[0], x);
-      tesseract_common::toNumeric<double>(tokens[1], y);
-      tesseract_common::toNumeric<double>(tokens[2], z);
-
-      tcp.translation() = Eigen::Vector3d(x, y, z);
-    }
-
-    if (tcp_element->Attribute("wxyz") == nullptr)
-    {
-      status = tesseract_common::QueryStringAttribute(tcp_element, "rpy", rpy_string);
+      Eigen::Isometry3d local_tcp{ Eigen::Isometry3d::Identity() };
+      std::string xyz_string, rpy_string, wxyz_string;
+      tinyxml2::XMLError status = tesseract_common::QueryStringAttribute(tcp_element, "xyz", xyz_string);
       if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-        throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute rpy.");
+        throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute xyz.");
 
       if (status != tinyxml2::XML_NO_ATTRIBUTE)
       {
         std::vector<std::string> tokens;
-        boost::split(tokens, rpy_string, boost::is_any_of(" "), boost::token_compress_on);
+        boost::split(tokens, xyz_string, boost::is_any_of(" "), boost::token_compress_on);
         if (tokens.size() != 3 || !tesseract_common::isNumeric(tokens))
-          throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute rpy string.");
+          throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute xyz string.");
 
-        double r{ 0 }, p{ 0 }, y{ 0 };
+        double x{ 0 }, y{ 0 }, z{ 0 };
         // No need to check return values because the tokens are verified above
-        tesseract_common::toNumeric<double>(tokens[0], r);
-        tesseract_common::toNumeric<double>(tokens[1], p);
-        tesseract_common::toNumeric<double>(tokens[2], y);
+        tesseract_common::toNumeric<double>(tokens[0], x);
+        tesseract_common::toNumeric<double>(tokens[1], y);
+        tesseract_common::toNumeric<double>(tokens[2], z);
 
-        Eigen::AngleAxisd rollAngle(r, Eigen::Vector3d::UnitX());
-        Eigen::AngleAxisd pitchAngle(p, Eigen::Vector3d::UnitY());
-        Eigen::AngleAxisd yawAngle(y, Eigen::Vector3d::UnitZ());
-
-        Eigen::Quaterniond rpy = yawAngle * pitchAngle * rollAngle;
-
-        tcp.linear() = rpy.toRotationMatrix();
+        local_tcp.translation() = Eigen::Vector3d(x, y, z);
       }
+
+      if (tcp_element->Attribute("wxyz") == nullptr)
+      {
+        status = tesseract_common::QueryStringAttribute(tcp_element, "rpy", rpy_string);
+        if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+          throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute rpy.");
+
+        if (status != tinyxml2::XML_NO_ATTRIBUTE)
+        {
+          std::vector<std::string> tokens;
+          boost::split(tokens, rpy_string, boost::is_any_of(" "), boost::token_compress_on);
+          if (tokens.size() != 3 || !tesseract_common::isNumeric(tokens))
+            throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute rpy string.");
+
+          double r{ 0 }, p{ 0 }, y{ 0 };
+          // No need to check return values because the tokens are verified above
+          tesseract_common::toNumeric<double>(tokens[0], r);
+          tesseract_common::toNumeric<double>(tokens[1], p);
+          tesseract_common::toNumeric<double>(tokens[2], y);
+
+          Eigen::AngleAxisd rollAngle(r, Eigen::Vector3d::UnitX());
+          Eigen::AngleAxisd pitchAngle(p, Eigen::Vector3d::UnitY());
+          Eigen::AngleAxisd yawAngle(y, Eigen::Vector3d::UnitZ());
+
+          Eigen::Quaterniond rpy = yawAngle * pitchAngle * rollAngle;
+
+          local_tcp.linear() = rpy.toRotationMatrix();
+        }
+      }
+      else
+      {
+        status = tesseract_common::QueryStringAttribute(tcp_element, "wxyz", wxyz_string);
+        if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+          throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute wxyz.");
+
+        if (status != tinyxml2::XML_NO_ATTRIBUTE)
+        {
+          std::vector<std::string> tokens;
+          boost::split(tokens, wxyz_string, boost::is_any_of(" "), boost::token_compress_on);
+          if (tokens.size() != 4 || !tesseract_common::isNumeric(tokens))
+            throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute wxyz string.");
+
+          double qw{ 0 }, qx{ 0 }, qy{ 0 }, qz{ 0 };
+          // No need to check return values because the tokens are verified above
+          tesseract_common::toNumeric<double>(tokens[0], qw);
+          tesseract_common::toNumeric<double>(tokens[1], qx);
+          tesseract_common::toNumeric<double>(tokens[2], qy);
+          tesseract_common::toNumeric<double>(tokens[3], qz);
+
+          Eigen::Quaterniond q(qw, qx, qy, qz);
+          q.normalize();
+
+          local_tcp.linear() = q.toRotationMatrix();
+        }
+      }
+      tcp = local_tcp;
     }
     else
     {
-      status = tesseract_common::QueryStringAttribute(tcp_element, "wxyz", wxyz_string);
-      if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-        throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute wxyz.");
+      std::string tcp_name;
+      tinyxml2::XMLError status = tesseract_common::QueryStringAttribute(tcp_element, "name", tcp_name);
+      if (status != tinyxml2::XML_SUCCESS)
+        throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute name.");
 
-      if (status != tinyxml2::XML_NO_ATTRIBUTE)
-      {
-        std::vector<std::string> tokens;
-        boost::split(tokens, wxyz_string, boost::is_any_of(" "), boost::token_compress_on);
-        if (tokens.size() != 4 || !tesseract_common::isNumeric(tokens))
-          throw std::runtime_error("ManipulatorInfo: Error parsing TCP attribute wxyz string.");
-
-        double qw{ 0 }, qx{ 0 }, qy{ 0 }, qz{ 0 };
-        // No need to check return values because the tokens are verified above
-        tesseract_common::toNumeric<double>(tokens[0], qw);
-        tesseract_common::toNumeric<double>(tokens[1], qx);
-        tesseract_common::toNumeric<double>(tokens[2], qy);
-        tesseract_common::toNumeric<double>(tokens[3], qz);
-
-        Eigen::Quaterniond q(qw, qx, qy, qz);
-        q.normalize();
-
-        tcp.linear() = q.toRotationMatrix();
-      }
+      tcp = tcp_name;
     }
   }
 }
 
-bool ManipulatorInfo::isEmpty() const { return manipulator.empty(); }
+ManipulatorInfo ManipulatorInfo::getCombined(const ManipulatorInfo& manip_info_override) const
+{
+  ManipulatorInfo combined = *this;
+
+  if (!manip_info_override.manipulator.empty())
+    combined.manipulator = manip_info_override.manipulator;
+
+  if (!manip_info_override.manipulator_ik_solver.empty())
+    combined.manipulator_ik_solver = manip_info_override.manipulator_ik_solver;
+
+  if (!manip_info_override.working_frame.empty())
+    combined.working_frame = manip_info_override.working_frame;
+
+  if (!manip_info_override.tcp.empty())
+    combined.tcp = manip_info_override.tcp;
+
+  return combined;
+}
+
+bool ManipulatorInfo::empty() const
+{
+  if (!manipulator.empty())
+    return false;
+
+  if (!manipulator_ik_solver.empty())
+    return false;
+
+  if (!working_frame.empty())
+    return false;
+
+  if (!tcp.empty())
+    return false;
+
+  return true;
+}
 
 tinyxml2::XMLElement* ManipulatorInfo::toXML(tinyxml2::XMLDocument& doc) const
 {
-  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
   tinyxml2::XMLElement* xml_manip_info = doc.NewElement("ManipulatorInfo");
 
   tinyxml2::XMLElement* xml_manipulator = doc.NewElement("Manipulator");
@@ -167,17 +235,27 @@ tinyxml2::XMLElement* ManipulatorInfo::toXML(tinyxml2::XMLDocument& doc) const
   xml_working_frame->SetText(working_frame.c_str());
   xml_manip_info->InsertEndChild(xml_working_frame);
 
-  tinyxml2::XMLElement* xml_tcp = doc.NewElement("TCP");
-  std::stringstream xyz_string;
-  xyz_string << tcp.translation().format(eigen_format);
-  xml_tcp->SetAttribute("xyz", xyz_string.str().c_str());
+  if (tcp.isString())
+  {
+    tinyxml2::XMLElement* xml_tcp = doc.NewElement("TCP");
+    xml_tcp->SetAttribute("name", tcp.getString().c_str());
+    xml_manip_info->InsertEndChild(xml_tcp);
+  }
+  else if (tcp.isTransform())
+  {
+    const Eigen::Isometry3d& local_tcp = tcp.getTransform();
+    tinyxml2::XMLElement* xml_tcp = doc.NewElement("TCP");
+    std::stringstream xyz_string;
+    xyz_string << local_tcp.translation().format(eigen_format);
+    xml_tcp->SetAttribute("xyz", xyz_string.str().c_str());
 
-  std::stringstream wxyz_string;
-  Eigen::Quaterniond q(tcp.linear());
-  wxyz_string << Eigen::Vector4d(q.w(), q.x(), q.y(), q.z()).format(eigen_format);
+    std::stringstream wxyz_string;
+    Eigen::Quaterniond q(local_tcp.linear());
+    wxyz_string << Eigen::Vector4d(q.w(), q.x(), q.y(), q.z()).format(eigen_format);
 
-  xml_tcp->SetAttribute("wxyz", wxyz_string.str().c_str());
-  xml_manip_info->InsertEndChild(xml_tcp);
+    xml_tcp->SetAttribute("wxyz", wxyz_string.str().c_str());
+    xml_manip_info->InsertEndChild(xml_tcp);
+  }
 
   return xml_manip_info;
 }

--- a/tesseract/tesseract_planning/tesseract_command_language/src/move_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/move_instruction.cpp
@@ -101,7 +101,7 @@ tinyxml2::XMLElement* MoveInstruction::toXML(tinyxml2::XMLDocument& doc) const
   xml_profile->SetText(getProfile().c_str());
   xml_move_instruction->InsertEndChild(xml_profile);
 
-  if (!getManipulatorInfo().isEmpty())
+  if (!getManipulatorInfo().empty())
   {
     tinyxml2::XMLElement* xml_manip_info = getManipulatorInfo().toXML(doc);
     xml_move_instruction->InsertEndChild(xml_manip_info);

--- a/tesseract/tesseract_planning/tesseract_command_language/src/plan_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/plan_instruction.cpp
@@ -92,7 +92,7 @@ tinyxml2::XMLElement* PlanInstruction::toXML(tinyxml2::XMLDocument& doc) const
   xml_profile->SetText(getProfile().c_str());
   xml_plan_instruction->InsertEndChild(xml_profile);
 
-  if (!getManipulatorInfo().isEmpty())
+  if (!getManipulatorInfo().empty())
   {
     tinyxml2::XMLElement* xml_manip_info = getManipulatorInfo().toXML(doc);
     xml_plan_instruction->InsertEndChild(xml_manip_info);

--- a/tesseract/tesseract_planning/tesseract_command_language/src/serialize.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/serialize.cpp
@@ -38,7 +38,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/command_language.h>
 
 static const std::array<int, 3> VERSION{ { 1, 0, 0 } };
-static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
 
 namespace tesseract_planning
 {

--- a/tesseract/tesseract_planning/tesseract_command_language/src/state_waypoint.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/state_waypoint.cpp
@@ -140,7 +140,7 @@ int StateWaypoint::getType() const { return static_cast<int>(WaypointType::STATE
 
 tinyxml2::XMLElement* StateWaypoint::toXML(tinyxml2::XMLDocument& doc) const
 {
-  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
   tinyxml2::XMLElement* xml_waypoint = doc.NewElement("Waypoint");
   xml_waypoint->SetAttribute("type", std::to_string(getType()).c_str());
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/examples/freespace_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/examples/freespace_example.cpp
@@ -102,31 +102,6 @@ int main(int /*argc*/, char** /*argv*/)
   manip.manipulator = "manipulator";
   manip.manipulator_ik_solver = "OPWInvKin";
 
-  opw_kinematics::Parameters<double> opw_params;
-  opw_params.a1 = (0.100);
-  opw_params.a2 = (-0.135);
-  opw_params.b = (0.000);
-  opw_params.c1 = (0.615);
-  opw_params.c2 = (0.705);
-  opw_params.c3 = (0.755);
-  opw_params.c4 = (0.085);
-
-  opw_params.offsets[2] = -M_PI / 2.0;
-
-  auto robot_kin = tesseract->getManipulatorManager()->getFwdKinematicSolver(manip.manipulator);
-  auto opw_kin = std::make_shared<tesseract_kinematics::OPWInvKin>();
-  opw_kin->init(manip.manipulator,
-                opw_params,
-                robot_kin->getBaseLinkName(),
-                robot_kin->getTipLinkName(),
-                robot_kin->getJointNames(),
-                robot_kin->getLinkNames(),
-                robot_kin->getActiveLinkNames(),
-                robot_kin->getLimits());
-
-  tesseract->getManipulatorManager()->addInvKinematicSolver(opw_kin);
-  tesseract->getManipulatorManager()->setDefaultInvKinematicSolver(manip.manipulator, opw_kin->getSolverName());
-
   auto fwd_kin = tesseract->getManipulatorManager()->getFwdKinematicSolver(manip.manipulator);
   auto inv_kin = tesseract->getManipulatorManager()->getInvKinematicSolver(manip.manipulator);
   auto cur_state = tesseract->getEnvironment()->getCurrentState();

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
@@ -33,6 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract/tesseract.h>
 #include <tesseract_environment/core/environment.h>
 #include <tesseract_environment/core/types.h>
 #include <tesseract_environment/core/utils.h>

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/profile/descartes_default_plan_profile.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/profile/descartes_default_plan_profile.hpp
@@ -165,9 +165,9 @@ void DescartesDefaultPlanProfile<FloatType>::apply(DescartesProblem<FloatType>& 
 {
   assert(isPlanInstruction(parent_instruction));
   const auto* base_instruction = parent_instruction.cast_const<PlanInstruction>();
-  assert(!(manip_info.isEmpty() && base_instruction->getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction->getManipulatorInfo().isEmpty()) ? manip_info : base_instruction->getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction->getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction->getManipulatorInfo());
+  Eigen::Isometry3d tcp = prob.tesseract->findTCP(mi);
 
   /* Check if this cartesian waypoint is dynamic
    * (i.e. defined relative to a frame that will move with the kinematic chain) */
@@ -197,7 +197,7 @@ void DescartesDefaultPlanProfile<FloatType>::apply(DescartesProblem<FloatType>& 
   }
 
   auto sampler = std::make_shared<DescartesRobotSampler<FloatType>>(
-      manip_baselink_to_waypoint, target_pose_sampler, prob.manip_inv_kin, ci, mi.tcp, allow_collision, is_valid);
+      manip_baselink_to_waypoint, target_pose_sampler, prob.manip_inv_kin, ci, tcp, allow_collision, is_valid);
   prob.samplers.push_back(std::move(sampler));
 
   if (index != 0)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/profile/simple_planner_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/profile/simple_planner_default_plan_profile.h
@@ -37,7 +37,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-class SimplePlannerDefaultPlanProfile : public SimplePlannerPlanProfile
+class DEPRECATED("Please use SimplePlannerLVSDefaultPlanProfile") SimplePlannerDefaultPlanProfile
+  : public SimplePlannerPlanProfile
 {
 public:
   using Ptr = std::shared_ptr<SimplePlannerDefaultPlanProfile>;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/descartes/serialize.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/descartes/serialize.cpp
@@ -37,7 +37,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/descartes/serialize.h>
 
 static const std::array<int, 3> VERSION{ { 1, 0, 0 } };
-static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
 
 namespace tesseract_planning
 {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
@@ -60,17 +60,16 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& nam
   tesseract_kinematics::InverseKinematics::Ptr manip_inv_kin_;
 
   // Assume all the plan instructions have the same manipulator as the composite
-  assert(!request.instructions.getManipulatorInfo().isEmpty());
-  const ManipulatorInfo& composite_mi = request.instructions.getManipulatorInfo();
-  const std::string& manipulator = composite_mi.manipulator;
-  const std::string& manipulator_ik_solver = composite_mi.manipulator_ik_solver;
+  assert(!request.instructions.getManipulatorInfo().empty());
 
-  manip_fwd_kin_ = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(manipulator);
-  if (manipulator_ik_solver.empty())
-    manip_inv_kin_ = request.tesseract->getManipulatorManager()->getInvKinematicSolver(manipulator);
+  const ManipulatorInfo& composite_mi = request.instructions.getManipulatorInfo();
+
+  manip_fwd_kin_ = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(composite_mi.manipulator);
+  if (composite_mi.manipulator_ik_solver.empty())
+    manip_inv_kin_ = request.tesseract->getManipulatorManager()->getInvKinematicSolver(composite_mi.manipulator);
   else
-    manip_inv_kin_ =
-        request.tesseract->getManipulatorManager()->getInvKinematicSolver(manipulator, manipulator_ik_solver);
+    manip_inv_kin_ = request.tesseract->getManipulatorManager()->getInvKinematicSolver(
+        composite_mi.manipulator, composite_mi.manipulator_ik_solver);
   if (!manip_fwd_kin_)
   {
     CONSOLE_BRIDGE_logError("No Forward Kinematics solver found");

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/serialize.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/serialize.cpp
@@ -37,7 +37,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/ompl/serialize.h>
 
 static const std::array<int, 3> VERSION{ { 1, 0, 0 } };
-static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
 
 namespace tesseract_planning
 {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/fixed_size_assign_position.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/fixed_size_assign_position.cpp
@@ -43,9 +43,8 @@ CompositeInstruction fixedSizeAssignJointPosition(const Eigen::Ref<const Eigen::
                                                   const ManipulatorInfo& manip_info,
                                                   int steps)
 {
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Get Kinematics Object
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
@@ -65,6 +64,7 @@ CompositeInstruction fixedSizeAssignJointPosition(const Eigen::Ref<const Eigen::
   for (int i = 1; i <= steps; ++i)
   {
     MoveInstruction move_instruction(StateWaypoint(fwd_kin->getJointNames(), position), mv_type);
+    move_instruction.setManipulatorInfo(base_instruction.getManipulatorInfo());
     move_instruction.setDescription(base_instruction.getDescription());
     composite.push_back(move_instruction);
   }
@@ -105,9 +105,8 @@ CompositeInstruction fixedSizeAssignJointPosition(const CartesianWaypoint& /*sta
                                                   const ManipulatorInfo& manip_info,
                                                   int steps)
 {
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
   Eigen::VectorXd position = request.env_state->getJointValues(fwd_kin->getJointNames());
   return fixedSizeAssignJointPosition(position, base_instruction, request, manip_info, steps);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/fixed_size_interpolation.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/fixed_size_interpolation.cpp
@@ -71,9 +71,8 @@ CompositeInstruction fixedSizeJointInterpolation(const JointWaypoint& start,
                                                  const ManipulatorInfo& manip_info,
                                                  int steps)
 {
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Joint waypoints should have joint names
   assert(static_cast<long>(start.joint_names.size()) == start.size());
@@ -81,7 +80,7 @@ CompositeInstruction fixedSizeJointInterpolation(const JointWaypoint& start,
   // Initialize
   auto inv_kin = request.tesseract->getManipulatorManager()->getInvKinematicSolver(mi.manipulator);
   auto world_to_base = request.env_state->link_transforms.at(inv_kin->getBaseLinkName());
-  const Eigen::Isometry3d& tcp = mi.tcp;
+  Eigen::Isometry3d tcp = request.tesseract->findTCP(mi);
   assert(start.joint_names.size() == inv_kin->getJointNames().size());
 
   CompositeInstruction composite;
@@ -134,9 +133,8 @@ CompositeInstruction fixedSizeJointInterpolation(const CartesianWaypoint& start,
                                                  const ManipulatorInfo& manip_info,
                                                  int steps)
 {
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Joint waypoints should have joint names
   assert(static_cast<long>(end.joint_names.size()) == end.size());
@@ -144,7 +142,7 @@ CompositeInstruction fixedSizeJointInterpolation(const CartesianWaypoint& start,
   // Initialize
   auto inv_kin = request.tesseract->getManipulatorManager()->getInvKinematicSolver(mi.manipulator);
   auto world_to_base = request.env_state->link_transforms.at(inv_kin->getBaseLinkName());
-  const Eigen::Isometry3d& tcp = mi.tcp;
+  Eigen::Isometry3d tcp = request.tesseract->findTCP(mi);
   assert(end.joint_names.size() == inv_kin->getJointNames().size());
 
   CompositeInstruction composite;
@@ -198,14 +196,13 @@ CompositeInstruction fixedSizeJointInterpolation(const CartesianWaypoint& start,
                                                  const ManipulatorInfo& manip_info,
                                                  int steps)
 {
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto inv_kin = request.tesseract->getManipulatorManager()->getInvKinematicSolver(mi.manipulator);
   auto world_to_base = request.env_state->link_transforms.at(inv_kin->getBaseLinkName());
-  const Eigen::Isometry3d& tcp = mi.tcp;
+  Eigen::Isometry3d tcp = request.tesseract->findTCP(mi);
 
   CompositeInstruction composite;
 
@@ -276,14 +273,13 @@ CompositeInstruction fixedSizeCartesianInterpolation(const JointWaypoint& start,
   /// @todo: Need to create a cartesian state waypoint and update the code below
   throw std::runtime_error("Not implemented, PR's are welcome!");
 
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
   auto world_to_base = request.env_state->link_transforms.at(fwd_kin->getBaseLinkName());
-  const Eigen::Isometry3d& tcp = mi.tcp;
+  Eigen::Isometry3d tcp = request.tesseract->findTCP(mi);
 
   CompositeInstruction composite;
 
@@ -323,14 +319,13 @@ CompositeInstruction fixedSizeCartesianInterpolation(const JointWaypoint& start,
   /// @todo: Need to create a cartesian state waypoint and update the code below
   throw std::runtime_error("Not implemented, PR's are welcome!");
 
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
   auto world_to_base = request.env_state->link_transforms.at(fwd_kin->getBaseLinkName());
-  const Eigen::Isometry3d& tcp = mi.tcp;
+  Eigen::Isometry3d tcp = request.tesseract->findTCP(mi);
 
   CompositeInstruction composite;
 
@@ -367,14 +362,13 @@ CompositeInstruction fixedSizeCartesianInterpolation(const CartesianWaypoint& st
   /// @todo: Need to create a cartesian state waypoint and update the code below
   throw std::runtime_error("Not implemented, PR's are welcome!");
 
-  assert(!(manip_info.isEmpty() && base_instruction.getManipulatorInfo().isEmpty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().isEmpty()) ? manip_info : base_instruction.getManipulatorInfo();
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
   auto world_to_base = request.env_state->link_transforms.at(fwd_kin->getBaseLinkName());
-  const Eigen::Isometry3d& tcp = mi.tcp;
+  Eigen::Isometry3d tcp = request.tesseract->findTCP(mi);
 
   CompositeInstruction composite;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/profile/trajopt_default_composite_profile.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/profile/trajopt_default_composite_profile.cpp
@@ -221,7 +221,7 @@ void TrajOptDefaultCompositeProfile::apply(trajopt::ProblemConstructionInfo& pci
 
 tinyxml2::XMLElement* TrajOptDefaultCompositeProfile::toXML(tinyxml2::XMLDocument& doc) const
 {
-  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
 
   tinyxml2::XMLElement* xml_planner = doc.NewElement("Planner");
   xml_planner->SetAttribute("type", std::to_string(1).c_str());

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/serialize.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/serialize.cpp
@@ -37,7 +37,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/trajopt/serialize.h>
 
 static const std::array<int, 3> VERSION{ { 1, 0, 0 } };
-static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, 0, " ", " ");
+static const Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
 
 namespace tesseract_planning
 {

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_manager_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_manager_example.cpp
@@ -102,7 +102,7 @@ int main()
   if (plotter)
   {
     plotter->waitForInput();
-    plotter->plotTrajectory(*(input.results));
+    plotter->plotTrajectory(*(input.getResults()));
   }
 
   std::cout << "Execution Complete" << std::endl;

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_manager_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_manager_example.cpp
@@ -109,7 +109,7 @@ int main()
   if (plotter)
   {
     plotter->waitForInput();
-    plotter->plotTrajectory(*(input.results));
+    plotter->plotTrajectory(*(input.getResults()));
   }
 
   std::cout << "Execution Complete" << std::endl;

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h
@@ -29,7 +29,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <vector>
 #include <atomic>
-#include <limits>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_process_managers/process_generator.h>
@@ -69,7 +68,7 @@ private:
 
   std::string name_;
 
-  double longest_valid_segment_length_{ std::numeric_limits<double>::max() };
+  double longest_valid_segment_length_{ 0.1 };
 
   double contact_distance_{ 0 };
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h
@@ -29,7 +29,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <vector>
 #include <atomic>
-#include <limits>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_process_managers/process_generator.h>
@@ -69,7 +68,7 @@ private:
 
   std::string name_;
 
-  double longest_valid_segment_length_{ std::numeric_limits<double>::max() };
+  double longest_valid_segment_length_{ 0.1 };
 
   double contact_distance_{ 0 };
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_input.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_input.h
@@ -69,25 +69,8 @@ struct ProcessInput
 
   ProcessInput(tesseract::Tesseract::ConstPtr tesseract, const Instruction* instruction, Instruction* seed);
 
-  /**
-   * @brief Creates a sub-ProcessInput from instruction[index] and seed[index]
-   * @param index sub-Instruction used to create the ProcessInput
-   * @return A ProcessInput containing a subset of the original's instructions
-   */
-  ProcessInput operator[](std::size_t index);
-
-  /**
-   * @brief Gets the number of instructions contained in the ProcessInput
-   * @return 1 instruction if not a composite, otherwise size of the composite @todo Should this be -1, becuase
-   * composite size could be 1, 0, or other?
-   */
-  std::size_t size();
-
   /** @brief Tesseract associated with current state of the system */
   const tesseract::Tesseract::ConstPtr tesseract;
-
-  /** @brief Instructions to be carried out by process */
-  const Instruction* instruction;
 
   /** @brief Global Manipulator Information */
   const ManipulatorInfo& manip_info;
@@ -104,14 +87,61 @@ struct ProcessInput
    */
   const PlannerProfileRemapping& composite_profile_remapping;
 
-  /** @brief Results/Seed for this process */
-  Instruction* results;
+  /**
+   * @brief Creates a sub-ProcessInput from instruction[index] and seed[index]
+   * @param index sub-Instruction used to create the ProcessInput
+   * @return A ProcessInput containing a subset of the original's instructions
+   */
+  ProcessInput operator[](std::size_t index);
 
-  // These are used to store alternative start and end instructions
-  Instruction start_instruction;
-  Instruction end_instruction;
-  const Instruction* start_instruction_ptr{ nullptr };
-  const Instruction* end_instruction_ptr{ nullptr };
+  /**
+   * @brief Gets the number of instructions contained in the ProcessInput
+   * @return 1 instruction if not a composite, otherwise size of the composite @todo Should this be -1, becuase
+   * composite size could be 1, 0, or other?
+   */
+  std::size_t size();
+
+  /**
+   * @brief Get the process inputs instructions
+   * @return A const pointer to the instruction
+   */
+  const Instruction* getInstruction() const;
+
+  /**
+   * @brief Get the process inputs results instruction
+   * @return A pointer to the results instruction
+   */
+  Instruction* getResults();
+
+  void setStartInstruction(Instruction start);
+  void setStartInstruction(std::vector<std::size_t> start);
+  Instruction getStartInstruction() const;
+
+  void setEndInstruction(Instruction end);
+  void setEndInstruction(std::vector<std::size_t> end);
+  Instruction getEndInstruction() const;
+
+protected:
+  /** @brief Instructions to be carried out by process */
+  const Instruction* instruction_;
+
+  /** @brief Results/Seed for this process */
+  Instruction* results_;
+
+  /** @brief The indicies used to access this process inputs instructions and results */
+  std::vector<std::size_t> instruction_indice_;
+
+  /** @brief This proccess inputs start instruction */
+  Instruction start_instruction_{ NullInstruction() };
+
+  /** @brief Indices to the start instruction in the results data struction */
+  std::vector<std::size_t> start_instruction_indice_;
+
+  /** @brief This proccess inputs end instruction */
+  Instruction end_instruction_{ NullInstruction() };
+
+  /** @brief Indices to the end instruction in the results data struction */
+  std::vector<std::size_t> end_instruction_indice_;
 };
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_managers/raster_process_manager.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_managers/raster_process_manager.h
@@ -69,6 +69,13 @@ public:
                        TaskflowGenerator::UPtr transition_taskflow_generator,
                        TaskflowGenerator::UPtr raster_taskflow_generator,
                        std::size_t n = std::thread::hardware_concurrency());
+
+  RasterProcessManager(TaskflowGenerator::UPtr global_taskflow_generator,
+                       TaskflowGenerator::UPtr freespace_taskflow_generator,
+                       TaskflowGenerator::UPtr transition_taskflow_generator,
+                       TaskflowGenerator::UPtr raster_taskflow_generator,
+                       std::size_t n = std::thread::hardware_concurrency());
+
   ~RasterProcessManager() override = default;
   RasterProcessManager(const RasterProcessManager&) = delete;
   RasterProcessManager& operator=(const RasterProcessManager&) = delete;
@@ -88,11 +95,14 @@ private:
   void failureCallback(std::string message);
   bool success_;
 
+  TaskflowGenerator::UPtr global_taskflow_generator_;
   TaskflowGenerator::UPtr freespace_taskflow_generator_;
   TaskflowGenerator::UPtr transition_taskflow_generator_;
   TaskflowGenerator::UPtr raster_taskflow_generator_;
   tf::Executor executor_;
   tf::Taskflow taskflow_;
+
+  tf::Task global_task_;
   std::vector<tf::Task> freespace_tasks_;
   std::vector<tf::Task> transition_tasks_;
   std::vector<tf::Task> raster_tasks_;
@@ -103,6 +113,9 @@ private:
    * @return True if in the correct format
    */
   bool checkProcessInput(const ProcessInput& input) const;
+
+  bool initDefault(ProcessInput input);
+  bool initGlobal(ProcessInput input);
 };
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_managers/raster_process_manager.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_managers/raster_process_manager.h
@@ -103,9 +103,12 @@ private:
   tf::Taskflow taskflow_;
 
   tf::Task global_task_;
+  tf::Task global_post_task_;
   std::vector<tf::Task> freespace_tasks_;
   std::vector<tf::Task> transition_tasks_;
   std::vector<tf::Task> raster_tasks_;
+
+  static void globalPostProcess(ProcessInput input);
 
   /**
    * @brief Checks that the ProcessInput is in the correct format.

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/descartes_taskflow.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/descartes_taskflow.h
@@ -32,11 +32,18 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createDescartesTaskflow(
-    bool create_seed,
-    const SimplePlannerPlanProfileMap& simple_plan_profiles = SimplePlannerPlanProfileMap(),
-    const SimplePlannerCompositeProfileMap& simple_composite_profiles = SimplePlannerCompositeProfileMap(),
-    const DescartesPlanProfileMap<double>& descartes_plan_profiles = DescartesPlanProfileMap<double>());
-}
+struct DescartesTaskflowParams
+{
+  bool enable_simple_planner{ true };
+  bool enable_post_contact_discrete_check{ false };
+  bool enable_post_contact_continuous_check{ true };
+  bool enable_time_parameterization{ true };
+  SimplePlannerPlanProfileMap simple_plan_profiles;
+  SimplePlannerCompositeProfileMap simple_composite_profiles;
+  DescartesPlanProfileMap<double> descartes_plan_profiles;
+};
+
+GraphTaskflow::UPtr createDescartesTaskflow(DescartesTaskflowParams params);
+}  // namespace tesseract_planning
 
 #endif  // TESSERACT_PROCESS_MANAGERS_DESCARTES_TASKFLOW_H

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/continuous_contact_check_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/continuous_contact_check_process_generator.cpp
@@ -69,7 +69,8 @@ int ContinuousContactCheckProcessGenerator::conditionalProcess(ProcessInput inpu
   // --------------------
   // Check that inputs are valid
   // --------------------
-  if (!isCompositeInstruction(*(input.results)))
+  Instruction* input_results = input.getResults();
+  if (!isCompositeInstruction(*input_results))
   {
     CONSOLE_BRIDGE_logError("Input seed to TrajOpt Planner must be a composite instruction");
     return 0;
@@ -81,12 +82,12 @@ int ContinuousContactCheckProcessGenerator::conditionalProcess(ProcessInput inpu
       input.tesseract->getEnvironment()->getContinuousContactManager();
   manager->setContactDistanceThreshold(contact_distance_);
 
-  const auto* ci = input.results->cast_const<CompositeInstruction>();
+  const auto* ci = input_results->cast_const<CompositeInstruction>();
   std::vector<tesseract_collision::ContactResultMap> contacts;
   if (contactCheckProgram(contacts, *manager, *state_solver, *ci, longest_valid_segment_length_))
   {
     CONSOLE_BRIDGE_logInform("Results are not contact free for process input: %s!",
-                             input.instruction->getDescription().c_str());
+                             input_results->getDescription().c_str());
     for (std::size_t i = 0; i < contacts.size(); i++)
       for (const auto& contact_vec : contacts[i])
         for (const auto& contact : contact_vec.second)

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/discrete_contact_check_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/discrete_contact_check_process_generator.cpp
@@ -66,7 +66,8 @@ int DiscreteContactCheckProcessGenerator::conditionalProcess(ProcessInput input)
   // --------------------
   // Check that inputs are valid
   // --------------------
-  if (!isCompositeInstruction(*(input.results)))
+  Instruction* input_result = input.getResults();
+  if (!isCompositeInstruction(*input_result))
   {
     CONSOLE_BRIDGE_logError("Input seed to TrajOpt Planner must be a composite instruction");
     return 0;
@@ -78,12 +79,12 @@ int DiscreteContactCheckProcessGenerator::conditionalProcess(ProcessInput input)
       input.tesseract->getEnvironment()->getDiscreteContactManager();
   manager->setContactDistanceThreshold(contact_distance_);
 
-  const auto* ci = input.results->cast_const<CompositeInstruction>();
+  const auto* ci = input_result->cast_const<CompositeInstruction>();
   std::vector<tesseract_collision::ContactResultMap> contacts;
   if (contactCheckProgram(contacts, *manager, *state_solver, *ci, longest_valid_segment_length_))
   {
     CONSOLE_BRIDGE_logInform("Results are not contact free for process intput: %s !",
-                             input.instruction->getDescription().c_str());
+                             input_result->getDescription().c_str());
     for (std::size_t i = 0; i < contacts.size(); i++)
       for (const auto& contact_vec : contacts[i])
         for (const auto& contact : contact_vec.second)

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/fix_state_bounds_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/fix_state_bounds_process_generator.cpp
@@ -60,13 +60,14 @@ int FixStateBoundsProcessGenerator::conditionalProcess(ProcessInput input) const
   // --------------------
   // Check that inputs are valid
   // --------------------
-  if (!isCompositeInstruction(*(input.instruction)))
+  const Instruction* input_instruction = input.getInstruction();
+  if (!isCompositeInstruction(*input_instruction))
   {
     CONSOLE_BRIDGE_logError("Input instruction to FixStateBounds must be a composite instruction");
     return 0;
   }
 
-  auto* ci = input.instruction->cast_const<CompositeInstruction>();
+  const auto* ci = input_instruction->cast_const<CompositeInstruction>();
   const ManipulatorInfo& manip_info = input.manip_info;
   const auto fwd_kin = input.tesseract->getManipulatorManager()->getFwdKinematicSolver(manip_info.manipulator);
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/fix_state_collision_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/fix_state_collision_process_generator.cpp
@@ -225,13 +225,14 @@ int FixStateCollisionProcessGenerator::conditionalProcess(ProcessInput input) co
   // --------------------
   // Check that inputs are valid
   // --------------------
-  if (!isCompositeInstruction(*(input.instruction)))
+  const Instruction* input_intruction = input.getInstruction();
+  if (!isCompositeInstruction(*(input_intruction)))
   {
     CONSOLE_BRIDGE_logError("Input instruction to FixStateCollision must be a composite instruction");
     return 0;
   }
 
-  auto* ci = input.instruction->cast_const<CompositeInstruction>();
+  const auto* ci = input_intruction->cast_const<CompositeInstruction>();
   const ManipulatorInfo& manip_info = input.manip_info;
   const auto fwd_kin = input.tesseract->getManipulatorManager()->getFwdKinematicSolver(manip_info.manipulator);
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/iterative_spline_parameterization_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/iterative_spline_parameterization_process_generator.cpp
@@ -73,13 +73,14 @@ int IterativeSplineParameterizationProcessGenerator::conditionalProcess(ProcessI
   // --------------------
   // Check that inputs are valid
   // --------------------
-  if (!isCompositeInstruction(*(input.results)))
+  Instruction* input_results = input.getResults();
+  if (!isCompositeInstruction(*input_results))
   {
     CONSOLE_BRIDGE_logError("Input results to iterative spline parameterization must be a composite instruction");
     return 0;
   }
 
-  auto* ci = input.results->cast<CompositeInstruction>();
+  auto* ci = input_results->cast<CompositeInstruction>();
   const ManipulatorInfo& manip_info = ci->getManipulatorInfo();
   const auto fwd_kin = input.tesseract->getManipulatorManager()->getFwdKinematicSolver(manip_info.manipulator);
 
@@ -151,7 +152,7 @@ int IterativeSplineParameterizationProcessGenerator::conditionalProcess(ProcessI
                        acceleration_scaling_factors))
   {
     CONSOLE_BRIDGE_logInform("Failed to perform iterative spline time parameterization for process input: %s!",
-                             input.instruction->getDescription().c_str());
+                             input_results->getDescription().c_str());
     return 0;
   }
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/motion_planner_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/motion_planner_process_generator.cpp
@@ -73,11 +73,8 @@ int MotionPlannerProcessGenerator::conditionalProcess(ProcessInput input) const
 
   // Make a non-const copy of the input instructions to update the start/end
   CompositeInstruction instructions = *input.instruction->cast_const<CompositeInstruction>();
-  if (instructions.getManipulatorInfo().isEmpty())
-  {
-    assert(!input.manip_info.isEmpty());
-    instructions.setManipulatorInfo(input.manip_info);
-  }
+  assert(!(input.manip_info.empty() && input.manip_info.empty()));
+  instructions.setManipulatorInfo(instructions.getManipulatorInfo().getCombined(input.manip_info));
 
   // If the start and end waypoints need to be updated prior to planning
   const Instruction* start_instruction = nullptr;

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_managers/raster_waad_dt_process_manager.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_managers/raster_waad_dt_process_manager.cpp
@@ -69,51 +69,53 @@ bool RasterWAADDTProcessManager::init(ProcessInput input)
   for (std::size_t idx = 1; idx < input.size() - 1; idx += 2)
   {
     // Get the last plan instruction of the approach
-    assert(isCompositeInstruction(*(input[idx][0].instruction)));
-    const auto* aci = input[idx][0].instruction->cast_const<CompositeInstruction>();
+    assert(isCompositeInstruction(*(input[idx][0].getInstruction())));
+    const auto* aci = input[idx][0].getInstruction()->cast_const<CompositeInstruction>();
     auto* ali = getLastPlanInstruction(*aci);
     assert(ali != nullptr);
 
     // Create the process taskflow
     ProcessInput process_input = input[idx][1];
-    process_input.start_instruction = *ali;
-    auto process_step =
-        taskflow_
-            .composed_of(raster_taskflow_generator_->generateTaskflow(
-                process_input,
-                std::bind(
-                    &RasterWAADDTProcessManager::successCallback, this, process_input.instruction->getDescription()),
-                std::bind(
-                    &RasterWAADDTProcessManager::failureCallback, this, process_input.instruction->getDescription())))
-            .name("raster_" + std::to_string(idx));
+    process_input.setStartInstruction(*ali);
+    auto process_step = taskflow_
+                            .composed_of(raster_taskflow_generator_->generateTaskflow(
+                                process_input,
+                                std::bind(&RasterWAADDTProcessManager::successCallback,
+                                          this,
+                                          process_input.getInstruction()->getDescription()),
+                                std::bind(&RasterWAADDTProcessManager::failureCallback,
+                                          this,
+                                          process_input.getInstruction()->getDescription())))
+                            .name("raster_" + std::to_string(idx));
 
     // Create Departure Taskflow
     ProcessInput departure_input = input[idx][2];
-    departure_input.start_instruction_ptr = input[idx][1].results;
-    auto departure_step =
-        taskflow_
-            .composed_of(raster_taskflow_generator_->generateTaskflow(
-                departure_input,
-                std::bind(
-                    &RasterWAADDTProcessManager::successCallback, this, departure_input.instruction->getDescription()),
-                std::bind(
-                    &RasterWAADDTProcessManager::failureCallback, this, departure_input.instruction->getDescription())))
-            .name("departure_" + std::to_string(idx));
+    departure_input.setStartInstruction(std::vector<std::size_t>({ idx, 1 }));
+    auto departure_step = taskflow_
+                              .composed_of(raster_taskflow_generator_->generateTaskflow(
+                                  departure_input,
+                                  std::bind(&RasterWAADDTProcessManager::successCallback,
+                                            this,
+                                            departure_input.getInstruction()->getDescription()),
+                                  std::bind(&RasterWAADDTProcessManager::failureCallback,
+                                            this,
+                                            departure_input.getInstruction()->getDescription())))
+                              .name("departure_" + std::to_string(idx));
 
     // Get Start Plan Instruction for approach
     Instruction start_instruction = NullInstruction();
     if (idx == 1)
     {
-      assert(isCompositeInstruction(*(input[0].instruction)));
-      const auto* ci = input[0].instruction->cast_const<CompositeInstruction>();
+      assert(isCompositeInstruction(*(input[0].getInstruction())));
+      const auto* ci = input[0].getInstruction()->cast_const<CompositeInstruction>();
       const auto* li = getLastPlanInstruction(*ci);
       assert(li != nullptr);
       start_instruction = *li;
     }
     else
     {
-      assert(isCompositeInstruction(*(input[idx - 1].instruction)));
-      const auto* tci = input[idx - 1].instruction->cast_const<CompositeInstruction>();
+      assert(isCompositeInstruction(*(input[idx - 1].getInstruction())));
+      const auto* tci = input[idx - 1].getInstruction()->cast_const<CompositeInstruction>();
       auto* li = getLastPlanInstruction(*tci);
       assert(li != nullptr);
       start_instruction = *li;
@@ -122,17 +124,18 @@ bool RasterWAADDTProcessManager::init(ProcessInput input)
     // Create the departure taskflow
     start_instruction.cast<PlanInstruction>()->setPlanType(PlanInstructionType::START);
     ProcessInput approach_input = input[idx][0];
-    approach_input.start_instruction = start_instruction;
-    approach_input.end_instruction_ptr = input[idx][1].results;
-    auto approach_step =
-        taskflow_
-            .composed_of(raster_taskflow_generator_->generateTaskflow(
-                approach_input,
-                std::bind(
-                    &RasterWAADDTProcessManager::successCallback, this, approach_input.instruction->getDescription()),
-                std::bind(
-                    &RasterWAADDTProcessManager::failureCallback, this, approach_input.instruction->getDescription())))
-            .name("approach_" + std::to_string(idx));
+    approach_input.setStartInstruction(start_instruction);
+    approach_input.setEndInstruction(std::vector<std::size_t>({ idx, 1 }));
+    auto approach_step = taskflow_
+                             .composed_of(raster_taskflow_generator_->generateTaskflow(
+                                 approach_input,
+                                 std::bind(&RasterWAADDTProcessManager::successCallback,
+                                           this,
+                                           approach_input.getInstruction()->getDescription()),
+                                 std::bind(&RasterWAADDTProcessManager::failureCallback,
+                                           this,
+                                           approach_input.getInstruction()->getDescription())))
+                             .name("approach_" + std::to_string(idx));
 
     // Each approach and departure depend on raster
     approach_step.succeed(process_step);
@@ -151,17 +154,17 @@ bool RasterWAADDTProcessManager::init(ProcessInput input)
     // robust because planners could modify composite size, which is rare but does happen when using OMPL where it is
     // not possible to simplify the trajectory to the desired number of states.
     ProcessInput transition_from_end_input = input[input_idx][0];
-    transition_from_end_input.start_instruction_ptr = input[input_idx - 1][2].results;
-    transition_from_end_input.end_instruction_ptr = input[input_idx + 1][0].results;
+    transition_from_end_input.setStartInstruction(std::vector<std::size_t>({ input_idx - 1, 2 }));
+    transition_from_end_input.setEndInstruction(std::vector<std::size_t>({ input_idx + 1, 0 }));
     auto transition_from_end_step = taskflow_
                                         .composed_of(transition_taskflow_generator_->generateTaskflow(
                                             transition_from_end_input,
                                             std::bind(&RasterWAADDTProcessManager::successCallback,
                                                       this,
-                                                      transition_from_end_input.instruction->getDescription()),
+                                                      transition_from_end_input.getInstruction()->getDescription()),
                                             std::bind(&RasterWAADDTProcessManager::failureCallback,
                                                       this,
-                                                      transition_from_end_input.instruction->getDescription())))
+                                                      transition_from_end_input.getInstruction()->getDescription())))
                                         .name("transition_" + std::to_string(input_idx));
 
     // Each transition is independent and thus depends only on the adjacent rasters approach and departure
@@ -171,17 +174,17 @@ bool RasterWAADDTProcessManager::init(ProcessInput input)
     transition_tasks_.push_back(transition_from_end_step);
 
     ProcessInput transition_to_start_input = input[input_idx][1];
-    transition_to_start_input.start_instruction_ptr = input[input_idx + 1][2].results;
-    transition_to_start_input.end_instruction_ptr = input[input_idx - 1][0].results;
+    transition_to_start_input.setStartInstruction(std::vector<std::size_t>({ input_idx + 1, 2 }));
+    transition_to_start_input.setEndInstruction(std::vector<std::size_t>({ input_idx - 1, 0 }));
     auto transition_to_start_step = taskflow_
                                         .composed_of(transition_taskflow_generator_->generateTaskflow(
                                             transition_to_start_input,
                                             std::bind(&RasterWAADDTProcessManager::successCallback,
                                                       this,
-                                                      transition_to_start_input.instruction->getDescription()),
+                                                      transition_to_start_input.getInstruction()->getDescription()),
                                             std::bind(&RasterWAADDTProcessManager::failureCallback,
                                                       this,
-                                                      transition_to_start_input.instruction->getDescription())))
+                                                      transition_to_start_input.getInstruction()->getDescription())))
                                         .name("transition_" + std::to_string(input_idx));
 
     // Each transition is independent and thus depends only on the adjacent rasters approach and departure
@@ -195,30 +198,33 @@ bool RasterWAADDTProcessManager::init(ProcessInput input)
 
   // Plan from_start - preceded by the first raster
   ProcessInput from_start_input = input[0];
-  from_start_input.start_instruction = input.instruction->cast_const<CompositeInstruction>()->getStartInstruction();
-  from_start_input.end_instruction_ptr = input[1][0].results;
-  auto from_start =
-      taskflow_
-          .composed_of(freespace_taskflow_generator_->generateTaskflow(
-              from_start_input,
-              std::bind(
-                  &RasterWAADDTProcessManager::successCallback, this, from_start_input.instruction->getDescription()),
-              std::bind(
-                  &RasterWAADDTProcessManager::failureCallback, this, from_start_input.instruction->getDescription())))
-          .name("from_start");
+  from_start_input.setStartInstruction(
+      input.getInstruction()->cast_const<CompositeInstruction>()->getStartInstruction());
+  from_start_input.setEndInstruction(std::vector<std::size_t>({ 1, 0 }));
+  auto from_start = taskflow_
+                        .composed_of(freespace_taskflow_generator_->generateTaskflow(
+                            from_start_input,
+                            std::bind(&RasterWAADDTProcessManager::successCallback,
+                                      this,
+                                      from_start_input.getInstruction()->getDescription()),
+                            std::bind(&RasterWAADDTProcessManager::failureCallback,
+                                      this,
+                                      from_start_input.getInstruction()->getDescription())))
+                        .name("from_start");
   raster_tasks_[starting_raster_idx][0].precede(from_start);
   freespace_tasks_.push_back(from_start);
 
   // Plan to_end - preceded by the last raster
   ProcessInput to_end_input = input[input.size() - 1];
-  to_end_input.start_instruction_ptr = input[input.size() - 2][2].results;
+  to_end_input.setStartInstruction(std::vector<std::size_t>({ input.size() - 2, 2 }));
   auto to_end =
       taskflow_
           .composed_of(freespace_taskflow_generator_->generateTaskflow(
               to_end_input,
-              std::bind(&RasterWAADDTProcessManager::successCallback, this, to_end_input.instruction->getDescription()),
               std::bind(
-                  &RasterWAADDTProcessManager::failureCallback, this, to_end_input.instruction->getDescription())))
+                  &RasterWAADDTProcessManager::successCallback, this, to_end_input.getInstruction()->getDescription()),
+              std::bind(
+                  &RasterWAADDTProcessManager::failureCallback, this, to_end_input.getInstruction()->getDescription())))
           .name("to_end");
   raster_tasks_.back()[2].precede(to_end);
   freespace_tasks_.push_back(to_end);
@@ -243,7 +249,10 @@ bool RasterWAADDTProcessManager::execute()
 
   // Wait for currently running taskflows to end.
   executor_.wait_for_all();
-  executor_.run(taskflow_).wait();
+  executor_.run(taskflow_);
+  executor_.wait_for_all();
+
+  clear();  // I believe clear must be called so memory is cleaned up
 
   return success_;
 }
@@ -282,16 +291,16 @@ bool RasterWAADDTProcessManager::checkProcessInput(const tesseract_planning::Pro
   }
 
   // Check the overall input
-  if (!isCompositeInstruction(*(input.instruction)))
+  const Instruction* input_instruction = input.getInstruction();
+  if (!isCompositeInstruction(*input_instruction))
   {
     CONSOLE_BRIDGE_logError("ProcessInput Invalid: input.instructions should be a composite");
     return false;
   }
-  const auto* composite = input.instruction->cast_const<CompositeInstruction>();
+  const auto* composite = input_instruction->cast_const<CompositeInstruction>();
 
   // Check that it has a start instruction
-  if (!composite->hasStartInstruction() && input.start_instruction_ptr == nullptr &&
-      isNullInstruction(input.start_instruction))
+  if (!composite->hasStartInstruction() && isNullInstruction(input.getStartInstruction()))
   {
     CONSOLE_BRIDGE_logError("ProcessInput Invalid: input.instructions should have a start instruction");
     return false;

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/descartes_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/descartes_taskflow.cpp
@@ -27,6 +27,7 @@
 #include <tesseract_process_managers/taskflows/descartes_taskflow.h>
 #include <tesseract_process_managers/process_generators/motion_planner_process_generator.h>
 #include <tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h>
+#include <tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h>
 #include <tesseract_process_managers/process_generators/iterative_spline_parameterization_process_generator.h>
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
@@ -36,10 +37,7 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createDescartesTaskflow(bool create_seed,
-                                            const SimplePlannerPlanProfileMap& simple_plan_profiles,
-                                            const SimplePlannerCompositeProfileMap& simple_composite_profiles,
-                                            const DescartesPlanProfileMap<double>& descartes_plan_profiles)
+GraphTaskflow::UPtr createDescartesTaskflow(DescartesTaskflowParams params)
 {
   auto graph = std::make_unique<GraphTaskflow>();
 
@@ -49,11 +47,11 @@ GraphTaskflow::UPtr createDescartesTaskflow(bool create_seed,
 
   // Setup Interpolator
   int interpolator_idx;
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
     auto interpolator = std::make_shared<SimpleMotionPlanner>("Interpolator");
-    interpolator->plan_profiles = simple_plan_profiles;
-    interpolator->composite_profiles = simple_composite_profiles;
+    interpolator->plan_profiles = params.simple_plan_profiles;
+    interpolator->composite_profiles = params.simple_composite_profiles;
     auto interpolator_generator = std::make_unique<MotionPlannerProcessGenerator>(interpolator);
     interpolator_idx = graph->addNode(std::move(interpolator_generator), GraphTaskflow::NodeType::CONDITIONAL);
   }
@@ -61,18 +59,31 @@ GraphTaskflow::UPtr createDescartesTaskflow(bool create_seed,
   // Setup Descartes
   auto descartes_planner = std::make_shared<DescartesMotionPlanner<double>>();
   descartes_planner->problem_generator = &DefaultDescartesProblemGenerator<double>;
-  descartes_planner->plan_profiles = descartes_plan_profiles;
+  descartes_planner->plan_profiles = params.descartes_plan_profiles;
   auto descartes_generator = std::make_unique<MotionPlannerProcessGenerator>(descartes_planner);
   int descartes_idx = graph->addNode(std::move(descartes_generator), GraphTaskflow::NodeType::CONDITIONAL);
 
   // Add Final Continuous Contact Check of trajectory
-  auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
-  int contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int contact_check_idx;
+  if (params.enable_post_contact_continuous_check)
+  {
+    auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
+  else if (params.enable_post_contact_discrete_check)
+  {
+    auto contact_check_generator = std::make_unique<DiscreteContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   // Time parameterization trajectory
-  auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
-  int time_parameterization_idx =
-      graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int time_parameterization_idx;
+  if (params.enable_time_parameterization)
+  {
+    auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
+    time_parameterization_idx =
+        graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   /////////////////
   /// Add Edges ///
@@ -83,20 +94,34 @@ GraphTaskflow::UPtr createDescartesTaskflow(bool create_seed,
   auto ERROR_CALLBACK = GraphTaskflow::DestinationChannel::ERROR_CALLBACK;
   auto DONE_CALLBACK = GraphTaskflow::DestinationChannel::DONE_CALLBACK;
 
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
     graph->addEdge(interpolator_idx, ON_SUCCESS, descartes_idx, PROCESS_NODE);
     graph->addEdge(interpolator_idx, ON_FAILURE, -1, ERROR_CALLBACK);
   }
 
-  graph->addEdge(descartes_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
   graph->addEdge(descartes_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+    graph->addEdge(descartes_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
+  else if (params.enable_time_parameterization)
+    graph->addEdge(descartes_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+  else
+    graph->addEdge(descartes_idx, ON_SUCCESS, -1, DONE_CALLBACK);
 
-  graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
-  graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+  {
+    graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+    if (params.enable_time_parameterization)
+      graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+    else
+      graph->addEdge(contact_check_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+  }
 
-  graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
-  graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_time_parameterization)
+  {
+    graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+    graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  }
 
   return graph;
 }

--- a/tesseract/tesseract_planning/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
@@ -81,11 +81,11 @@ protected:
 TEST_F(TesseractProcessManagerUnit, RasterSimpleMotionPlannerTest)
 {
   tesseract_planning::CompositeInstruction program = rasterExampleProgram();
-  EXPECT_FALSE(program.getManipulatorInfo().isEmpty());
+  EXPECT_FALSE(program.getManipulatorInfo().empty());
 
   program.setManipulatorInfo(manip);
   EXPECT_TRUE(program.hasStartInstruction());
-  EXPECT_FALSE(program.getManipulatorInfo().isEmpty());
+  EXPECT_FALSE(program.getManipulatorInfo().empty());
 
   auto interpolator = std::make_shared<SimpleMotionPlanner>("INTERPOLATOR");
 
@@ -106,17 +106,17 @@ TEST_F(TesseractProcessManagerUnit, RasterSimpleMotionPlannerTest)
   // ten move instruction.
   EXPECT_EQ(((pcnt - 1) * 10) + 1, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
-  EXPECT_FALSE(response.results.getManipulatorInfo().isEmpty());
+  EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }
 
 TEST_F(TesseractProcessManagerUnit, FreespaceSimpleMotionPlannerTest)
 {
   CompositeInstruction program = freespaceExampleProgram();
-  EXPECT_FALSE(program.getManipulatorInfo().isEmpty());
+  EXPECT_FALSE(program.getManipulatorInfo().empty());
 
   program.setManipulatorInfo(manip);
   EXPECT_TRUE(program.hasStartInstruction());
-  EXPECT_FALSE(program.getManipulatorInfo().isEmpty());
+  EXPECT_FALSE(program.getManipulatorInfo().empty());
 
   auto interpolator = std::make_shared<SimpleMotionPlanner>("INTERPOLATOR");
 
@@ -137,7 +137,7 @@ TEST_F(TesseractProcessManagerUnit, FreespaceSimpleMotionPlannerTest)
   // ten move instruction.
   EXPECT_EQ(((pcnt - 1) * 10) + 1, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
-  EXPECT_FALSE(response.results.getManipulatorInfo().isEmpty());
+  EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }
 
 TEST_F(TesseractProcessManagerUnit, RasterProcessManagerTest)

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rep_kinematics.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rep_kinematics.h
@@ -1,0 +1,101 @@
+#ifndef TESSERACT_SCENE_GRAPH_SRDF_GROUP_REP_KINEMATICS_H
+#define TESSERACT_SCENE_GRAPH_SRDF_GROUP_REP_KINEMATICS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <array>
+#include <console_bridge/console.h>
+#include <tinyxml2.h>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/utils.h>
+#include <tesseract_scene_graph/graph.h>
+#include <tesseract_scene_graph/srdf/types.h>
+
+namespace tesseract_scene_graph
+{
+/**
+ * @brief Parse group Robot with External Positioner kinematics from srdf xml element
+ * @param scene_graph The tesseract scene graph
+ * @param srdf_xml The xml element to parse
+ * @param version The srdf version number
+ * @return Group OPW kinematics parameters
+ */
+inline GroupREPKinematics parseGroupREPKinematics(const tesseract_scene_graph::SceneGraph& /*scene_graph*/,
+                                                  const tinyxml2::XMLElement* srdf_xml,
+                                                  const std::array<int, 3>& /*version*/)
+{
+  GroupREPKinematics group_rep_kinematics;
+
+  for (const tinyxml2::XMLElement* xml_element = srdf_xml->FirstChildElement("group_rep"); xml_element;
+       xml_element = xml_element->NextSiblingElement("group_rep"))
+  {
+    std::string group_name_string;
+    tinyxml2::XMLError status = tesseract_common::QueryStringAttributeRequired(xml_element, "group", group_name_string);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    // get the robot with external positioner group information
+    REPKinematicParameters rep_info;
+    const tinyxml2::XMLElement* manip_xml = xml_element->FirstChildElement("manipulator");
+    if (manip_xml == nullptr)
+    {
+      CONSOLE_BRIDGE_logError("REP Group defined, but missing manipulator element!");
+      continue;
+    }
+
+    status = tesseract_common::QueryStringAttributeRequired(manip_xml, "group", rep_info.manipulator_group);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    status = tesseract_common::QueryStringAttributeRequired(manip_xml, "ik_solver", rep_info.manipulator_ik_solver);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    status = tesseract_common::QueryDoubleAttributeRequired(manip_xml, "reach", rep_info.manipulator_reach);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    const tinyxml2::XMLElement* positioner_xml = xml_element->FirstChildElement("positioner");
+    if (positioner_xml == nullptr)
+    {
+      CONSOLE_BRIDGE_logError("REP Group defined, but missing positioner element!");
+      continue;
+    }
+
+    status = tesseract_common::QueryStringAttributeRequired(positioner_xml, "group", rep_info.positioner_group);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    status = tesseract_common::QueryStringAttribute(positioner_xml, "fk_solver", rep_info.positioner_fk_solver);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    {
+      CONSOLE_BRIDGE_logInform("REP Group, positioner element missing or failed to parse 'fk_solver' attribute!");
+      continue;
+    }
+
+    // get the chains in the groups
+    for (const tinyxml2::XMLElement* joint_xml = positioner_xml->FirstChildElement("joint"); positioner_xml;
+         positioner_xml = positioner_xml->NextSiblingElement("joint"))
+    {
+      std::string joint_name;
+      status = tesseract_common::QueryStringAttributeRequired(joint_xml, "name", joint_name);
+      if (status != tinyxml2::XML_SUCCESS)
+        continue;
+
+      double resolution;
+      status = tesseract_common::QueryDoubleAttributeRequired(joint_xml, "resolution", resolution);
+      if (status != tinyxml2::XML_SUCCESS)
+        continue;
+
+      rep_info.positioner_sample_resolution[joint_name] = resolution;
+    }
+    group_rep_kinematics[group_name_string] = rep_info;
+  }
+
+  return group_rep_kinematics;
+}
+}  // namespace tesseract_scene_graph
+#endif  // TESSERACT_SCENE_GRAPH_SRDF_GROUP_REP_KINEMATICS_H

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rop_kinematics.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rop_kinematics.h
@@ -1,0 +1,101 @@
+#ifndef TESSERACT_SCENE_GRAPH_SRDF_GROUP_ROP_KINEMATICS_H
+#define TESSERACT_SCENE_GRAPH_SRDF_GROUP_ROP_KINEMATICS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <array>
+#include <console_bridge/console.h>
+#include <tinyxml2.h>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/utils.h>
+#include <tesseract_scene_graph/graph.h>
+#include <tesseract_scene_graph/srdf/types.h>
+
+namespace tesseract_scene_graph
+{
+/**
+ * @brief Parse group Robot on Positioner kinematics from srdf xml element
+ * @param scene_graph The tesseract scene graph
+ * @param srdf_xml The xml element to parse
+ * @param version The srdf version number
+ * @return Group OPW kinematics parameters
+ */
+inline GroupROPKinematics parseGroupROPKinematics(const tesseract_scene_graph::SceneGraph& /*scene_graph*/,
+                                                  const tinyxml2::XMLElement* srdf_xml,
+                                                  const std::array<int, 3>& /*version*/)
+{
+  GroupROPKinematics group_rop_kinematics;
+
+  for (const tinyxml2::XMLElement* xml_element = srdf_xml->FirstChildElement("group_rop"); xml_element;
+       xml_element = xml_element->NextSiblingElement("group_rop"))
+  {
+    std::string group_name_string;
+    tinyxml2::XMLError status = tesseract_common::QueryStringAttributeRequired(xml_element, "group", group_name_string);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    // get the robot on positioner group information
+    ROPKinematicParameters rop_info;
+    const tinyxml2::XMLElement* manip_xml = xml_element->FirstChildElement("manipulator");
+    if (manip_xml == nullptr)
+    {
+      CONSOLE_BRIDGE_logError("ROP Group defined, but missing manipulator element!");
+      continue;
+    }
+
+    status = tesseract_common::QueryStringAttributeRequired(manip_xml, "group", rop_info.manipulator_group);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    status = tesseract_common::QueryStringAttributeRequired(manip_xml, "ik_solver", rop_info.manipulator_ik_solver);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    status = tesseract_common::QueryDoubleAttributeRequired(manip_xml, "reach", rop_info.manipulator_reach);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    const tinyxml2::XMLElement* positioner_xml = xml_element->FirstChildElement("positioner");
+    if (positioner_xml == nullptr)
+    {
+      CONSOLE_BRIDGE_logError("ROP Group defined, but missing positioner element!");
+      continue;
+    }
+
+    status = tesseract_common::QueryStringAttributeRequired(positioner_xml, "group", rop_info.positioner_group);
+    if (status != tinyxml2::XML_SUCCESS)
+      continue;
+
+    status = tesseract_common::QueryStringAttribute(positioner_xml, "fk_solver", rop_info.positioner_fk_solver);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    {
+      CONSOLE_BRIDGE_logInform("ROP Group, positioner element missing or failed to parse 'fk_solver' attribute!");
+      continue;
+    }
+
+    // get the chains in the groups
+    for (const tinyxml2::XMLElement* joint_xml = positioner_xml->FirstChildElement("joint"); positioner_xml;
+         positioner_xml = positioner_xml->NextSiblingElement("joint"))
+    {
+      std::string joint_name;
+      status = tesseract_common::QueryStringAttributeRequired(joint_xml, "name", joint_name);
+      if (status != tinyxml2::XML_SUCCESS)
+        continue;
+
+      double resolution;
+      status = tesseract_common::QueryDoubleAttributeRequired(joint_xml, "resolution", resolution);
+      if (status != tinyxml2::XML_SUCCESS)
+        continue;
+
+      rop_info.positioner_sample_resolution[joint_name] = resolution;
+    }
+    group_rop_kinematics[group_name_string] = rop_info;
+  }
+
+  return group_rop_kinematics;
+}
+}  // namespace tesseract_scene_graph
+#endif  // TESSERACT_SCENE_GRAPH_SRDF_GROUP_ROP_KINEMATICS_H

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/groups.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/groups.h
@@ -22,7 +22,7 @@ namespace tesseract_scene_graph
  * @param version The srdf version number
  * @return GroupNames, ChainGroups, JointGroups, LinkGroups
  */
-inline std::tuple<GroupNames, ChainGroups, JointGroups, LinkGroups, ROPGroups, REPGroups>
+inline std::tuple<GroupNames, ChainGroups, JointGroups, LinkGroups>
 parseGroups(const tesseract_scene_graph::SceneGraph& scene_graph,
             const tinyxml2::XMLElement* srdf_xml,
             const std::array<int, 3>& /*version*/)
@@ -31,8 +31,6 @@ parseGroups(const tesseract_scene_graph::SceneGraph& scene_graph,
   ChainGroups chain_groups;
   LinkGroups link_groups;
   JointGroups joint_groups;
-  ROPGroups rop_groups;
-  REPGroups rep_groups;
 
   for (const tinyxml2::XMLElement* xml_element = srdf_xml->FirstChildElement("group"); xml_element;
        xml_element = xml_element->NextSiblingElement("group"))
@@ -116,130 +114,6 @@ parseGroups(const tesseract_scene_graph::SceneGraph& scene_graph,
       chains.emplace_back(base_link_name, tip_link_name);
     }
 
-    // get the robot on positioner group information
-    const tinyxml2::XMLElement* rop_xml = xml_element->FirstChildElement("rop");
-    if (rop_xml != nullptr)
-    {
-      ROPKinematicParameters rop_info;
-      const tinyxml2::XMLElement* manip_xml = rop_xml->FirstChildElement("manipulator");
-      if (manip_xml == nullptr)
-      {
-        CONSOLE_BRIDGE_logError("ROP Group defined, but missing manipulator element!");
-        continue;
-      }
-
-      tinyxml2::XMLError status =
-          tesseract_common::QueryStringAttributeRequired(manip_xml, "group", rop_info.manipulator_group);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      status = tesseract_common::QueryStringAttributeRequired(manip_xml, "ik_solver", rop_info.manipulator_ik_solver);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      status = tesseract_common::QueryDoubleAttributeRequired(manip_xml, "reach", rop_info.manipulator_reach);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      const tinyxml2::XMLElement* positioner_xml = rop_xml->FirstChildElement("positioner");
-      if (positioner_xml == nullptr)
-      {
-        CONSOLE_BRIDGE_logError("ROP Group defined, but missing positioner element!");
-        continue;
-      }
-
-      status = tesseract_common::QueryStringAttributeRequired(positioner_xml, "group", rop_info.positioner_group);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      status = tesseract_common::QueryStringAttribute(positioner_xml, "fk_solver", rop_info.positioner_fk_solver);
-      if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-      {
-        CONSOLE_BRIDGE_logInform("ROP Group, positioner element missing or failed to parse 'fk_solver' attribute!");
-        continue;
-      }
-
-      // get the chains in the groups
-      for (const tinyxml2::XMLElement* joint_xml = positioner_xml->FirstChildElement("joint"); positioner_xml;
-           positioner_xml = positioner_xml->NextSiblingElement("joint"))
-      {
-        std::string joint_name;
-        status = tesseract_common::QueryStringAttributeRequired(joint_xml, "name", joint_name);
-        if (status != tinyxml2::XML_SUCCESS)
-          continue;
-
-        double resolution;
-        status = tesseract_common::QueryDoubleAttributeRequired(joint_xml, "resolution", resolution);
-        if (status != tinyxml2::XML_SUCCESS)
-          continue;
-
-        rop_info.positioner_sample_resolution[joint_name] = resolution;
-      }
-      rop_groups[group_name] = rop_info;
-    }
-
-    // get the robot with external positioner group information
-    const tinyxml2::XMLElement* rep_xml = xml_element->FirstChildElement("rep");
-    if (rep_xml != nullptr)
-    {
-      REPKinematicParameters rep_info;
-      const tinyxml2::XMLElement* manip_xml = rep_xml->FirstChildElement("manipulator");
-      if (manip_xml == nullptr)
-      {
-        CONSOLE_BRIDGE_logError("REP Group defined, but missing manipulator element!");
-        continue;
-      }
-
-      tinyxml2::XMLError status =
-          tesseract_common::QueryStringAttributeRequired(manip_xml, "group", rep_info.manipulator_group);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      status = tesseract_common::QueryStringAttributeRequired(manip_xml, "ik_solver", rep_info.manipulator_ik_solver);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      status = tesseract_common::QueryDoubleAttributeRequired(manip_xml, "reach", rep_info.manipulator_reach);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      const tinyxml2::XMLElement* positioner_xml = rop_xml->FirstChildElement("positioner");
-      if (positioner_xml == nullptr)
-      {
-        CONSOLE_BRIDGE_logError("REP Group defined, but missing positioner element!");
-        continue;
-      }
-
-      status = tesseract_common::QueryStringAttributeRequired(positioner_xml, "group", rep_info.positioner_group);
-      if (status != tinyxml2::XML_SUCCESS)
-        continue;
-
-      status = tesseract_common::QueryStringAttribute(positioner_xml, "fk_solver", rep_info.positioner_fk_solver);
-      if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-      {
-        CONSOLE_BRIDGE_logInform("REP Group, positioner element missing or failed to parse 'fk_solver' attribute!");
-        continue;
-      }
-
-      // get the chains in the groups
-      for (const tinyxml2::XMLElement* joint_xml = positioner_xml->FirstChildElement("joint"); positioner_xml;
-           positioner_xml = positioner_xml->NextSiblingElement("joint"))
-      {
-        std::string joint_name;
-        status = tesseract_common::QueryStringAttributeRequired(joint_xml, "name", joint_name);
-        if (status != tinyxml2::XML_SUCCESS)
-          continue;
-
-        double resolution;
-        status = tesseract_common::QueryDoubleAttributeRequired(joint_xml, "resolution", resolution);
-        if (status != tinyxml2::XML_SUCCESS)
-          continue;
-
-        rep_info.positioner_sample_resolution[joint_name] = resolution;
-      }
-      rep_groups[group_name] = rep_info;
-    }
-
     if (!chains.empty() && links.empty() && joints.empty())
     {
       chain_groups[group_name] = chains;
@@ -261,7 +135,7 @@ parseGroups(const tesseract_scene_graph::SceneGraph& scene_graph,
     }
   }
 
-  return std::make_tuple(group_names, chain_groups, joint_groups, link_groups, rop_groups, rep_groups);
+  return std::make_tuple(group_names, chain_groups, joint_groups, link_groups);
 }
 }  // namespace tesseract_scene_graph
 

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/types.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/types.h
@@ -51,8 +51,8 @@ using JointGroups = std::unordered_map<std::string, JointGroup>;
 using LinkGroup = std::vector<std::string>;
 using LinkGroups = std::unordered_map<std::string, LinkGroup>;
 using GroupNames = std::vector<std::string>;
-using ROPGroups = std::unordered_map<std::string, ROPKinematicParameters>;
-using REPGroups = std::unordered_map<std::string, REPKinematicParameters>;
+using GroupROPKinematics = std::unordered_map<std::string, ROPKinematicParameters>;
+using GroupREPKinematics = std::unordered_map<std::string, REPKinematicParameters>;
 using GroupOPWKinematics = std::unordered_map<std::string, OPWKinematicParameters>;
 
 }  // namespace tesseract_scene_graph

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf_model.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf_model.h
@@ -102,14 +102,6 @@ public:
   const LinkGroups& getLinkGroups() const;
   LinkGroups& getLinkGroups();
 
-  /** @brief Get the map of robot on positioner groups defined for this model */
-  const ROPGroups& getROPGroups() const;
-  ROPGroups& getROPGroups();
-
-  /** @brief Get the map of robot with external positioner groups defined for this model */
-  const REPGroups& getREPGroups() const;
-  REPGroups& getREPGroups();
-
   /** @brief Get the map of group tool center points (TCP) defined for this model */
   const GroupTCPs& getGroupTCPs() const;
   GroupTCPs& getGroupTCPs();
@@ -122,6 +114,14 @@ public:
   const GroupOPWKinematics& getGroupOPWKinematics() const;
   GroupOPWKinematics& getGroupOPWKinematics();
 
+  /** @brief Get the map of robot on positioner groups defined for this model */
+  const GroupROPKinematics& getGroupROPKinematics() const;
+  GroupROPKinematics& getGroupROPKinematics();
+
+  /** @brief Get the map of robot with external positioner groups defined for this model */
+  const GroupREPKinematics& getGroupREPKinematics() const;
+  GroupREPKinematics& getGroupREPKinematics();
+
   /** @brief Clear the model */
   void clear();
 
@@ -131,13 +131,13 @@ private:
   ChainGroups chain_groups_;                  /**< @brief A map of chains groups*/
   JointGroups joint_groups_;                  /**< @brief A map of joint groups */
   LinkGroups link_groups_;                    /**< @brief A map of link groups */
-  ROPGroups rop_groups_;                      /**< @brief A map of robot on positioner groups */
-  REPGroups rep_groups_;                      /**< @brief A map of robot with external positioner groups */
   std::vector<std::string> group_names_;      /**< @brief A vector of group names */
   GroupJointStates group_states_;             /**< @brief A map of group states */
   GroupTCPs group_tcps_;                      /**< @brief A map of group tool center points */
   AllowedCollisionMatrix acm_;                /**< @brief The allowed collision matrix */
   GroupOPWKinematics group_opw_kinematics_;   /**< @brief A map of group opw kinematics data */
+  GroupROPKinematics group_rop_kinematics_;   /**< @brief A map of robot on positioner groups */
+  GroupREPKinematics group_rep_kinematics_;   /**< @brief A map of robot with external positioner groups */
 };
 
 }  // namespace tesseract_scene_graph


### PR DESCRIPTION
This add a global raster taskflow which will run descartes on the whole raster followed by trajopt at the individual raster and transitions. This helps with limiting the number of configuration flips between rasters.

![image](https://user-images.githubusercontent.com/9803128/93133436-d5c4d880-f69c-11ea-8e9e-7cd67f5354c0.png)
