### PR TITLE
Setting Active collision objects for the contact managers in trajopt motion planner

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -164,17 +164,18 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(PlannerResponse& respon
 
   std::vector<tesseract_collision::ContactResultMap> collisions;
   tesseract_environment::StateSolver::Ptr state_solver = config_->prob->GetEnv()->getStateSolver();
-  tesseract_collision::ContinuousContactManager::Ptr continuous_manager =
-      config_->prob->GetEnv()->getContinuousContactManager();
   tesseract_environment::AdjacencyMap::Ptr adjacency_map = std::make_shared<tesseract_environment::AdjacencyMap>(
       config_->prob->GetEnv()->getSceneGraph(),
       config_->prob->GetKin()->getActiveLinkNames(),
       config_->prob->GetEnv()->getCurrentState()->link_transforms);
 
-  validator_ = std::make_shared<TrajectoryValidator>(config_->prob->GetEnv()->getContinuousContactManager(),
-                                                     config_->prob->GetEnv()->getDiscreteContactManager(),
-                                                     length,
-                                                     verbose);
+  auto continuous_manager = config_->prob->GetEnv()->getContinuousContactManager();
+  continuous_manager->setActiveCollisionObjects(adjacency_map->getActiveLinkNames());
+
+  auto discrete_manager = config_->prob->GetEnv()->getDiscreteContactManager();
+  discrete_manager->setActiveCollisionObjects(adjacency_map->getActiveLinkNames());
+
+  validator_ = std::make_shared<TrajectoryValidator>(continuous_manager, discrete_manager, length, verbose);
 
   tesseract_collision::ContactRequest request(tesseract_collision::ContactTestType::FIRST);
   request.is_valid = [&](const tesseract_collision::ContactResult& res) {


### PR DESCRIPTION
In the current code version both the continuous_manager and the adjacency_map are declared but unused; the active collision objects used for the collision check consequently default to all the active objects in the environment (meaning that unaffected parts of the system are checked too).

With this PR, the Active collision objects for the final collision check are set to those of the Kinematic chain affected by the plan.