### PR TITLE
Update default longest valid segment length and set default to use discrete continuous.

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
@@ -67,7 +67,7 @@ public:
   // Applied during edge evaluation
   bool enable_edge_collision{ false };
   double edge_collision_saftey_margin{ 0 };
-  double edge_longest_valid_segment_length = 0.5;
+  double edge_longest_valid_segment_length = 0.1;
 
   int num_threads{ 1 };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
@@ -121,7 +121,7 @@ public:
    * Note: This gets converted to longest_valid_segment_fraction.
    *       longest_valid_segment_fraction = longest_valid_segment_length / state_space.getMaximumExtent()
    */
-  double longest_valid_segment_length = 0.5;
+  double longest_valid_segment_length = 0.1;
 
   /** @brief This scales the variables search space. Must be same size as number of joints.
    *         If empty it defaults to all ones */

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
@@ -101,7 +101,7 @@ public:
   bool collision_check = true;
 
   /** @brief If true, use continuous collision checking */
-  bool collision_continuous = true;
+  bool collision_continuous = false;
 
   /** @brief Max distance over which collisions are checked */
   double collision_safety_margin = 0.00;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h
@@ -83,7 +83,7 @@ public:
    * Note: This gets converted to longest_valid_segment_fraction.
    *       longest_valid_segment_fraction = longest_valid_segment_length / state_space.getMaximumExtent()
    */
-  double longest_valid_segment_length = 0.5;
+  double longest_valid_segment_length = 0.1;
 
   /**@brief Special link collision cost distances */
   trajopt::SafetyMarginData::Ptr special_collision_cost{ nullptr };

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_collision_config.h
@@ -47,19 +47,23 @@ struct CollisionCostConfig
 
   /** @brief If true, a collision cost term will be added to the problem. Default: true*/
   bool enabled = true;
+
   /**
    * @brief Use the weighted sum for each link pair. This reduces the number equations added to the problem
    * If set to true, it is recommended to start with the coeff set to one
    */
   bool use_weighted_sum = false;
+
   /** @brief The evaluator type that will be used for collision checking. */
-  trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::CAST_CONTINUOUS;
+  trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::DISCRETE_CONTINUOUS;
 
   /** @brief Max distance in which collision costs will be evaluated. */
   double buffer_margin = 0.025;
+
   /** @brief Distance beyond buffer_margin in which collision optimization will be evaluated.
       This is set to 0 by default (effectively disabled) for collision costs.*/
   double safety_margin_buffer = 0.0;
+
   /** @brief The collision coeff/weight */
   double coeff = 20;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -200,7 +200,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
   plan_profile->collision_safety_margin = 0.025;
-  plan_profile->planning_time = 8;
+  plan_profile->planning_time = 10;
   plan_profile->max_solutions = 2;
   plan_profile->longest_valid_segment_fraction = 0.01;
   plan_profile->collision_continuous = true;
@@ -350,7 +350,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespaceCartesianGoalPlannerUnit)
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
   plan_profile->collision_safety_margin = 0.02;
-  plan_profile->planning_time = 5;
+  plan_profile->planning_time = 10;
   plan_profile->max_solutions = 2;
   plan_profile->longest_valid_segment_fraction = 0.01;
   plan_profile->collision_continuous = true;
@@ -439,7 +439,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespaceCartesianStartPlannerUnit)
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
   plan_profile->collision_safety_margin = 0.02;
-  plan_profile->planning_time = 5;
+  plan_profile->planning_time = 10;
   plan_profile->max_solutions = 2;
   plan_profile->longest_valid_segment_fraction = 0.01;
   plan_profile->collision_continuous = true;

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h
@@ -68,7 +68,7 @@ private:
 
   std::string name_;
 
-  double longest_valid_segment_length_{ 0.1 };
+  double longest_valid_segment_length_{ 0.05 };
 
   double contact_distance_{ 0 };
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h
@@ -68,7 +68,7 @@ private:
 
   std::string name_;
 
-  double longest_valid_segment_length_{ 0.1 };
+  double longest_valid_segment_length_{ 0.05 };
 
   double contact_distance_{ 0 };
 


### PR DESCRIPTION
The challenge I keep running into with continuous collision checking is that if you have two kinematic links that are always within say 2cm and are not disabled in ACM. Then if you move more than 2cm in a single time step it will report collision because the end state of the first shape overlaps with the start state of the second shape. This switches the default to leverage Discrete Continuous which will make motion planning more stable and will use casted collision checking in the post check with a fine resolution to catch collisions if the planners longest valid segment length was not set fine enough.