### PR TITLE
Improve global raster taskflow

### DIFF
--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_manager_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_manager_example.cpp
@@ -87,7 +87,7 @@ int main()
   // --------------------
   // Initialize Freespace Manager
   // --------------------
-  SimpleProcessManager freespace_manager(createFreespaceTaskflow(true));
+  SimpleProcessManager freespace_manager(createFreespaceTaskflow(FreespaceTaskflowParams()));
   freespace_manager.init(input);
 
   // --------------------

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_manager_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_manager_example.cpp
@@ -88,8 +88,8 @@ int main()
   // --------------------
   // Initialize Freespace Manager
   // --------------------
-  auto freespace_taskflow_generator = createFreespaceTaskflow(true);
-  auto transition_taskflow_generator = createFreespaceTaskflow(true);
+  auto freespace_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
+  auto transition_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
   auto raster_taskflow_generator = createCartesianTaskflow(true);
   RasterProcessManager raster_manager(std::move(freespace_taskflow_generator),
                                       std::move(transition_taskflow_generator),

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/freespace_taskflow.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/freespace_taskflow.h
@@ -33,13 +33,27 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createFreespaceTaskflow(
-    bool create_seed,
-    const SimplePlannerPlanProfileMap& simple_plan_profiles = SimplePlannerPlanProfileMap(),
-    const SimplePlannerCompositeProfileMap& simple_composite_profiles = SimplePlannerCompositeProfileMap(),
-    const OMPLPlanProfileMap& ompl_plan_profiles = OMPLPlanProfileMap(),
-    const TrajOptPlanProfileMap& trajopt_plan_profiles = TrajOptPlanProfileMap(),
-    const TrajOptCompositeProfileMap& trajopt_composite_profiles = TrajOptCompositeProfileMap());
-}
+enum class FreespaceTaskflowType : int
+{
+  DEFAULT = 0,       /**< @brief This will run omp followed by trajopt */
+  TRAJOPT_FIRST = 1, /**< @brief This will run trajopt first then if it fails it will run ompl followed by trajopt */
+};
+
+struct FreespaceTaskflowParams
+{
+  FreespaceTaskflowType type{ FreespaceTaskflowType::DEFAULT };
+  bool enable_simple_planner{ true };
+  bool enable_post_contact_discrete_check{ false };
+  bool enable_post_contact_continuous_check{ true };
+  bool enable_time_parameterization{ true };
+  SimplePlannerPlanProfileMap simple_plan_profiles;
+  SimplePlannerCompositeProfileMap simple_composite_profiles;
+  OMPLPlanProfileMap ompl_plan_profiles;
+  TrajOptPlanProfileMap trajopt_plan_profiles;
+  TrajOptCompositeProfileMap trajopt_composite_profiles;
+};
+
+GraphTaskflow::UPtr createFreespaceTaskflow(FreespaceTaskflowParams params);
+}  // namespace tesseract_planning
 
 #endif  // TESSERACT_PROCESS_MANAGERS_FREESPACE_TASKFLOW_H

--- a/tesseract/tesseract_planning/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
@@ -151,8 +151,8 @@ TEST_F(TesseractProcessManagerUnit, RasterProcessManagerTest)
   ProcessInput input(tesseract_ptr_, &program_instruction, program.getManipulatorInfo(), &seed);
 
   // Initialize Freespace Manager
-  auto freespace_taskflow_generator = createFreespaceTaskflow(true);
-  auto transition_taskflow_generator = createFreespaceTaskflow(true);
+  auto freespace_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
+  auto transition_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
   auto raster_taskflow_generator = createCartesianTaskflow(true);
   RasterProcessManager raster_manager(std::move(freespace_taskflow_generator),
                                       std::move(transition_taskflow_generator),
@@ -175,8 +175,8 @@ TEST_F(TesseractProcessManagerUnit, RasterDTProcessManagerTest)
   ProcessInput input(tesseract_ptr_, &program_instruction, program.getManipulatorInfo(), &seed);
 
   // Initialize Freespace Manager
-  auto freespace_taskflow_generator = createFreespaceTaskflow(true);
-  auto transition_taskflow_generator = createFreespaceTaskflow(true);
+  auto freespace_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
+  auto transition_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
   auto raster_taskflow_generator = createCartesianTaskflow(true);
   RasterDTProcessManager raster_manager(std::move(freespace_taskflow_generator),
                                         std::move(transition_taskflow_generator),
@@ -199,8 +199,8 @@ TEST_F(TesseractProcessManagerUnit, RasterWAADProcessManagerTest)
   ProcessInput input(tesseract_ptr_, &program_instruction, program.getManipulatorInfo(), &seed);
 
   // Initialize Freespace Manager
-  auto freespace_taskflow_generator = createFreespaceTaskflow(true);
-  auto transition_taskflow_generator = createFreespaceTaskflow(true);
+  auto freespace_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
+  auto transition_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
   auto raster_taskflow_generator = createCartesianTaskflow(true);
   RasterWAADProcessManager raster_manager(std::move(freespace_taskflow_generator),
                                           std::move(transition_taskflow_generator),
@@ -223,8 +223,8 @@ TEST_F(TesseractProcessManagerUnit, RasterWAADDTProcessManagerTest)
   ProcessInput input(tesseract_ptr_, &program_instruction, program.getManipulatorInfo(), &seed);
 
   // Initialize Freespace Manager
-  auto freespace_taskflow_generator = createFreespaceTaskflow(true);
-  auto transition_taskflow_generator = createFreespaceTaskflow(true);
+  auto freespace_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
+  auto transition_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
   auto raster_taskflow_generator = createCartesianTaskflow(true);
   RasterWAADDTProcessManager raster_manager(std::move(freespace_taskflow_generator),
                                             std::move(transition_taskflow_generator),


### PR DESCRIPTION
Through testing it was found for the global planner that since Descartes was already ran as the global planner that running TrajOpt first succeeds more often that it does not. This switches it to try TrajOpt first then if it fails it will then try OMPL followed by TrajOpt.

![image](https://user-images.githubusercontent.com/9803128/94489496-2878b700-01aa-11eb-993b-7b790c4b8e0b.png)
