### PR TITLE
Fix safety margin name

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_collision_config.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_collision_config.h
@@ -58,8 +58,7 @@ struct CollisionCostConfig
   trajopt::CollisionEvaluatorType type = trajopt::CollisionEvaluatorType::DISCRETE_CONTINUOUS;
 
   /** @brief Max distance in which collision costs will be evaluated. */
-  double buffer_margin = 0.025;
-
+  double safety_margin = 0.025;
   /** @brief Distance beyond buffer_margin in which collision optimization will be evaluated.
       This is set to 0 by default (effectively disabled) for collision costs.*/
   double safety_margin_buffer = 0.0;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
@@ -402,7 +402,10 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
   TrajOptCompositeProfile::Ptr cur_composite_profile{ nullptr };
   auto it_composite = composite_profiles.find(profile);
   if (it_composite == composite_profiles.end())
+  {
+    CONSOLE_BRIDGE_logDebug("Trajopt profile not found. Setting default");
     cur_composite_profile = std::make_shared<TrajOptDefaultCompositeProfile>();
+  }
   else
     cur_composite_profile = it_composite->second;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/profile/trajopt_default_composite_profile.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/profile/trajopt_default_composite_profile.cpp
@@ -330,7 +330,7 @@ void TrajOptDefaultCompositeProfile::addCollisionCost(trajopt::ProblemConstructi
   // Create a default collision term info
   trajopt::TermInfo::Ptr ti = createCollisionTermInfo(start_index,
                                                       end_index,
-                                                      collision_cost_config.buffer_margin,
+                                                      collision_cost_config.safety_margin,
                                                       collision_constraint_config.safety_margin_buffer,
                                                       collision_cost_config.type,
                                                       collision_cost_config.use_weighted_sum,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_collision_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_collision_config.cpp
@@ -78,7 +78,7 @@ CollisionCostConfig::CollisionCostConfig(const tinyxml2::XMLElement& xml_element
     if (!tesseract_common::isNumeric(buffer_margin_string))
       throw std::runtime_error("CollisionCostConfig: BufferMargin is not a numeric values.");
 
-    tesseract_common::toNumeric<double>(buffer_margin_string, buffer_margin);
+    tesseract_common::toNumeric<double>(buffer_margin_string, safety_margin);
   }
 
   if (safety_margin_buffer_element)
@@ -125,7 +125,7 @@ tinyxml2::XMLElement* CollisionCostConfig::toXML(tinyxml2::XMLDocument& doc) con
   xml_coll_cost_config->InsertEndChild(xml_type);
 
   tinyxml2::XMLElement* xml_buffer_margin = doc.NewElement("BufferMargin");
-  xml_buffer_margin->SetText(buffer_margin);
+  xml_buffer_margin->SetText(safety_margin);
   xml_coll_cost_config->InsertEndChild(xml_buffer_margin);
 
   tinyxml2::XMLElement* xml_safety_margin_buffer = doc.NewElement("SafetyMarginBuffer");


### PR DESCRIPTION
I imagine this was an oversite, but costs had a "buffer_margin" and constraints had a "safety_margin". I renamed this so that they are both the same. 

Note: this is a breaking change.