### PR TITLE
Remove const from return type in ikfast.h

### DIFF
--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/external/ikfast.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/external/ikfast.h
@@ -197,7 +197,7 @@ public:
   }
 
   virtual const std::vector<int>& GetFree() const { return _vfree; }
-  virtual const int GetDOF() const { return static_cast<int>(_vbasesol.size()); }
+  virtual int GetDOF() const { return static_cast<int>(_vbasesol.size()); }
 
   virtual void Validate() const
   {


### PR DESCRIPTION
The [Cpp Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#con2-by-default-make-member-functions-const) recommends against forcing `const` on function return types and function parameters that are not references or pointers. The user can decide if they want to store the function return variable into a const or not. If you use Clang-Tidy, warnings will be produced, but since this does not have a test that leverages this header it was not found until recently when using it in another project.

Given:

`const int test(const int i)`

Should be:

`int test(int i)`