### PR TITLE
Remove inheritance of std::vector from Composite Instruction

### DIFF
--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.6.0)
 project(tesseract_collision VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(Eigen3 REQUIRED)
@@ -8,12 +8,15 @@ find_package(console_bridge REQUIRED)
 find_package(tesseract_geometry REQUIRED)
 find_package(tesseract_common REQUIRED)
 find_package(tesseract_support REQUIRED)
-find_package(Bullet REQUIRED)
 find_package(fcl REQUIRED)
 find_package(cmake_common_scripts REQUIRED)
 
 # We need to find ccd ourselves because FCL doesn't do it in their fclConfig.cmake
 find_package(ccd REQUIRED)
+
+# Find Bullet using PkgConfig which is the recommended way
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(bullet REQUIRED IMPORTED_TARGET bullet)
 
 # These targets are necessary for 16.04 builds. Remove when Kinetic support is dropped
 if(NOT TARGET octomap)
@@ -36,18 +39,16 @@ tesseract_variables()
 
 # Create interface for core
 add_library(${PROJECT_NAME}_core INTERFACE)
-target_link_libraries(${PROJECT_NAME}_core INTERFACE tesseract::tesseract_common tesseract::tesseract_geometry ${Boost_LIBRARIES} ${BULLET_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_core INTERFACE tesseract::tesseract_common tesseract::tesseract_geometry PkgConfig::bullet ${Boost_LIBRARIES})
 target_compile_options(${PROJECT_NAME}_core INTERFACE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(${PROJECT_NAME}_core ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_core INTERFACE VERSION ${TESSERACT_CXX_VERSION})
 target_code_coverage(${PROJECT_NAME}_core INTERFACE ALL EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_TESTING})
-target_compile_definitions(${PROJECT_NAME}_core INTERFACE "-DBT_USE_DOUBLE_PRECISION")
 target_include_directories(${PROJECT_NAME}_core INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_core SYSTEM INTERFACE
     ${EIGEN3_INCLUDE_DIRS}
-    ${BULLET_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS})
 
 # Create target for Bullet implementation
@@ -63,7 +64,7 @@ add_library(${PROJECT_NAME}_bullet SHARED
   src/bullet/tesseract_convex_convex_algorithm.cpp
   src/bullet/tesseract_gjk_pair_detector.cpp
 )
-target_link_libraries(${PROJECT_NAME}_bullet PUBLIC ${PROJECT_NAME}_core tesseract::tesseract_geometry console_bridge octomap octomath)
+target_link_libraries(${PROJECT_NAME}_bullet PUBLIC ${PROJECT_NAME}_core tesseract::tesseract_geometry PkgConfig::bullet console_bridge octomap octomath)
 target_compile_options(${PROJECT_NAME}_bullet PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(${PROJECT_NAME}_bullet ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_bullet PUBLIC VERSION ${TESSERACT_CXX_VERSION})
@@ -73,7 +74,6 @@ target_include_directories(${PROJECT_NAME}_bullet PUBLIC
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_bullet SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIRS}
-    ${BULLET_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS})
 
 # Create target for FCL implementation
@@ -81,7 +81,7 @@ add_library(${PROJECT_NAME}_fcl SHARED
   src/fcl/fcl_discrete_managers.cpp
   src/fcl/fcl_utils.cpp
   src/fcl/fcl_collision_object_wrapper.cpp)
-target_link_libraries(${PROJECT_NAME}_fcl PUBLIC ${PROJECT_NAME}_core tesseract::tesseract_geometry console_bridge octomap octomath fcl)
+target_link_libraries(${PROJECT_NAME}_fcl PUBLIC ${PROJECT_NAME}_core tesseract::tesseract_geometry PkgConfig::bullet console_bridge octomap octomath fcl)
 target_compile_options(${PROJECT_NAME}_fcl PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(${PROJECT_NAME}_fcl ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_fcl PUBLIC VERSION ${TESSERACT_CXX_VERSION})
@@ -91,12 +91,11 @@ target_include_directories(${PROJECT_NAME}_fcl PUBLIC
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_fcl SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIRS}
-    ${BULLET_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS})
 
 # Create target for creating convex hull's from meshes
 add_executable(create_convex_hull src/create_convex_hull.cpp)
-target_link_libraries(create_convex_hull PUBLIC tesseract::tesseract_common tesseract::tesseract_geometry console_bridge ${BULLET_LIBRARIES} ${Boost_LIBRARIES} octomap octomath)
+target_link_libraries(create_convex_hull PUBLIC tesseract::tesseract_common tesseract::tesseract_geometry console_bridge PkgConfig::bullet ${Boost_LIBRARIES} octomap octomath)
 target_compile_options(create_convex_hull PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(create_convex_hull ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(create_convex_hull PRIVATE VERSION ${TESSERACT_CXX_VERSION})
@@ -104,7 +103,6 @@ target_compile_definitions(create_convex_hull PRIVATE "-DBT_USE_DOUBLE_PRECISION
 target_include_directories(create_convex_hull PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_include_directories(create_convex_hull SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIRS}
-    ${BULLET_INCLUDE_DIRS}
     ${LIBFCL_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS})
 

--- a/tesseract/tesseract_collision/CMakeLists.txt
+++ b/tesseract/tesseract_collision/CMakeLists.txt
@@ -100,7 +100,6 @@ target_link_libraries(create_convex_hull PUBLIC tesseract::tesseract_common tess
 target_compile_options(create_convex_hull PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(create_convex_hull ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(create_convex_hull PRIVATE VERSION ${TESSERACT_CXX_VERSION})
-target_code_coverage(create_convex_hull ALL EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_TESTING})
 target_compile_definitions(create_convex_hull PRIVATE "-DBT_USE_DOUBLE_PRECISION")
 target_include_directories(create_convex_hull PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 target_include_directories(create_convex_hull SYSTEM PUBLIC

--- a/tesseract/tesseract_collision/cmake/tesseract_collision-config.cmake.in
+++ b/tesseract/tesseract_collision/cmake/tesseract_collision-config.cmake.in
@@ -16,9 +16,12 @@ find_dependency(console_bridge)
 find_dependency(tesseract_common)
 find_dependency(tesseract_geometry)
 find_dependency(tesseract_support)
-find_dependency(Bullet)
 find_dependency(fcl)
 find_dependency(ccd)
+
+# Find Bullet using PkgConfig which is the recommended way
+find_dependency(PkgConfig)
+pkg_check_modules(bullet REQUIRED IMPORTED_TARGET bullet)
 
 # These targets are necessary for 16.04 builds. Remove when Kinetic support is dropped
 if(NOT TARGET octomap)

--- a/tesseract/tesseract_collision/examples/CMakeLists.txt
+++ b/tesseract/tesseract_collision/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(${PROJECT_NAME}_box_box_example box_box_example.cpp)
-target_link_libraries(${PROJECT_NAME}_box_box_example ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl tesseract::tesseract_geometry console_bridge ${BULLET_LIBRARIES} ${Boost_LIBRARIES} octomap octomath ${${LIBFCL_LIBRARIES}})
+target_link_libraries(${PROJECT_NAME}_box_box_example ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl tesseract::tesseract_geometry console_bridge PkgConfig::bullet ${Boost_LIBRARIES} octomap octomath ${${LIBFCL_LIBRARIES}})
 target_compile_options(${PROJECT_NAME}_box_box_example PRIVATE ${TESSERACT_COMPILE_OPTIONS})
 target_clang_tidy(${PROJECT_NAME}_box_box_example ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_box_box_example PRIVATE VERSION ${TESSERACT_CXX_VERSION})

--- a/tesseract/tesseract_collision/test/CMakeLists.txt
+++ b/tesseract/tesseract_collision/test/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(tesseract_scene_graph REQUIRED)
 
 macro(add_gtest test_name test_file)
   add_executable(${test_name} ${test_file})
-  target_link_libraries(${test_name} PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME}_test_suite ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl tesseract::tesseract_geometry tesseract::tesseract_scene_graph console_bridge ${BULLET_LIBRARIES} ${Boost_LIBRARIES} octomap octomath ${LIBFCL_LIBRARIES})
+  target_link_libraries(${test_name} PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME}_test_suite ${PROJECT_NAME}_bullet ${PROJECT_NAME}_fcl tesseract::tesseract_geometry tesseract::tesseract_scene_graph console_bridge PkgConfig::bullet ${Boost_LIBRARIES} octomap octomath ${LIBFCL_LIBRARIES})
   target_compile_options(${test_name} PRIVATE ${TESSERACT_COMPILE_OPTIONS})
   target_clang_tidy(${test_name} ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_cxx_version(${test_name} PRIVATE VERSION ${TESSERACT_CXX_VERSION})

--- a/tesseract/tesseract_collision/test/benchmarks/CMakeLists.txt
+++ b/tesseract/tesseract_collision/test/benchmarks/CMakeLists.txt
@@ -15,7 +15,7 @@ macro(add_benchmark benchmark_name benchmark_file)
       tesseract::tesseract_geometry
       tesseract::tesseract_scene_graph
       console_bridge
-      ${BULLET_LIBRARIES}
+      PkgConfig::bullet
       ${Boost_LIBRARIES}
       octomap octomath
       ${LIBFCL_LIBRARIES}

--- a/tesseract/tesseract_common/include/tesseract_common/utils.h
+++ b/tesseract/tesseract_common/include/tesseract_common/utils.h
@@ -44,7 +44,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_common
 {
-#if __cplusplus <= 201402
+#if __cplusplus < 201703L
 /** @brief Random number generator */
 static std::mt19937 mersenne{ static_cast<std::mt19937::result_type>(std::time(nullptr)) };
 #else

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
@@ -39,26 +39,12 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-class CartesianWaypoint : public Eigen::Isometry3d
+class CartesianWaypoint
 {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   CartesianWaypoint() = default;
-
-  // This constructor allows you to construct MyVectorType from Eigen expressions
-  template <typename OtherDerived>
-  CartesianWaypoint(const Eigen::MatrixBase<OtherDerived>& other) : Eigen::Isometry3d(other)
-  {
-  }
-
-  // This method allows you to assign Eigen expressions to MyVectorType
-  template <typename OtherDerived>
-  CartesianWaypoint& operator=(const Eigen::MatrixBase<OtherDerived>& other)
-  {
-    this->Eigen::Isometry3d::operator=(other);
-    return *this;
-  }
-
-  CartesianWaypoint(const Eigen::Isometry3d& other) : Eigen::Isometry3d(other) {}
 
   CartesianWaypoint(const tinyxml2::XMLElement& xml_element)
   {
@@ -143,12 +129,6 @@ public:
     }
   }
 
-  CartesianWaypoint& operator=(const Eigen::Isometry3d& other)
-  {
-    this->Eigen::Isometry3d::operator=(other);
-    return *this;
-  }
-
   int getType() const { return static_cast<int>(WaypointType::CARTESIAN_WAYPOINT); }
 
   tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const
@@ -171,6 +151,105 @@ public:
 
     return xml_waypoint;
   }
+
+  /////////////////////
+  // Eigen Container //
+  /////////////////////
+
+  using ConstLinearPart = Eigen::Isometry3d::ConstLinearPart;
+  using LinearPart = Eigen::Isometry3d::LinearPart;
+  using ConstTranslationPart = Eigen::Isometry3d::ConstTranslationPart;
+  using TranslationPart = Eigen::Isometry3d::TranslationPart;
+
+  ////////////////////////
+  // Eigen Constructors //
+  ////////////////////////
+
+  // This constructor allows you to construct from Eigen expressions
+  template <typename OtherDerived>
+  CartesianWaypoint(const Eigen::MatrixBase<OtherDerived>& other) : waypoint(other)
+  {
+  }
+
+  CartesianWaypoint(const Eigen::Isometry3d& other) : waypoint(other) {}
+
+  ///////////////////
+  // Eigen Methods //
+  ///////////////////
+
+  /** @returns a read-only expression of the linear part of the transformation */
+  inline ConstLinearPart linear() const { return waypoint.linear(); }
+
+  /** @returns a writable expression of the linear part of the transformation */
+  inline LinearPart linear() { return waypoint.linear(); }
+
+  /** @returns a read-only expression of the translation vector of the transformation */
+  inline ConstTranslationPart translation() const { return waypoint.translation(); }
+
+  /** @returns a writable expression of the translation vector of the transformation */
+  inline TranslationPart translation() { return waypoint.translation(); }
+
+  /** @returns true if two are approximate */
+  inline bool isApprox(const Eigen::Isometry3d& other, double prec = 1e-12) { return waypoint.isApprox(other, prec); }
+
+  /////////////////////
+  // Eigen Operators //
+  /////////////////////
+
+  // This method allows you to assign Eigen expressions to MyVectorType
+  template <typename OtherDerived>
+  inline CartesianWaypoint& operator=(const Eigen::MatrixBase<OtherDerived>& other)
+  {
+    waypoint = other;
+    return *this;
+  }
+
+  template <typename OtherDerived>
+  inline CartesianWaypoint& operator*=(const Eigen::MatrixBase<OtherDerived>& other)
+  {
+    waypoint = waypoint * other;
+    return *this;
+  }
+
+  template <typename OtherDerived>
+  inline CartesianWaypoint operator*(const Eigen::MatrixBase<OtherDerived>& other) const
+  {
+    CartesianWaypoint cwp = *this;
+    cwp.waypoint = cwp.waypoint * other;
+    return cwp;
+  }
+
+  inline CartesianWaypoint& operator=(const Eigen::Isometry3d& other)
+  {
+    waypoint = other;
+    return *this;
+  }
+
+  inline CartesianWaypoint& operator*=(const Eigen::Isometry3d& other) { return *this = waypoint * other; }
+
+  inline CartesianWaypoint operator*(const Eigen::Isometry3d& other) const
+  {
+    CartesianWaypoint cwp = *this;
+    cwp.waypoint = cwp.waypoint * other;
+    return cwp;
+  }
+
+  //////////////////////////
+  // Implicit Conversions //
+  //////////////////////////
+
+  /** @return Implicit Conversions to read-only Eigen::Isometry3d */
+  inline operator const Eigen::Isometry3d&() const { return waypoint; }
+
+  /** @return Implicit Conversions to writable Eigen::Isometry3d */
+  inline operator Eigen::Isometry3d&() { return waypoint; }
+
+  //////////////////////////////////
+  // Cartesian Waypoint Container //
+  //////////////////////////////////
+
+  /** @brief The Cartesian Waypoint */
+  Eigen::Isometry3d waypoint;
 };
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
@@ -47,7 +47,7 @@ enum class CompositeInstructionOrder
   ORDERED_AND_REVERABLE  // Can go forward or reverse the order
 };
 
-class CompositeInstruction : public std::vector<Instruction>
+class CompositeInstruction
 {
 public:
   using Ptr = std::shared_ptr<CompositeInstruction>;
@@ -81,7 +81,138 @@ public:
 
   tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const;
 
+  // C++ container support
+
+  /** value_type */
+  using value_type = Instruction;
+  /** pointer */
+  using pointer = typename std::vector<value_type>::pointer;
+  /** const_pointer */
+  using const_pointer = typename std::vector<value_type>::const_pointer;
+  /** reference */
+  using reference = typename std::vector<value_type>::reference;
+  /** const_reference */
+  using const_reference = typename std::vector<value_type>::const_reference;
+  /** size_type */
+  using size_type = typename std::vector<value_type>::size_type;
+  /** difference_type */
+  using difference_type = typename std::vector<value_type>::difference_type;
+  /** iterator */
+  using iterator = typename std::vector<value_type>::iterator;
+  /** const_iterator */
+  using const_iterator = typename std::vector<value_type>::const_iterator;
+  /** reverse_iterator */
+  using reverse_iterator = typename std::vector<value_type>::reverse_iterator;
+  /** const_reverse_iterator */
+  using const_reverse_iterator = typename std::vector<value_type>::const_reverse_iterator;
+
+  ///////////////
+  // Iterators //
+  ///////////////
+  /** @brief returns an iterator to the beginning */
+  iterator begin();
+  /** @brief returns an iterator to the beginning */
+  const_iterator begin() const;
+  /** @brief returns an iterator to the end */
+  iterator end();
+  /** @brief returns an iterator to the end */
+  const_iterator end() const;
+  /** @brief returns a reverse iterator to the beginning */
+  reverse_iterator rbegin();
+  /** @brief returns a reverse iterator to the beginning */
+  const_reverse_iterator rbegin() const;
+  /** @brief returns a reverse iterator to the end */
+  reverse_iterator rend();
+  /** @brief returns a reverse iterator to the end */
+  const_reverse_iterator crend() const;
+  /** @brief returns a reverse iterator to the end */
+  const_reverse_iterator rend() const;
+  /** @brief returns an iterator to the beginning */
+  const_iterator cbegin() const;
+  /** @brief returns an iterator to the end */
+  const_iterator cend() const;
+  /** @brief returns a reverse iterator to the beginning */
+  const_reverse_iterator const crbegin();
+  /** @brief returns a reverse iterator to the end */
+  const_reverse_iterator const crend();
+
+  //////////////
+  // Capacity //
+  //////////////
+  /** @brief checks whether the container is empty */
+  bool empty() const;
+  /** @brief returns the number of elements */
+  size_type size() const;
+  /** @brief returns the maximum possible number of elements */
+  size_type max_size() const;
+  /** @brief reserve number of elements */
+  void reserve(size_type n);
+  /** @brief returns the number of elements that can be held in currently allocated storage */
+  size_type capacity() const;
+  /** @brief reduces memory usage by freeing unused memory  */
+  void shrink_to_fit();
+
+  ////////////////////
+  // Element Access //
+  ////////////////////
+  /** @brief access the first element */
+  reference front();
+  /** @brief access the first element */
+  const_reference front() const;
+  /** @brief access the last element */
+  reference back();
+  /** @brief access the last element */
+  const_reference back() const;
+  /** @brief access specified element with bounds checking */
+  reference at(size_type n);
+  /** @brief access specified element with bounds checking */
+  const_reference at(size_type n) const;
+  /** @brief direct access to the underlying array  */
+  pointer data();
+  /** @brief direct access to the underlying array  */
+  const_pointer data() const;
+  /** @brief access specified element */
+  reference operator[](size_type pos);
+  /** @brief access specified element */
+  const_reference operator[](size_type pos) const;
+
+  ///////////////
+  // Modifiers //
+  ///////////////
+  /** @brief clears the contents */
+  void clear();
+  /** @brief inserts element */
+  iterator insert(const_iterator p, const value_type& x);
+  iterator insert(const_iterator p, value_type&& x);
+  iterator insert(const_iterator p, std::initializer_list<value_type> l);
+
+  /** @brief constructs element in-place */
+  template <class... Args>
+  iterator emplace(const_iterator pos, Args&&... args);
+
+  /** @brief erases element */
+  iterator erase(const_iterator p);
+  iterator erase(const_iterator first, const_iterator last);
+  /** @brief adds an element to the end */
+  void push_back(const value_type& x);
+  void push_back(const value_type&& x);
+
+  /** @brief constructs an element in-place at the end  */
+  template <typename... Args>
+#if __cplusplus > 201402L
+  reference emplace_back(Args&&... args);
+#else
+  void emplace_back(Args&&... args);
+#endif
+
+  /** @brief removes the last element */
+  void pop_back();
+  /** @brief swaps the contents  */
+  void swap(std::vector<value_type>& other);
+
 private:
+  std::vector<value_type> container_;
+
   int type_{ static_cast<int>(InstructionType::COMPOSITE_INSTRUCTION) };
 
   /** @brief The description of the instruction */
@@ -106,7 +237,7 @@ private:
    *
    * If not provided, the planner should use the current state of the robot is used and defined as fixed.
    */
-  Instruction start_instruction_{ NullInstruction() };
+  value_type start_instruction_{ NullInstruction() };
 };
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
@@ -117,4 +117,92 @@ tinyxml2::XMLElement* CompositeInstruction::toXML(tinyxml2::XMLDocument& doc) co
   return xml_instruction;
 }
 
+///////////////
+// Iterators //
+///////////////
+CompositeInstruction::iterator CompositeInstruction::begin() { return container_.begin(); }
+CompositeInstruction::const_iterator CompositeInstruction::begin() const { return container_.begin(); }
+CompositeInstruction::iterator CompositeInstruction::end() { return container_.end(); }
+CompositeInstruction::const_iterator CompositeInstruction::end() const { return container_.end(); }
+CompositeInstruction::reverse_iterator CompositeInstruction::rbegin() { return container_.rbegin(); }
+CompositeInstruction::const_reverse_iterator CompositeInstruction::rbegin() const { return container_.rbegin(); }
+CompositeInstruction::reverse_iterator CompositeInstruction::rend() { return container_.rend(); }
+CompositeInstruction::const_reverse_iterator CompositeInstruction::crend() const { return container_.crend(); }
+CompositeInstruction::const_reverse_iterator CompositeInstruction::rend() const { return container_.rend(); }
+CompositeInstruction::const_iterator CompositeInstruction::cbegin() const { return container_.cbegin(); }
+CompositeInstruction::const_iterator CompositeInstruction::cend() const { return container_.cend(); }
+CompositeInstruction::const_reverse_iterator const CompositeInstruction::crbegin() { return container_.crbegin(); }
+CompositeInstruction::const_reverse_iterator const CompositeInstruction::crend() { return container_.crend(); }
+
+//////////////
+// Capacity //
+//////////////
+bool CompositeInstruction::empty() const { return container_.empty(); }
+CompositeInstruction::size_type CompositeInstruction::size() const { return container_.size(); }
+CompositeInstruction::size_type CompositeInstruction::max_size() const { return container_.max_size(); }
+void CompositeInstruction::reserve(size_type n) { container_.reserve(n); }
+CompositeInstruction::size_type CompositeInstruction::capacity() const { return container_.capacity(); }
+void CompositeInstruction::shrink_to_fit() { container_.shrink_to_fit(); }
+
+////////////////////
+// Element Access //
+////////////////////
+CompositeInstruction::reference CompositeInstruction::front() { return container_.front(); }
+CompositeInstruction::const_reference CompositeInstruction::front() const { return container_.front(); }
+CompositeInstruction::reference CompositeInstruction::back() { return container_.back(); }
+CompositeInstruction::const_reference CompositeInstruction::back() const { return container_.back(); }
+CompositeInstruction::reference CompositeInstruction::at(size_type n) { return container_.at(n); }
+CompositeInstruction::const_reference CompositeInstruction::at(size_type n) const { return container_.at(n); }
+CompositeInstruction::pointer CompositeInstruction::data() { return container_.data(); }
+CompositeInstruction::const_pointer CompositeInstruction::data() const { return container_.data(); }
+CompositeInstruction::reference CompositeInstruction::operator[](size_type pos) { return container_[pos]; }
+CompositeInstruction::const_reference CompositeInstruction::operator[](size_type pos) const { return container_[pos]; };
+
+///////////////
+// Modifiers //
+///////////////
+void CompositeInstruction::clear() { container_.clear(); }
+CompositeInstruction::iterator CompositeInstruction::insert(const_iterator p, const value_type& x)
+{
+  return container_.insert(p, x);
+}
+CompositeInstruction::iterator CompositeInstruction::insert(const_iterator p, value_type&& x)
+{
+  return container_.insert(p, x);
+}
+CompositeInstruction::iterator CompositeInstruction::insert(const_iterator p, std::initializer_list<value_type> l)
+{
+  return container_.insert(p, l);
+}
+
+template <class... Args>
+CompositeInstruction::iterator CompositeInstruction::emplace(const_iterator pos, Args&&... args)
+{
+  return container_.emplace(pos, std::forward<Args>(args)...);
+}
+
+CompositeInstruction::iterator CompositeInstruction::erase(const_iterator p) { return container_.erase(p); }
+CompositeInstruction::iterator CompositeInstruction::erase(const_iterator first, const_iterator last)
+{
+  return container_.erase(first, last);
+}
+void CompositeInstruction::push_back(const value_type& x) { container_.push_back(x); }
+void CompositeInstruction::push_back(const value_type&& x) { container_.push_back(x); }
+
+template <typename... Args>
+#if __cplusplus > 201402L
+CompositeInstruction::reference CompositeInstruction::emplace_back(Args&&... args)
+{
+  return container_.emplace_back(std::forward<Args>(args)...);
+}
+#else
+void CompositeInstruction::emplace_back(Args&&... args)
+{
+  container_.emplace_back(std::forward<Args>(args)...);
+}
+#endif
+
+void CompositeInstruction::pop_back() { container_.pop_back(); }
+void CompositeInstruction::swap(std::vector<value_type>& other) { container_.swap(other); }
+
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
@@ -205,11 +205,10 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointJoint)  // NOLINT
 
   // Specify a JointWaypoint as the start
   JointWaypoint wp1(joint_names, Eigen::VectorXd::Zero(7));
-  wp1 << 0, 0, 0, -1.57, 0, 0, 0;
+  wp1 = { 0, 0, 0, -1.57, 0, 0, 0 };
 
   // Specify a Joint Waypoint as the finish
-  JointWaypoint wp2(joint_names, Eigen::VectorXd::Zero(7));
-  wp2 << 0, 0, 0, 1.57, 0, 0, 0;
+  JointWaypoint wp2(joint_names, { 0, 0, 0, 1.57, 0, 0, 0 });
 
   // Define Start Instruction
   PlanInstruction start_instruction(wp1, PlanInstructionType::START, "TEST_PROFILE");


### PR DESCRIPTION
Having the CompositeInstruction inherit directly form std:vector was going to make python wrapper very difficult or even impossible leveraging SWIG. Same issues exists for the JointWaypoint and CartesianWaypoint. This remove the inheritance and adds all of the container methods required.