### PR TITLE
Add utility for getting profiles

### DIFF
--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/command_language.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/command_language.h
@@ -28,6 +28,7 @@
 
 #include <tesseract_command_language/cartesian_waypoint.h>
 #include <tesseract_command_language/composite_instruction.h>
+#include <tesseract_command_language/constants.h>
 #include <tesseract_command_language/instruction_type.h>
 #include <tesseract_command_language/joint_waypoint.h>
 #include <tesseract_command_language/manipulator_info.h>

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/core/instruction.h>
+#include <tesseract_command_language/constants.h>
 #include <tesseract_command_language/instruction_type.h>
 #include <tesseract_command_language/manipulator_info.h>
 #include <tesseract_command_language/null_instruction.h>
@@ -53,7 +54,7 @@ public:
   using Ptr = std::shared_ptr<CompositeInstruction>;
   using ConstPtr = std::shared_ptr<const CompositeInstruction>;
 
-  CompositeInstruction(std::string profile = "DEFAULT",
+  CompositeInstruction(std::string profile = DEFAULT_PROFILE_KEY,
                        CompositeInstructionOrder order = CompositeInstructionOrder::ORDERED,
                        ManipulatorInfo manipulator_info = ManipulatorInfo());
 
@@ -226,7 +227,7 @@ private:
    *
    * If it has a child composite instruction it uses the child composites profile for that section
    */
-  std::string profile_{ "DEFAULT" };
+  std::string profile_{ DEFAULT_PROFILE_KEY };
 
   /** @brief The order of the composite instruction */
   CompositeInstructionOrder order_{ CompositeInstructionOrder::ORDERED };

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/constants.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/constants.h
@@ -1,0 +1,33 @@
+/**
+ * @file constants.h
+ * @brief Containst Tesseract Command Language constants
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COMMAND_LANGUAGE_CONSTANTS_H
+#define TESSERACT_COMMAND_LANGUAGE_CONSTANTS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <string>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_planning
+{
+/** @brief Set to DEFAULT. Default profiles are given this name. */
+static const std::string DEFAULT_PROFILE_KEY = "DEFAULT";
+
+}  // namespace tesseract_planning
+#endif  // TESSERACT_COMMAND_LANGUAGE_CONSTANTS_H

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -33,6 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/core/waypoint.h>
+#include <tesseract_command_language/constants.h>
 #include <tesseract_command_language/instruction_type.h>
 #include <tesseract_command_language/manipulator_info.h>
 
@@ -54,7 +55,7 @@ public:
 
   MoveInstruction(Waypoint waypoint,
                   MoveInstructionType type,
-                  const std::string& profile = "DEFAULT",
+                  const std::string& profile = DEFAULT_PROFILE_KEY,
                   ManipulatorInfo manipulator_info = ManipulatorInfo());
 
   void setWaypoint(Waypoint waypoint);
@@ -97,7 +98,7 @@ private:
   std::string description_;
 
   /** @brief The profile used for this move instruction */
-  std::string profile_{ "DEFAULT" };
+  std::string profile_{ DEFAULT_PROFILE_KEY };
 
   /** @brief The assigned waypoint (Cartesian or Joint) */
   Waypoint waypoint_;

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/core/waypoint.h>
+#include <tesseract_command_language/constants.h>
 #include <tesseract_command_language/instruction_type.h>
 #include <tesseract_command_language/manipulator_info.h>
 
@@ -55,7 +56,7 @@ public:
 
   PlanInstruction(Waypoint waypoint,
                   PlanInstructionType type,
-                  std::string profile = "DEFAULT",
+                  std::string profile = DEFAULT_PROFILE_KEY,
                   ManipulatorInfo manipulator_info = ManipulatorInfo());
 
   void setWaypoint(Waypoint waypoint);
@@ -100,7 +101,7 @@ private:
   Waypoint waypoint_;
 
   /** @brief The profile used for this plan instruction */
-  std::string profile_{ "DEFAULT" };
+  std::string profile_{ DEFAULT_PROFILE_KEY };
 
   /** @brief Contains information about the manipulator associated with this instruction*/
   ManipulatorInfo manipulator_info_;

--- a/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/composite_instruction.cpp
@@ -52,7 +52,7 @@ void CompositeInstruction::setDescription(const std::string& description) { desc
 
 void CompositeInstruction::setProfile(const std::string& profile)
 {
-  profile_ = (profile.empty()) ? "DEFAULT" : profile;
+  profile_ = (profile.empty()) ? DEFAULT_PROFILE_KEY : profile;
 }
 const std::string& CompositeInstruction::getProfile() const { return profile_; }
 

--- a/tesseract/tesseract_planning/tesseract_command_language/src/move_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/move_instruction.cpp
@@ -58,7 +58,10 @@ void MoveInstruction::setManipulatorInfo(ManipulatorInfo info) { manipulator_inf
 const ManipulatorInfo& MoveInstruction::getManipulatorInfo() const { return manipulator_info_; }
 ManipulatorInfo& MoveInstruction::getManipulatorInfo() { return manipulator_info_; }
 
-void MoveInstruction::setProfile(const std::string& profile) { profile_ = (profile.empty()) ? "DEFAULT" : profile; }
+void MoveInstruction::setProfile(const std::string& profile)
+{
+  profile_ = (profile.empty()) ? DEFAULT_PROFILE_KEY : profile;
+}
 const std::string& MoveInstruction::getProfile() const { return profile_; }
 
 int MoveInstruction::getType() const { return type_; }

--- a/tesseract/tesseract_planning/tesseract_command_language/src/plan_instruction.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/plan_instruction.cpp
@@ -49,7 +49,10 @@ void PlanInstruction::setManipulatorInfo(ManipulatorInfo info) { manipulator_inf
 const ManipulatorInfo& PlanInstruction::getManipulatorInfo() const { return manipulator_info_; }
 ManipulatorInfo& PlanInstruction::getManipulatorInfo() { return manipulator_info_; }
 
-void PlanInstruction::setProfile(const std::string& profile) { profile_ = (profile.empty()) ? "DEFAULT" : profile; }
+void PlanInstruction::setProfile(const std::string& profile)
+{
+  profile_ = (profile.empty()) ? DEFAULT_PROFILE_KEY : profile;
+}
 const std::string& PlanInstruction::getProfile() const { return profile_; }
 
 int PlanInstruction::getType() const { return type_; }

--- a/tesseract/tesseract_planning/tesseract_command_language/test/serialize_test.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/test/serialize_test.cpp
@@ -101,7 +101,7 @@ CompositeInstruction getProgram()
     transition_from_start.setDescription("transition_from_start");
     transition_from_start.push_back(plan_f1);
 
-    CompositeInstruction transitions("DEFAULT", CompositeInstructionOrder::UNORDERED);
+    CompositeInstruction transitions(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::UNORDERED);
     transitions.setDescription("transitions");
     transitions.push_back(transition_from_start);
     transitions.push_back(transition_from_end);
@@ -130,7 +130,7 @@ CompositeInstruction getProgram()
     transition_from_start.setDescription("transition_from_start");
     transition_from_start.push_back(plan_f1);
 
-    CompositeInstruction transitions("DEFAULT", CompositeInstructionOrder::UNORDERED);
+    CompositeInstruction transitions(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::UNORDERED);
     transitions.setDescription("transitions");
     transitions.push_back(transition_from_start);
     transitions.push_back(transition_from_end);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
@@ -72,9 +72,6 @@ public:
   /** @brief Clear the data structures used by the planner */
   virtual void clear() = 0;
 
-  /** @brief Set to DEFAULT. Default profiles are given this name. */
-  static const std::string DEFAULT_PROFILE_KEY;
-
 protected:
   std::string name_; /**< @brief The name of this planner */
 };

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
@@ -72,6 +72,9 @@ public:
   /** @brief Clear the data structures used by the planner */
   virtual void clear() = 0;
 
+  /** @brief Set to DEFAULT. Default profiles are given this name. */
+  static const std::string DEFAULT_PROFILE_KEY;
+
 protected:
   std::string name_; /**< @brief The name of this planner */
 };

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -45,6 +45,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/descartes/descartes_motion_planner.h>
+#include <tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h>
 #include <tesseract_motion_planners/core/utils.h>
 
 #include <tesseract_command_language/command_language.h>
@@ -56,6 +57,7 @@ template <typename FloatType>
 DescartesMotionPlanner<FloatType>::DescartesMotionPlanner(std::string name)
   : MotionPlanner(name), status_category_(std::make_shared<const DescartesMotionPlannerStatusCategory>(name))
 {
+  plan_profiles["DEFAULT"] = std::make_shared<DescartesDefaultPlanProfile<FloatType>>();
 }
 
 template <typename FloatType>

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -57,7 +57,7 @@ template <typename FloatType>
 DescartesMotionPlanner<FloatType>::DescartesMotionPlanner(std::string name)
   : MotionPlanner(name), status_category_(std::make_shared<const DescartesMotionPlannerStatusCategory>(name))
 {
-  plan_profiles["DEFAULT"] = std::make_shared<DescartesDefaultPlanProfile<FloatType>>();
+  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<DescartesDefaultPlanProfile<FloatType>>();
 }
 
 template <typename FloatType>

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
@@ -121,7 +121,8 @@ DefaultDescartesProblemGenerator(const std::string& name,
   }
 
   profile = getProfileString(profile, name, request.plan_profile_remapping);
-  auto cur_plan_profile = getProfile<DescartesPlanProfile<FloatType>>(profile, plan_profiles);
+  auto cur_plan_profile = getProfile<DescartesPlanProfile<FloatType>>(
+      profile, plan_profiles, std::make_shared<DescartesDefaultPlanProfile<FloatType>>());
   if (!cur_plan_profile)
     throw std::runtime_error("DescartesMotionPlannerConfig: Invalid profile");
 
@@ -167,7 +168,8 @@ DefaultDescartesProblemGenerator(const std::string& name,
       // Get Plan Profile
       std::string profile = plan_instruction->getProfile();
       profile = getProfileString(profile, name, request.plan_profile_remapping);
-      auto cur_plan_profile = getProfile<DescartesPlanProfile<FloatType>>(profile, plan_profiles);
+      auto cur_plan_profile = getProfile<DescartesPlanProfile<FloatType>>(
+          profile, plan_profiles, std::make_shared<DescartesDefaultPlanProfile<FloatType>>());
       if (!cur_plan_profile)
         throw std::runtime_error("DescartesMotionPlannerConfig: Invalid profile");
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
@@ -28,6 +28,7 @@
 
 #include <tesseract_motion_planners/core/utils.h>
 #include <tesseract_motion_planners/descartes/descartes_problem.h>
+#include <tesseract_motion_planners/planner_utils.h>
 #include <tesseract_motion_planners/descartes/profile/descartes_profile.h>
 #include <tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h>
 #include <tesseract_kinematics/core/validate.h>
@@ -119,25 +120,10 @@ DefaultDescartesProblemGenerator(const std::string& name,
     start_waypoint = swp;
   }
 
-  // Check Start Profile
-  if (profile.empty())
-    profile = "DEFAULT";
-
-  // Check for remapping of profile
-  auto remap = request.plan_profile_remapping.find(name);
-  if (remap != request.plan_profile_remapping.end())
-  {
-    auto p = remap->second.find(profile);
-    if (p != remap->second.end())
-      profile = p->second;
-  }
-
-  typename DescartesPlanProfile<FloatType>::Ptr cur_plan_profile{ nullptr };
-  auto it = plan_profiles.find(profile);
-  if (it == plan_profiles.end())
-    cur_plan_profile = std::make_shared<DescartesDefaultPlanProfile<FloatType>>();
-  else
-    cur_plan_profile = it->second;
+  profile = getProfileString(profile, name, request.plan_profile_remapping);
+  auto cur_plan_profile = getProfile<DescartesPlanProfile<FloatType>>(profile, plan_profiles);
+  if (!cur_plan_profile)
+    throw std::runtime_error("DescartesMotionPlannerConfig: Invalid profile");
 
   // Add start waypoint
   if (isCartesianWaypoint(start_waypoint))
@@ -180,24 +166,10 @@ DefaultDescartesProblemGenerator(const std::string& name,
 
       // Get Plan Profile
       std::string profile = plan_instruction->getProfile();
-      if (profile.empty())
-        profile = "DEFAULT";
-
-      // Check for remapping of profile
-      auto remap = request.plan_profile_remapping.find(name);
-      if (remap != request.plan_profile_remapping.end())
-      {
-        auto p = remap->second.find(profile);
-        if (p != remap->second.end())
-          profile = p->second;
-      }
-
-      typename DescartesPlanProfile<FloatType>::Ptr cur_plan_profile{ nullptr };
-      auto it = plan_profiles.find(profile);
-      if (it == plan_profiles.end())
-        cur_plan_profile = std::make_shared<DescartesDefaultPlanProfile<FloatType>>();
-      else
-        cur_plan_profile = it->second;
+      profile = getProfileString(profile, name, request.plan_profile_remapping);
+      auto cur_plan_profile = getProfile<DescartesPlanProfile<FloatType>>(profile, plan_profiles);
+      if (!cur_plan_profile)
+        throw std::runtime_error("DescartesMotionPlannerConfig: Invalid profile");
 
       if (plan_instruction->isLinear())
       {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/planner_utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/planner_utils.h
@@ -132,30 +132,29 @@ inline std::string getProfileString(const std::string& profile,
   return results;
 }
 
+/**
+ * @brief Gets the profile specified from the profile map
+ * @param profile The requested profile
+ * @param profile_map map that contains the profiles
+ * @param default_profile Profile that is returned if the requested profile is not found in the map. Default = nullptr
+ * @return The profile requested if found. Otherwise the default_profile
+ */
 template <typename ProfileType>
 std::shared_ptr<ProfileType>
-getProfile(const std::string& profile, const std::unordered_map<std::string, std::shared_ptr<ProfileType>>& profile_map, std::string default_profile = "DEFAULT")
+getProfile(const std::string& profile,
+           const std::unordered_map<std::string, std::shared_ptr<ProfileType>>& profile_map,
+           std::shared_ptr<ProfileType> default_profile = nullptr)
 {
-  std::string profile_string = profile;
   std::shared_ptr<ProfileType> results;
-  auto it = profile_map.find(profile_string);
+  auto it = profile_map.find(profile);
 
-  // If profile not found, look for default_profile.
   if (it == profile_map.end())
   {
-    profile_string = default_profile;
-    CONSOLE_BRIDGE_logDebug("Profile %s was not found. Setting to %s. Available profiles:", default_profile.c_str(), profile.c_str());
+    CONSOLE_BRIDGE_logDebug("Profile %s was not found. Using default if available. Available profiles:",
+                            profile.c_str());
     for (const auto& pair : profile_map)
       CONSOLE_BRIDGE_logDebug("%s", pair.first.c_str());
-    it = profile_map.find(profile_string);
-  }
-
-  // If default_profile not found, print an error
-  if (it == profile_map.end())
-  {
-    CONSOLE_BRIDGE_logError("Profile %s was not found. Available profiles:", profile.c_str());
-    for (const auto& pair : profile_map)
-      CONSOLE_BRIDGE_logError("%s", pair.first.c_str());
+    results = default_profile;
   }
   else
     results = it->second;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/planner_utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/planner_utils.h
@@ -134,10 +134,23 @@ inline std::string getProfileString(const std::string& profile,
 
 template <typename ProfileType>
 std::shared_ptr<ProfileType>
-getProfile(const std::string& profile, const std::unordered_map<std::string, std::shared_ptr<ProfileType>>& profile_map)
+getProfile(const std::string& profile, const std::unordered_map<std::string, std::shared_ptr<ProfileType>>& profile_map, std::string default_profile = "DEFAULT")
 {
+  std::string profile_string = profile;
   std::shared_ptr<ProfileType> results;
-  auto it = profile_map.find(profile);
+  auto it = profile_map.find(profile_string);
+
+  // If profile not found, look for default_profile.
+  if (it == profile_map.end())
+  {
+    profile_string = default_profile;
+    CONSOLE_BRIDGE_logDebug("Profile %s was not found. Setting to %s. Available profiles:", default_profile.c_str(), profile.c_str());
+    for (const auto& pair : profile_map)
+      CONSOLE_BRIDGE_logDebug("%s", pair.first.c_str());
+    it = profile_map.find(profile_string);
+  }
+
+  // If default_profile not found, print an error
   if (it == profile_map.end())
   {
     CONSOLE_BRIDGE_logError("Profile %s was not found. Available profiles:", profile.c_str());

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/planner_utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/planner_utils.h
@@ -29,7 +29,10 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
+#include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_motion_planners/robot_config.h>
+#include <tesseract_motion_planners/core/types.h>
 
 namespace tesseract_planning
 {
@@ -101,6 +104,51 @@ bool isValidState(const tesseract_kinematics::ForwardKinematics::ConstPtr& robot
   return !(robot_config != RobotConfig::FUT && robot_config != RobotConfig::NUT);
 }
 
+/**
+ * @brief Get the profile string taking into account defaults and profile remapping
+ * @param profile The requested profile name in the instructions
+ * @param planner_name Used to look up if there are remappings available
+ * @param profile_remapping Remapping used to remap a profile name based on the planner name
+ * @param default_profile Default = DEFAULT. This is set if profile.empty()
+ * @return The profile string taking into account defaults and profile remapping
+ */
+inline std::string getProfileString(const std::string& profile,
+                                    const std::string& planner_name,
+                                    const PlannerProfileRemapping& profile_remapping,
+                                    std::string default_profile = "DEFAULT")
+{
+  std::string results = profile;
+  if (profile.empty())
+    results = std::move(default_profile);
+
+  // Check for remapping of profile
+  auto remap = profile_remapping.find(planner_name);
+  if (remap != profile_remapping.end())
+  {
+    auto p = remap->second.find(profile);
+    if (p != remap->second.end())
+      results = p->second;
+  }
+  return results;
+}
+
+template <typename ProfileType>
+std::shared_ptr<ProfileType>
+getProfile(const std::string& profile, const std::unordered_map<std::string, std::shared_ptr<ProfileType>>& profile_map)
+{
+  std::shared_ptr<ProfileType> results;
+  auto it = profile_map.find(profile);
+  if (it == profile_map.end())
+  {
+    CONSOLE_BRIDGE_logError("Profile %s was not found. Available profiles:", profile.c_str());
+    for (const auto& pair : profile_map)
+      CONSOLE_BRIDGE_logError("%s", pair.first.c_str());
+  }
+  else
+    results = it->second;
+
+  return results;
+}
 }  // namespace tesseract_planning
 
 #endif  // TESSERACT_MOTION_PLANNERS_PLANNER_UTILS_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/core/planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/core/planner.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file planner.cpp
+ * @brief
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_motion_planners/core/planner.h>
+
+namespace tesseract_planning
+{
+const std::string MotionPlanner::DEFAULT_PROFILE_KEY = "DEFAULT";
+
+};  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -90,7 +90,7 @@ bool checkGoalState(const ompl::base::ProblemDefinitionPtr& prob_def,
 OMPLMotionPlanner::OMPLMotionPlanner(std::string name)
   : MotionPlanner(std::move(name)), status_category_(std::make_shared<const OMPLMotionPlannerStatusCategory>(name_))
 {
-  plan_profiles["DEFAULT"] = std::make_shared<OMPLDefaultPlanProfile>();
+  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<OMPLDefaultPlanProfile>();
 }
 
 bool OMPLMotionPlanner::terminate()

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -39,6 +39,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/ompl/ompl_motion_planner.h>
 #include <tesseract_motion_planners/ompl/continuous_motion_validator.h>
 #include <tesseract_motion_planners/ompl/discrete_motion_validator.h>
+#include <tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h>
 #include <tesseract_motion_planners/ompl/weighted_real_vector_state_sampler.h>
 #include <tesseract_motion_planners/core/utils.h>
 
@@ -89,6 +90,7 @@ bool checkGoalState(const ompl::base::ProblemDefinitionPtr& prob_def,
 OMPLMotionPlanner::OMPLMotionPlanner(std::string name)
   : MotionPlanner(std::move(name)), status_category_(std::make_shared<const OMPLMotionPlannerStatusCategory>(name_))
 {
+  plan_profiles["DEFAULT"] = std::make_shared<OMPLDefaultPlanProfile>();
 }
 
 bool OMPLMotionPlanner::terminate()

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
@@ -146,7 +146,8 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& nam
       // Get Plan Profile
       std::string profile = plan_instruction->getProfile();
       profile = getProfileString(profile, name, request.plan_profile_remapping);
-      auto cur_plan_profile = getProfile<OMPLPlanProfile>(profile, plan_profiles);
+      auto cur_plan_profile =
+          getProfile<OMPLPlanProfile>(profile, plan_profiles, std::make_shared<OMPLDefaultPlanProfile>());
       if (!cur_plan_profile)
         throw std::runtime_error("OMPLMotionPlannerDefaultConfig: Invalid profile");
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
@@ -26,6 +26,7 @@
 
 #include <tesseract_kinematics/core/validate.h>
 #include <tesseract/tesseract.h>
+#include <tesseract_motion_planners/planner_utils.h>
 #include <tesseract_motion_planners/core/types.h>
 #include <tesseract_motion_planners/ompl/problem_generators/default_problem_generator.h>
 #include <tesseract_command_language/utils/utils.h>
@@ -144,24 +145,10 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& nam
 
       // Get Plan Profile
       std::string profile = plan_instruction->getProfile();
-      if (profile.empty())
-        profile = "DEFAULT";
-
-      // Check for remapping of profile
-      auto remap = request.plan_profile_remapping.find(name);
-      if (remap != request.plan_profile_remapping.end())
-      {
-        auto p = remap->second.find(profile);
-        if (p != remap->second.end())
-          profile = p->second;
-      }
-
-      typename OMPLPlanProfile::Ptr cur_plan_profile{ nullptr };
-      auto it = plan_profiles.find(profile);
-      if (it == plan_profiles.end())
-        cur_plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
-      else
-        cur_plan_profile = it->second;
+      profile = getProfileString(profile, name, request.plan_profile_remapping);
+      auto cur_plan_profile = getProfile<OMPLPlanProfile>(profile, plan_profiles);
+      if (!cur_plan_profile)
+        throw std::runtime_error("OMPLMotionPlannerDefaultConfig: Invalid profile");
 
       /** @todo Should check that the joint names match the order of the manipulator */
       OMPLProblem::Ptr sub_prob = CreateOMPLSubProblem(request, manip_fwd_kin_, manip_inv_kin_, active_link_names_);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -72,7 +72,7 @@ std::string SimpleMotionPlannerStatusCategory::message(int code) const
 SimpleMotionPlanner::SimpleMotionPlanner(std::string name)
   : MotionPlanner(std::move(name)), status_category_(std::make_shared<const SimpleMotionPlannerStatusCategory>(name_))
 {
-  plan_profiles["DEFAULT"] = std::make_shared<SimplePlannerDefaultPlanProfile>();
+  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<SimplePlannerDefaultPlanProfile>();
 }
 
 bool SimpleMotionPlanner::terminate()

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -37,6 +37,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/utils/utils.h>
 #include <tesseract_command_language/state_waypoint.h>
+#include <tesseract_motion_planners/planner_utils.h>
 
 using namespace trajopt;
 
@@ -213,25 +214,10 @@ CompositeInstruction SimpleMotionPlanner::processCompositeInstruction(const Comp
       assert(is_cwp1 || is_jwp1 || is_swp1);
       assert(is_cwp2 || is_jwp2 || is_swp2);
 
-      std::string profile = plan_instruction->getProfile();
-      if (profile.empty())
-        profile = "DEFAULT";
-
-      // Check for remapping of profile
-      auto remap = request.plan_profile_remapping.find(name_);
-      if (remap != request.plan_profile_remapping.end())
-      {
-        auto p = remap->second.find(profile);
-        if (p != remap->second.end())
-          profile = p->second;
-      }
-
-      SimplePlannerPlanProfile::Ptr start_plan_profile{ nullptr };
-      auto it = plan_profiles.find(profile);
-      if (it == plan_profiles.end())
-        start_plan_profile = std::make_shared<SimplePlannerDefaultPlanProfile>();
-      else
-        start_plan_profile = it->second;
+      std::string profile = getProfileString(plan_instruction->getProfile(), name_, request.plan_profile_remapping);
+      SimplePlannerPlanProfile::Ptr start_plan_profile = getProfile<SimplePlannerPlanProfile>(profile, plan_profiles);
+      if (!start_plan_profile)
+        throw std::runtime_error("SimpleMotionPlanner: Invalid start profile");
 
       if (plan_instruction->isLinear())
       {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -215,7 +215,8 @@ CompositeInstruction SimpleMotionPlanner::processCompositeInstruction(const Comp
       assert(is_cwp2 || is_jwp2 || is_swp2);
 
       std::string profile = getProfileString(plan_instruction->getProfile(), name_, request.plan_profile_remapping);
-      SimplePlannerPlanProfile::Ptr start_plan_profile = getProfile<SimplePlannerPlanProfile>(profile, plan_profiles);
+      SimplePlannerPlanProfile::Ptr start_plan_profile = getProfile<SimplePlannerPlanProfile>(
+          profile, plan_profiles, std::make_shared<SimplePlannerDefaultPlanProfile>());
       if (!start_plan_profile)
         throw std::runtime_error("SimpleMotionPlanner: Invalid start profile");
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
@@ -28,6 +28,7 @@
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h>
 #include <tesseract_motion_planners/core/utils.h>
+#include <tesseract_motion_planners/planner_utils.h>
 
 namespace tesseract_planning
 {
@@ -105,25 +106,10 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
     start_waypoint = swp;
   }
 
-  // Get Plan Profile
-  if (profile.empty())
-    profile = "DEFAULT";
-
-  // Check for remapping of profile
-  auto remap = request.plan_profile_remapping.find(name);
-  if (remap != request.plan_profile_remapping.end())
-  {
-    auto p = remap->second.find(profile);
-    if (p != remap->second.end())
-      profile = p->second;
-  }
-
-  TrajOptPlanProfile::Ptr start_plan_profile{ nullptr };
-  auto it = plan_profiles.find(profile);
-  if (it == plan_profiles.end())
-    start_plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
-  else
-    start_plan_profile = it->second;
+  profile = getProfileString(profile, name, request.plan_profile_remapping);
+  TrajOptPlanProfile::Ptr start_plan_profile = getProfile<TrajOptPlanProfile>(profile, plan_profiles);
+  if (!start_plan_profile)
+    throw std::runtime_error("TrajOptPlannerUniversalConfig: Invalid profile");
 
   // Add start seed state
   assert(request.seed.hasStartInstruction());
@@ -170,26 +156,10 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
       const auto* seed_composite = seed_flat[i].get().cast_const<tesseract_planning::CompositeInstruction>();
       auto interpolate_cnt = static_cast<int>(seed_composite->size());
 
-      // Get Plan Profile
-      std::string profile = plan_instruction->getProfile();
-      if (profile.empty())
-        profile = "DEFAULT";
-
-      // Check for remapping of profile
-      auto remap = request.plan_profile_remapping.find(name);
-      if (remap != request.plan_profile_remapping.end())
-      {
-        auto p = remap->second.find(profile);
-        if (p != remap->second.end())
-          profile = p->second;
-      }
-
-      TrajOptPlanProfile::Ptr cur_plan_profile{ nullptr };
-      auto it = plan_profiles.find(profile);
-      if (it == plan_profiles.end())
-        cur_plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
-      else
-        cur_plan_profile = it->second;
+      std::string profile = getProfileString(plan_instruction->getProfile(), name, request.plan_profile_remapping);
+      TrajOptPlanProfile::Ptr cur_plan_profile = getProfile<TrajOptPlanProfile>(profile, plan_profiles);
+      if (!start_plan_profile)
+        throw std::runtime_error("TrajOptPlannerUniversalConfig: Invalid profile");
 
       if (plan_instruction->isLinear())
       {
@@ -385,29 +355,10 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
   for (long i = 0; i < pci->basic_info.n_steps; ++i)
     pci->init_info.data.row(i) = seed_states[static_cast<std::size_t>(i)];
 
-  // Apply Composite Profile
-  profile = request.instructions.getProfile();
-  if (profile.empty())
-    profile = "DEFAULT";
-
-  // Check for remapping of profile
-  remap = request.composite_profile_remapping.find(name);
-  if (remap != request.composite_profile_remapping.end())
-  {
-    auto p = remap->second.find(profile);
-    if (p != remap->second.end())
-      profile = p->second;
-  }
-
-  TrajOptCompositeProfile::Ptr cur_composite_profile{ nullptr };
-  auto it_composite = composite_profiles.find(profile);
-  if (it_composite == composite_profiles.end())
-  {
-    CONSOLE_BRIDGE_logDebug("Trajopt profile not found. Setting default");
-    cur_composite_profile = std::make_shared<TrajOptDefaultCompositeProfile>();
-  }
-  else
-    cur_composite_profile = it_composite->second;
+  profile = getProfileString(profile, name, request.composite_profile_remapping);
+  TrajOptCompositeProfile::Ptr cur_composite_profile = getProfile<TrajOptCompositeProfile>(profile, composite_profiles);
+  if (!cur_composite_profile)
+    throw std::runtime_error("TrajOptPlannerUniversalConfig: Invalid profile");
 
   cur_composite_profile->apply(*pci, 0, pci->basic_info.n_steps - 1, composite_mi, active_links, fixed_steps);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
@@ -107,7 +107,8 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
   }
 
   profile = getProfileString(profile, name, request.plan_profile_remapping);
-  TrajOptPlanProfile::Ptr start_plan_profile = getProfile<TrajOptPlanProfile>(profile, plan_profiles);
+  TrajOptPlanProfile::Ptr start_plan_profile =
+      getProfile<TrajOptPlanProfile>(profile, plan_profiles, std::make_shared<TrajOptDefaultPlanProfile>());
   if (!start_plan_profile)
     throw std::runtime_error("TrajOptPlannerUniversalConfig: Invalid profile");
 
@@ -157,7 +158,8 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
       auto interpolate_cnt = static_cast<int>(seed_composite->size());
 
       std::string profile = getProfileString(plan_instruction->getProfile(), name, request.plan_profile_remapping);
-      TrajOptPlanProfile::Ptr cur_plan_profile = getProfile<TrajOptPlanProfile>(profile, plan_profiles);
+      TrajOptPlanProfile::Ptr cur_plan_profile =
+          getProfile<TrajOptPlanProfile>(profile, plan_profiles, std::make_shared<TrajOptDefaultPlanProfile>());
       if (!start_plan_profile)
         throw std::runtime_error("TrajOptPlannerUniversalConfig: Invalid profile");
 
@@ -356,7 +358,8 @@ trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name
     pci->init_info.data.row(i) = seed_states[static_cast<std::size_t>(i)];
 
   profile = getProfileString(profile, name, request.composite_profile_remapping);
-  TrajOptCompositeProfile::Ptr cur_composite_profile = getProfile<TrajOptCompositeProfile>(profile, composite_profiles);
+  TrajOptCompositeProfile::Ptr cur_composite_profile = getProfile<TrajOptCompositeProfile>(
+      profile, composite_profiles, std::make_shared<TrajOptDefaultCompositeProfile>());
   if (!cur_composite_profile)
     throw std::runtime_error("TrajOptPlannerUniversalConfig: Invalid profile");
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -37,6 +37,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt/trajopt_motion_planner.h>
+#include <tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h>
+#include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/utils/utils.h>
 #include <tesseract_motion_planners/core/utils.h>
@@ -74,6 +76,8 @@ std::string TrajOptMotionPlannerStatusCategory::message(int code) const
 TrajOptMotionPlanner::TrajOptMotionPlanner(std::string name)
   : MotionPlanner(std::move(name)), status_category_(std::make_shared<const TrajOptMotionPlannerStatusCategory>(name_))
 {
+  plan_profiles["DEFAULT"] = std::make_shared<TrajOptDefaultPlanProfile>();
+  composite_profiles["DEFAULT"] = std::make_shared<TrajOptDefaultCompositeProfile>();
 }
 
 bool TrajOptMotionPlanner::terminate()

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -76,8 +76,8 @@ std::string TrajOptMotionPlannerStatusCategory::message(int code) const
 TrajOptMotionPlanner::TrajOptMotionPlanner(std::string name)
   : MotionPlanner(std::move(name)), status_category_(std::make_shared<const TrajOptMotionPlannerStatusCategory>(name_))
 {
-  plan_profiles["DEFAULT"] = std::make_shared<TrajOptDefaultPlanProfile>();
-  composite_profiles["DEFAULT"] = std::make_shared<TrajOptDefaultCompositeProfile>();
+  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<TrajOptDefaultPlanProfile>();
+  composite_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<TrajOptDefaultCompositeProfile>();
 }
 
 bool TrajOptMotionPlanner::terminate()

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/utils_test.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/utils_test.cpp
@@ -31,6 +31,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract/tesseract.h>
 #include <tesseract_motion_planners/core/utils.h>
+#include <tesseract_motion_planners/planner_utils.h>
 #include <tesseract_command_language/plan_instruction.h>
 
 using namespace tesseract;
@@ -86,6 +87,40 @@ TEST_F(TesseractPlanningUtilsUnit, GenerateSeed)  // NOLINT
 {
   EXPECT_TRUE(true);
 }
+
+TEST_F(TesseractPlanningUtilsUnit, GetProfileStringTest)
+{
+  std::string input_profile = "";
+  std::string planner_name = "Planner_1";
+  std::string default_planner = "TEST_DEFAULT";
+
+  std::unordered_map<std::string, std::string> remap;
+  remap["profile_1"] = "profile_1_remapped";
+  PlannerProfileRemapping remapping;
+  remapping["Planner_2"] = remap;
+
+  // Empty input profile
+  std::string output_profile = getProfileString(input_profile, planner_name, remapping);
+  EXPECT_EQ(output_profile, "DEFAULT");
+  output_profile = getProfileString(input_profile, planner_name, remapping, default_planner);
+  EXPECT_EQ(output_profile, default_planner);
+
+  // Planner name doesn't match
+  input_profile = "profile_1";
+  output_profile = getProfileString(input_profile, planner_name, remapping, default_planner);
+  EXPECT_EQ(input_profile, output_profile);
+
+  // Profile name doesn't match
+  input_profile = "doesnt_match";
+  output_profile = getProfileString(input_profile, "Planner_2", remapping, default_planner);
+  EXPECT_EQ(input_profile, output_profile);
+
+  // Successful remap
+  input_profile = "profile_1";
+  output_profile = getProfileString(input_profile, "Planner_2", remapping, default_planner);
+  EXPECT_EQ(output_profile, "profile_1_remapped");
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/iterative_spline_parameterization_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/iterative_spline_parameterization_process_generator.cpp
@@ -29,6 +29,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_motion_planners/planner_utils.h>
 #include <tesseract_process_managers/process_generators/iterative_spline_parameterization_process_generator.h>
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_command_language/move_instruction.h>
@@ -84,29 +85,12 @@ int IterativeSplineParameterizationProcessGenerator::conditionalProcess(ProcessI
   const ManipulatorInfo& manip_info = ci->getManipulatorInfo();
   const auto fwd_kin = input.tesseract->getManipulatorManager()->getFwdKinematicSolver(manip_info.manipulator);
 
-  // Get Composite profile
+  // Get Plan Profile
   std::string profile = ci->getProfile();
-  if (profile.empty())
-    profile = "DEFAULT";
-
-  // Check for remapping of composite profile
-  {
-    auto remap = input.composite_profile_remapping.find(name_);
-    if (remap != input.composite_profile_remapping.end())
-    {
-      auto p = remap->second.find(profile);
-      if (p != remap->second.end())
-        profile = p->second;
-    }
-  }
-
-  // Get the parameters associated with this profile
-  typename IterativeSplineParameterizationProfile::Ptr cur_plan_profile{ nullptr };
-  auto it = composite_profiles.find(profile);
-  if (it == composite_profiles.end())
-    cur_plan_profile = std::make_shared<IterativeSplineParameterizationProfile>();
-  else
-    cur_plan_profile = it->second;
+  profile = getProfileString(profile, name_, input.composite_profile_remapping);
+  auto cur_composite_profile = getProfile<IterativeSplineParameterizationProfile>(profile, composite_profiles);
+  if (!cur_composite_profile)
+    cur_composite_profile = std::make_shared<IterativeSplineParameterizationProfile>();
 
   // Create data structures for checking for plan profile overrides
   auto flattened = flatten(*ci, moveFilter);
@@ -117,23 +101,18 @@ int IterativeSplineParameterizationProcessGenerator::conditionalProcess(ProcessI
   }
 
   Eigen::VectorXd velocity_scaling_factors = Eigen::VectorXd::Ones(static_cast<Eigen::Index>(flattened.size())) *
-                                             cur_plan_profile->max_velocity_scaling_factor;
+                                             cur_composite_profile->max_velocity_scaling_factor;
   Eigen::VectorXd acceleration_scaling_factors = Eigen::VectorXd::Ones(static_cast<Eigen::Index>(flattened.size())) *
-                                                 cur_plan_profile->max_acceleration_scaling_factor;
+                                                 cur_composite_profile->max_acceleration_scaling_factor;
 
   // Loop over all PlanInstructions
   for (Eigen::Index idx = 0; idx < static_cast<Eigen::Index>(flattened.size()); idx++)
   {
     profile = flattened[static_cast<std::size_t>(idx)].get().cast_const<MoveInstruction>()->getProfile();
 
-    // Check for remapping of plan profile
-    auto remap = input.plan_profile_remapping.find(name_);
-    if (remap != input.plan_profile_remapping.end())
-    {
-      auto p = remap->second.find(profile);
-      if (p != remap->second.end())
-        profile = p->second;
-    }
+    // Check for remapping of the plan profile
+    std::string remap = getProfileString(profile, name_, input.plan_profile_remapping);
+    auto cur_composite_profile = getProfile<IterativeSplineParameterizationProfile>(profile, composite_profiles);
 
     // If there is a move profile associated with it, override the parameters
     auto it = move_profiles.find(profile);

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/iterative_spline_parameterization_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/iterative_spline_parameterization_process_generator.cpp
@@ -88,7 +88,8 @@ int IterativeSplineParameterizationProcessGenerator::conditionalProcess(ProcessI
   // Get Plan Profile
   std::string profile = ci->getProfile();
   profile = getProfileString(profile, name_, input.composite_profile_remapping);
-  auto cur_composite_profile = getProfile<IterativeSplineParameterizationProfile>(profile, composite_profiles);
+  auto cur_composite_profile = getProfile<IterativeSplineParameterizationProfile>(
+      profile, composite_profiles, std::make_shared<IterativeSplineParameterizationProfile>());
   if (!cur_composite_profile)
     cur_composite_profile = std::make_shared<IterativeSplineParameterizationProfile>();
 
@@ -112,7 +113,8 @@ int IterativeSplineParameterizationProcessGenerator::conditionalProcess(ProcessI
 
     // Check for remapping of the plan profile
     std::string remap = getProfileString(profile, name_, input.plan_profile_remapping);
-    auto cur_composite_profile = getProfile<IterativeSplineParameterizationProfile>(profile, composite_profiles);
+    auto cur_composite_profile = getProfile<IterativeSplineParameterizationProfile>(
+        profile, composite_profiles, std::make_shared<IterativeSplineParameterizationProfile>());
 
     // If there is a move profile associated with it, override the parameters
     auto it = move_profiles.find(profile);


### PR DESCRIPTION
Consolidates all of the profile remapping into a single utility that gets used everywhere. Addresses #391. Note that all planners should now set a "DEFAULT" profile