### PR TITLE
Fixed SRDF parse

### DIFF
--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/groups.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/groups.h
@@ -135,7 +135,7 @@ parseGroups(const tesseract_scene_graph::SceneGraph& scene_graph,
     }
   }
 
-  return std::make_tuple(group_names, chain_groups, link_groups, joint_groups);
+  return std::make_tuple(group_names, chain_groups, joint_groups, link_groups);
 }
 }  // namespace tesseract_scene_graph
 


### PR DESCRIPTION
This tuple is constructed in the wrong order.

The puzzle piece examples (tesseract_ros) on master branch were not working due to this issue.