### PR TITLE
Fix simple lvs tests

### DIFF
--- a/.github/workflows/bionic_build.yml
+++ b/.github/workflows/bionic_build.yml
@@ -27,7 +27,7 @@ jobs:
       PARALLEL_TESTS: false
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
-      AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_scene_graph tesseract_urdf --make-args test'
+      AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_process_managers tesseract_time_parameterization tesseract_scene_graph tesseract_urdf --make-args test'
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/xenial_build.yml
+++ b/.github/workflows/xenial_build.yml
@@ -27,7 +27,7 @@ jobs:
       PARALLEL_TESTS: false
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON"
-      AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_scene_graph tesseract_urdf --make-args test'
+      AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_motion_planners tesseract_time_parameterization tesseract_scene_graph tesseract_urdf --make-args test'
     steps:
       - uses: actions/checkout@v1
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/interface_utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/interface_utils.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_default_plan_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_default_lvs_plan_profile.h>
 
 namespace tesseract_planning
 {
@@ -42,8 +42,10 @@ namespace tesseract_planning
 inline CompositeInstruction generateSeed(const CompositeInstruction& instructions,
                                          const tesseract_environment::EnvState::ConstPtr& current_state,
                                          const tesseract::Tesseract::ConstPtr& tesseract,
-                                         int freespace_steps = 10,
-                                         int cartesian_steps = 10)
+                                         double state_longest_valid_segment_length = 5 * M_PI / 180,
+                                         double translation_longest_valid_segment_length = 0.15,
+                                         double rotation_longest_valid_segment_length = 5 * M_PI / 180,
+                                         int min_steps = 1)
 {
   // Fill out request and response
   PlannerRequest request;
@@ -55,7 +57,10 @@ inline CompositeInstruction generateSeed(const CompositeInstruction& instruction
   // Set up planner
   SimpleMotionPlanner planner;
 
-  auto profile = std::make_shared<SimplePlannerDefaultPlanProfile>(freespace_steps, cartesian_steps);
+  auto profile = std::make_shared<SimplePlannerDefaultLVSPlanProfile>(state_longest_valid_segment_length,
+                                                                      translation_longest_valid_segment_length,
+                                                                      rotation_longest_valid_segment_length,
+                                                                      min_steps);
   planner.plan_profiles[instructions.getProfile()] = profile;
   auto flat = flattenProgram(instructions);
   for (const auto& i : flat)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/profile/simple_planner_default_lvs_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/profile/simple_planner_default_lvs_plan_profile.h
@@ -44,7 +44,7 @@ public:
   using ConstPtr = std::shared_ptr<const SimplePlannerDefaultLVSPlanProfile>;
 
   SimplePlannerDefaultLVSPlanProfile(double state_longest_valid_segment_length = 5 * M_PI / 180,
-                                     double translation_longest_valid_segment_length = 0.15,
+                                     double translation_longest_valid_segment_length = 0.1,
                                      double rotation_longest_valid_segment_length = 5 * M_PI / 180,
                                      int min_steps = 1);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -32,7 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_default_plan_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_default_lvs_plan_profile.h>
 #include <tesseract_motion_planners/core/utils.h>
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/utils/utils.h>
@@ -72,7 +72,7 @@ std::string SimpleMotionPlannerStatusCategory::message(int code) const
 SimpleMotionPlanner::SimpleMotionPlanner(std::string name)
   : MotionPlanner(std::move(name)), status_category_(std::make_shared<const SimpleMotionPlannerStatusCategory>(name_))
 {
-  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<SimplePlannerDefaultPlanProfile>();
+  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<SimplePlannerDefaultLVSPlanProfile>();
 }
 
 bool SimpleMotionPlanner::terminate()
@@ -215,7 +215,7 @@ CompositeInstruction SimpleMotionPlanner::processCompositeInstruction(const Comp
 
       std::string profile = getProfileString(plan_instruction->getProfile(), name_, request.plan_profile_remapping);
       SimplePlannerPlanProfile::Ptr start_plan_profile = getProfile<SimplePlannerPlanProfile>(
-          profile, plan_profiles, std::make_shared<SimplePlannerDefaultPlanProfile>());
+          profile, plan_profiles, std::make_shared<SimplePlannerDefaultLVSPlanProfile>());
       if (!start_plan_profile)
         throw std::runtime_error("SimpleMotionPlanner: Invalid start profile");
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/lvs_interpolation.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/lvs_interpolation.cpp
@@ -53,6 +53,7 @@ CompositeInstruction LVSInterpolateStateWaypoint(const JointWaypoint& start,
   assert(static_cast<long>(end.joint_names.size()) == end.size());
 
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   CompositeInstruction composite;
 
@@ -60,8 +61,6 @@ CompositeInstruction LVSInterpolateStateWaypoint(const JointWaypoint& start,
   {
     // Find number of states based on cartesian
     // Then find values
-    const ManipulatorInfo& mi =
-        (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
 
     // Initialize
     auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
@@ -137,12 +136,10 @@ CompositeInstruction LVSInterpolateStateWaypoint(const JointWaypoint& start,
                                                  int min_steps)
 {
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Joint waypoints should have joint names
   assert(static_cast<long>(start.joint_names.size()) == start.size());
-
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
 
   // Initialize
   auto inv_kin = request.tesseract->getManipulatorManager()->getInvKinematicSolver(mi.manipulator);
@@ -251,12 +248,10 @@ CompositeInstruction LVSInterpolateStateWaypoint(const CartesianWaypoint& start,
                                                  int min_steps)
 {
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Joint waypoints should have joint names
   assert(static_cast<long>(end.joint_names.size()) == end.size());
-
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
 
   // Initialize
   auto inv_kin = request.tesseract->getManipulatorManager()->getInvKinematicSolver(mi.manipulator);
@@ -365,9 +360,7 @@ CompositeInstruction LVSInterpolateStateWaypoint(const CartesianWaypoint& start,
                                                  int min_steps)
 {
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
-
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto inv_kin = request.tesseract->getManipulatorManager()->getInvKinematicSolver(mi.manipulator);
@@ -410,7 +403,7 @@ CompositeInstruction LVSInterpolateStateWaypoint(const CartesianWaypoint& start,
       /// @todo: May be nice to add contact checking to find best solution, but may not be neccessary because this is
       /// used to generate the seed.
       auto j2_solution = j2.middleRows(j * dof, dof);
-      double d = (j2 - j1).norm();
+      double d = (j2_solution - j1_solution).norm();
       if (d < dist)
       {
         j1_final = j1_solution;
@@ -486,8 +479,7 @@ CompositeInstruction LVSInterpolateCartStateWaypoint(const JointWaypoint& start,
   throw std::runtime_error("Not implemented, PR's are welcome!");
 
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
@@ -546,8 +538,7 @@ CompositeInstruction LVSInterpolateCartStateWaypoint(const JointWaypoint& start,
   throw std::runtime_error("Not implemented, PR's are welcome!");
 
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
@@ -603,8 +594,7 @@ CompositeInstruction LVSInterpolateCartStateWaypoint(const CartesianWaypoint& st
   throw std::runtime_error("Not implemented, PR's are welcome!");
 
   assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
-  const ManipulatorInfo& mi =
-      (base_instruction.getManipulatorInfo().empty()) ? manip_info : base_instruction.getManipulatorInfo();
+  ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
 
   // Initialize
   auto fwd_kin = request.tesseract->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_utils.cpp
@@ -166,6 +166,9 @@ trajopt::TermInfo::Ptr createCollisionTermInfo(int start_index,
 trajopt::TermInfo::Ptr
 createSmoothVelocityTermInfo(int start_index, int end_index, int n_joints, double coeff, trajopt::TermType type)
 {
+  if ((end_index - start_index) < 2)
+    throw std::runtime_error("TrajOpt JointVelTermInfo requires at least two states!");
+
   std::shared_ptr<trajopt::JointVelTermInfo> jv = std::make_shared<trajopt::JointVelTermInfo>();
   jv->coeffs = std::vector<double>(static_cast<std::size_t>(n_joints), coeff);
   jv->targets = std::vector<double>(static_cast<std::size_t>(n_joints), 0.0);
@@ -181,6 +184,9 @@ trajopt::TermInfo::Ptr createSmoothVelocityTermInfo(int start_index,
                                                     const Eigen::Ref<const Eigen::VectorXd>& coeff,
                                                     trajopt::TermType type)
 {
+  if ((end_index - start_index) < 2)
+    throw std::runtime_error("TrajOpt JointVelTermInfo requires at least two states!");
+
   std::shared_ptr<trajopt::JointVelTermInfo> jv = std::make_shared<trajopt::JointVelTermInfo>();
   jv->coeffs = std::vector<double>(coeff.data(), coeff.data() + coeff.size());
   jv->targets = std::vector<double>(static_cast<std::size_t>(coeff.size()), 0.0);
@@ -194,6 +200,9 @@ trajopt::TermInfo::Ptr createSmoothVelocityTermInfo(int start_index,
 trajopt::TermInfo::Ptr
 createSmoothAccelerationTermInfo(int start_index, int end_index, int n_joints, double coeff, trajopt::TermType type)
 {
+  if ((end_index - start_index) < 3)
+    throw std::runtime_error("TrajOpt JointAccTermInfo requires at least three states!");
+
   std::shared_ptr<trajopt::JointAccTermInfo> ja = std::make_shared<trajopt::JointAccTermInfo>();
   ja->coeffs = std::vector<double>(static_cast<std::size_t>(n_joints), coeff);
   ja->targets = std::vector<double>(static_cast<std::size_t>(n_joints), 0.0);
@@ -209,6 +218,9 @@ trajopt::TermInfo::Ptr createSmoothAccelerationTermInfo(int start_index,
                                                         const Eigen::Ref<const Eigen::VectorXd>& coeff,
                                                         trajopt::TermType type)
 {
+  if ((end_index - start_index) < 3)
+    throw std::runtime_error("TrajOpt JointAccTermInfo requires at least three states!");
+
   std::shared_ptr<trajopt::JointAccTermInfo> ja = std::make_shared<trajopt::JointAccTermInfo>();
   ja->coeffs = std::vector<double>(coeff.data(), coeff.data() + coeff.size());
   ja->targets = std::vector<double>(static_cast<std::size_t>(coeff.size()), 0.0);
@@ -222,6 +234,9 @@ trajopt::TermInfo::Ptr createSmoothAccelerationTermInfo(int start_index,
 trajopt::TermInfo::Ptr
 createSmoothJerkTermInfo(int start_index, int end_index, int n_joints, double coeff, trajopt::TermType type)
 {
+  if ((end_index - start_index) < 5)
+    throw std::runtime_error("TrajOpt JointJerkTermInfo requires at least five states!");
+
   std::shared_ptr<trajopt::JointJerkTermInfo> jj = std::make_shared<trajopt::JointJerkTermInfo>();
   jj->coeffs = std::vector<double>(static_cast<std::size_t>(n_joints), coeff);
   jj->targets = std::vector<double>(static_cast<std::size_t>(n_joints), 0.0);
@@ -237,6 +252,9 @@ trajopt::TermInfo::Ptr createSmoothJerkTermInfo(int start_index,
                                                 const Eigen::Ref<const Eigen::VectorXd>& coeff,
                                                 trajopt::TermType type)
 {
+  if ((end_index - start_index) < 5)
+    throw std::runtime_error("TrajOpt JointJerkTermInfo requires at least five states!");
+
   std::shared_ptr<trajopt::JointJerkTermInfo> jj = std::make_shared<trajopt::JointJerkTermInfo>();
   jj->coeffs = std::vector<double>(coeff.data(), coeff.data() + coeff.size());
   jj->targets = std::vector<double>(static_cast<std::size_t>(coeff.size()), 0.0);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/descartes_planner_tests.cpp
@@ -132,7 +132,7 @@ TEST_F(TesseractPlanningDescartesUnit, DescartesPlannerFixedPoses)  // NOLINT
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<DescartesDefaultPlanProfileD>();
@@ -249,7 +249,7 @@ TEST_F(TesseractPlanningDescartesUnit, DescartesPlannerAxialSymetric)  // NOLINT
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<DescartesDefaultPlanProfileD>();
@@ -356,7 +356,7 @@ TEST_F(TesseractPlanningDescartesUnit, DescartesPlannerCollisionEdgeEvaluator)  
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 2, 2);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 2);
 
   // Create Profiles
   auto plan_profile = std::make_shared<DescartesDefaultPlanProfileD>();

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -195,7 +195,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
@@ -249,7 +249,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
   program.push_back(plan_f1);
 
   // Create a new seed
-  seed = generateSeed(program, cur_state, tesseract);
+  seed = generateSeed(program, cur_state, tesseract, 3.14, 1.0, 3.14, 10);
 
   // Update Configuration
   request.instructions = program;
@@ -284,7 +284,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
   program.push_back(plan_f1);
 
   // Create a new seed
-  seed = generateSeed(program, cur_state, tesseract);
+  seed = generateSeed(program, cur_state, tesseract, 3.14, 1.0, 3.14, 10);
 
   // Update Configuration
   request.instructions = program;
@@ -345,7 +345,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespaceCartesianGoalPlannerUnit)
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
@@ -434,7 +434,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespaceCartesianStartPlannerUnit)
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/simple_planner_lvs_interpolation.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/simple_planner_lvs_interpolation.cpp
@@ -119,7 +119,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
       wp1, wp2, instr, request, ManipulatorInfo(), longest_valid_segment_length, 10, 6.28, min_steps);
   double dist = (wp1 - wp2).norm();
   int steps = int(dist / longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_long.size()) > min_steps);
   EXPECT_EQ(composite_long.size(), steps);
 }
 
@@ -159,7 +159,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
   fwd_kin->calcFwdKin(p2, wp2);
   double trans_dist = (p2.translation() - p1.translation()).norm();
   int trans_steps = int(trans_dist / translation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_trans_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_trans_long.size()) > min_steps);
   EXPECT_EQ(composite_trans_long.size(), trans_steps);
 
   // Ensure rotation_longest_valid_segment_length is used
@@ -168,7 +168,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
       wp1, wp2, instr, request, ManipulatorInfo(), 6.28, 10, rotation_longest_valid_segment_length, min_steps);
   double rot_dist = Eigen::Quaterniond(p1.linear()).angularDistance(Eigen::Quaterniond(p2.linear()));
   int rot_steps = int(rot_dist / rotation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_rot_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_rot_long.size()) > min_steps);
   EXPECT_EQ(composite_rot_long.size(), rot_steps);
 }
 
@@ -207,7 +207,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
   double longest_valid_segment_length = 0.01;
   auto composite_long = LVSInterpolateStateWaypoint(
       wp1, wp2, instr, request, ManipulatorInfo(), longest_valid_segment_length, 10, 6.28, min_steps);
-  EXPECT_TRUE(composite_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_long.size()) > min_steps);
 }
 
 TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypoint_JointCart_Linear)  // NOLINT
@@ -250,7 +250,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
   fwd_kin->calcFwdKin(p1, wp1);
   double trans_dist = (wp2.translation() - p1.translation()).norm();
   int trans_steps = int(trans_dist / translation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_trans_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_trans_long.size()) > min_steps);
   EXPECT_EQ(composite_trans_long.size(), trans_steps);
 
   // Ensure rotation_longest_valid_segment_length is used
@@ -259,7 +259,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
       wp1, wp2, instr, request, ManipulatorInfo(), 6.28, 10, rotation_longest_valid_segment_length, min_steps);
   double rot_dist = Eigen::Quaterniond(p1.linear()).angularDistance(Eigen::Quaterniond(wp2.linear()));
   int rot_steps = int(rot_dist / rotation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_rot_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_rot_long.size()) > min_steps);
   EXPECT_EQ(composite_rot_long.size(), rot_steps);
 }
 
@@ -296,7 +296,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
   double longest_valid_segment_length = 0.01;
   auto composite_long = LVSInterpolateStateWaypoint(
       wp1, wp2, instr, request, ManipulatorInfo(), longest_valid_segment_length, 10, 6.28, min_steps);
-  EXPECT_TRUE(composite_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_long.size()) > min_steps);
 }
 
 TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypoint_CartJoint_Linear)  // NOLINT
@@ -336,7 +336,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
   fwd_kin->calcFwdKin(p2, wp2);
   double trans_dist = (p2.translation() - wp1.translation()).norm();
   int trans_steps = int(trans_dist / translation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_trans_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_trans_long.size()) > min_steps);
   EXPECT_EQ(composite_trans_long.size(), trans_steps);
 
   // Ensure rotation_longest_valid_segment_length is used
@@ -345,7 +345,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
       wp1, wp2, instr, request, ManipulatorInfo(), 6.28, 10, rotation_longest_valid_segment_length, min_steps);
   double rot_dist = Eigen::Quaterniond(wp1.linear()).angularDistance(Eigen::Quaterniond(p2.linear()));
   int rot_steps = int(rot_dist / rotation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_rot_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_rot_long.size()) > min_steps);
   EXPECT_EQ(composite_rot_long.size(), rot_steps);
 }
 
@@ -386,7 +386,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
   double longest_valid_segment_length = 0.01;
   auto composite_long = LVSInterpolateStateWaypoint(
       wp1, wp2, instr, request, ManipulatorInfo(), longest_valid_segment_length, 10, 6.28, min_steps);
-  EXPECT_TRUE(composite_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_long.size()) > min_steps);
 }
 
 TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypoint_CartCart_Linear)  // NOLINT
@@ -428,7 +428,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
       wp1, wp2, instr, request, ManipulatorInfo(), 6.28, translation_longest_valid_segment_length, 6.28, min_steps);
   double trans_dist = (wp2.translation() - wp1.translation()).norm();
   int trans_steps = int(trans_dist / translation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_trans_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_trans_long.size()) > min_steps);
   EXPECT_EQ(composite_trans_long.size(), trans_steps);
 
   // Ensure rotation_longest_valid_segment_length is used
@@ -437,7 +437,7 @@ TEST_F(TesseractPlanningSimplePlannerLVSInterpolationUnit, InterpolateStateWaypo
       wp1, wp2, instr, request, ManipulatorInfo(), 6.28, 10, rotation_longest_valid_segment_length, min_steps);
   double rot_dist = Eigen::Quaterniond(wp1.linear()).angularDistance(Eigen::Quaterniond(wp2.linear()));
   int rot_steps = int(rot_dist / rotation_longest_valid_segment_length) + 1;
-  EXPECT_TRUE(composite_rot_long.size() > static_cast<std::size_t>(min_steps));
+  EXPECT_TRUE(static_cast<int>(composite_rot_long.size()) > min_steps);
   EXPECT_EQ(composite_rot_long.size(), rot_steps);
 }
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
@@ -153,7 +153,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptPlannerBooleanFlagsJointJoint)  // N
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -223,7 +223,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointJoint)  // NOLINT
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -298,7 +298,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointCart)  // NOLINT
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -378,7 +378,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartJoint)  // NOLINT
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -458,7 +458,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartCart)  // NOLINT
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -538,7 +538,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptPlannerBooleanFlagsCartCart)  // NOL
   program.push_back(plan_f1);
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -626,7 +626,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayJointConstraint)  // NOLINT
   }
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
@@ -692,7 +692,7 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayJointCost)  // NOLINT
   }
 
   // Create a seed
-  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_);
+  CompositeInstruction seed = generateSeed(program, cur_state, tesseract_ptr_, 3.14, 1.0, 3.14, 10);
 
   // Create Profiles
   auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();

--- a/tesseract/tesseract_planning/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract/tesseract_planning/tesseract_process_managers/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(${PROJECT_NAME}
     src/process_generators/iterative_spline_parameterization_process_generator.cpp
     src/process_generators/motion_planner_process_generator.cpp
     src/process_generators/profile_switch_process_generator.cpp
+    src/process_generators/seed_min_length_process_generator.cpp
     src/process_managers/raster_process_manager.cpp
     src/process_managers/raster_global_process_manager.cpp
     src/process_managers/raster_only_process_manager.cpp

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_example_program.h
@@ -9,10 +9,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-inline CompositeInstruction freespaceExampleProgram()
+inline CompositeInstruction freespaceExampleProgramIIWA(std::string composite_profile = DEFAULT_PROFILE_KEY,
+                                                        std::string freespace_profile = DEFAULT_PROFILE_KEY)
 {
-  CompositeInstruction program(
-      "freespace_composite", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+  CompositeInstruction program(composite_profile, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
   // Start Joint Position for the program
   std::vector<std::string> joint_names = { "joint_a1", "joint_a2", "joint_a3", "joint_a4",
@@ -23,7 +23,27 @@ inline CompositeInstruction freespaceExampleProgram()
 
   // Define target pose
   Waypoint wp2 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.2, 0.2, 1.0));
-  PlanInstruction plan_f0(wp2, PlanInstructionType::FREESPACE, "DEFAULT");
+  PlanInstruction plan_f0(wp2, PlanInstructionType::FREESPACE, freespace_profile);
+  plan_f0.setDescription("freespace_motion");
+  program.push_back(plan_f0);
+
+  return program;
+}
+
+inline CompositeInstruction freespaceExampleProgramABB(std::string composite_profile = DEFAULT_PROFILE_KEY,
+                                                       std::string freespace_profile = DEFAULT_PROFILE_KEY)
+{
+  CompositeInstruction program(composite_profile, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+
+  // Start Joint Position for the program
+  std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6" };
+  Waypoint wp1 = StateWaypoint(joint_names, Eigen::VectorXd::Zero(6));
+  PlanInstruction start_instruction(wp1, PlanInstructionType::START);
+  program.setStartInstruction(start_instruction);
+
+  // Define target pose
+  Waypoint wp2 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.2, 0.2, 1.0));
+  PlanInstruction plan_f0(wp2, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f0.setDescription("freespace_motion");
   program.push_back(plan_f0);
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_example_program.h
@@ -9,8 +9,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-inline CompositeInstruction freespaceExampleProgramIIWA(std::string composite_profile = DEFAULT_PROFILE_KEY,
-                                                        std::string freespace_profile = DEFAULT_PROFILE_KEY)
+inline CompositeInstruction freespaceExampleProgramIIWA(const std::string& composite_profile = DEFAULT_PROFILE_KEY,
+                                                        const std::string& freespace_profile = DEFAULT_PROFILE_KEY)
 {
   CompositeInstruction program(composite_profile, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
@@ -30,8 +30,8 @@ inline CompositeInstruction freespaceExampleProgramIIWA(std::string composite_pr
   return program;
 }
 
-inline CompositeInstruction freespaceExampleProgramABB(std::string composite_profile = DEFAULT_PROFILE_KEY,
-                                                       std::string freespace_profile = DEFAULT_PROFILE_KEY)
+inline CompositeInstruction freespaceExampleProgramABB(const std::string& composite_profile = DEFAULT_PROFILE_KEY,
+                                                       const std::string& freespace_profile = DEFAULT_PROFILE_KEY)
 {
   CompositeInstruction program(composite_profile, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_manager_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/freespace_manager_example.cpp
@@ -69,7 +69,7 @@ int main()
   // --------------------
   // Define the program
   // --------------------
-  CompositeInstruction program = freespaceExampleProgram();
+  CompositeInstruction program = freespaceExampleProgramIIWA();
   const Instruction program_instruction{ program };
   Instruction seed = generateSkeletonSeed(program);
 

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_dt_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_dt_example_program.h
@@ -33,9 +33,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 /** @brief Create a example raster program with dual transitions */
-inline CompositeInstruction rasterDTExampleProgram()
+inline CompositeInstruction rasterDTExampleProgram(const std::string& freespace_profile = DEFAULT_PROFILE_KEY,
+                                                   const std::string& process_profile = "PROCESS")
 {
-  CompositeInstruction program("raster_dt_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+  CompositeInstruction program(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
   // Start Joint Position for the program
   std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6" };
@@ -47,9 +48,9 @@ inline CompositeInstruction rasterDTExampleProgram()
                                    Eigen::Quaterniond(0, 0, -1.0, 0));
 
   // Define from start composite instruction
-  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f0.setDescription("from_start_plan");
-  CompositeInstruction from_start;
+  CompositeInstruction from_start(freespace_profile);
   from_start.setDescription("from_start");
   from_start.push_back(plan_f0);
   program.push_back(from_start);
@@ -73,25 +74,25 @@ inline CompositeInstruction rasterDTExampleProgram()
     Waypoint wp7 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.3, 0.8) *
                                      Eigen::Quaterniond(0, 0, -1.0, 0));
 
-    CompositeInstruction raster_segment;
+    CompositeInstruction raster_segment(freespace_profile);
     raster_segment.setDescription("Raster #" + std::to_string(i + 1));
     if (i == 0 || i == 2)
     {
-      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, process_profile));
     }
     else
     {
-      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, process_profile));
     }
     program.push_back(raster_segment);
 
@@ -106,17 +107,17 @@ inline CompositeInstruction rasterDTExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + (i * 0.1), -0.3, 0.8) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      PlanInstruction plan_f1_dt(wp7_dt, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1_dt(wp7_dt, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1_dt.setDescription("transition_to_start_plan");
 
-      CompositeInstruction transition_from_end;
+      CompositeInstruction transition_from_end(freespace_profile);
       transition_from_end.setDescription("transition_from_end");
       transition_from_end.push_back(plan_f1);
 
-      CompositeInstruction transition_to_start;
+      CompositeInstruction transition_to_start(freespace_profile);
       transition_to_start.setDescription("transition_to_start");
       transition_to_start.push_back(plan_f1_dt);
 
@@ -135,17 +136,17 @@ inline CompositeInstruction rasterDTExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + (i * 0.1), 0.3, 0.8) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      PlanInstruction plan_f1_dt(wp1_dt, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1_dt(wp1_dt, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1_dt.setDescription("transition_to_start_plan");
 
-      CompositeInstruction transition_from_end;
+      CompositeInstruction transition_from_end(freespace_profile);
       transition_from_end.setDescription("transition_from_end");
       transition_from_end.push_back(plan_f1);
 
-      CompositeInstruction transition_to_start;
+      CompositeInstruction transition_to_start(freespace_profile);
       transition_to_start.setDescription("transition_to_start");
       transition_to_start.push_back(plan_f1_dt);
 
@@ -156,7 +157,7 @@ inline CompositeInstruction rasterDTExampleProgram()
     }
   }
 
-  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f2.setDescription("to_end_plan");
   CompositeInstruction to_end;
   to_end.setDescription("to_end");

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_example_program.h
@@ -33,9 +33,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-inline CompositeInstruction rasterExampleProgram()
+inline CompositeInstruction rasterExampleProgram(const std::string& freespace_profile = DEFAULT_PROFILE_KEY,
+                                                 const std::string& process_profile = "PROCESS")
 {
-  CompositeInstruction program("raster_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+  CompositeInstruction program(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
   // Start Joint Position for the program
   std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6" };
@@ -47,9 +48,9 @@ inline CompositeInstruction rasterExampleProgram()
                                    Eigen::Quaterniond(0, 0, -1.0, 0));
 
   // Define from start composite instruction
-  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f0.setDescription("from_start_plan");
-  CompositeInstruction from_start;
+  CompositeInstruction from_start(freespace_profile);
   from_start.setDescription("from_start");
   from_start.push_back(plan_f0);
   program.push_back(from_start);
@@ -73,25 +74,25 @@ inline CompositeInstruction rasterExampleProgram()
     Waypoint wp7 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.3, 0.8) *
                                      Eigen::Quaterniond(0, 0, -1.0, 0));
 
-    CompositeInstruction raster_segment;
+    CompositeInstruction raster_segment(process_profile);
     raster_segment.setDescription("Raster #" + std::to_string(i + 1));
     if (i == 0 || i == 2)
     {
-      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, process_profile));
     }
     else
     {
-      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, process_profile));
     }
     program.push_back(raster_segment);
 
@@ -102,10 +103,10 @@ inline CompositeInstruction rasterExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), 0.3, 0.8) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      CompositeInstruction transition;
+      CompositeInstruction transition(freespace_profile);
       transition.setDescription("transition_from_end");
       transition.push_back(plan_f1);
       program.push_back(transition);
@@ -116,19 +117,19 @@ inline CompositeInstruction rasterExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), -0.3, 0.8) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      CompositeInstruction transition;
+      CompositeInstruction transition(freespace_profile);
       transition.setDescription("transition_from_end");
       transition.push_back(plan_f1);
       program.push_back(transition);
     }
   }
 
-  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f2.setDescription("to_end_plan");
-  CompositeInstruction to_end;
+  CompositeInstruction to_end(freespace_profile);
   to_end.setDescription("to_end");
   to_end.push_back(plan_f2);
   program.push_back(to_end);
@@ -136,9 +137,10 @@ inline CompositeInstruction rasterExampleProgram()
   return program;
 }
 
-inline CompositeInstruction rasterOnlyExampleProgram()
+inline CompositeInstruction rasterOnlyExampleProgram(const std::string& freespace_profile = DEFAULT_PROFILE_KEY,
+                                                     const std::string& process_profile = "PROCESS")
 {
-  CompositeInstruction program("raster_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+  CompositeInstruction program(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
   Waypoint wp1 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.3, 0.8) *
                                    Eigen::Quaterniond(0, 0, -1.0, 0));
@@ -166,25 +168,25 @@ inline CompositeInstruction rasterOnlyExampleProgram()
     Waypoint wp7 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.3, 0.8) *
                                      Eigen::Quaterniond(0, 0, -1.0, 0));
 
-    CompositeInstruction raster_segment;
+    CompositeInstruction raster_segment(process_profile);
     raster_segment.setDescription("Raster #" + std::to_string(i + 1));
     if (i == 0 || i == 2)
     {
-      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, process_profile));
     }
     else
     {
-      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "RASTER"));
-      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "RASTER"));
+      raster_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      raster_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, process_profile));
     }
     program.push_back(raster_segment);
 
@@ -195,10 +197,10 @@ inline CompositeInstruction rasterOnlyExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), 0.3, 0.8) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      CompositeInstruction transition;
+      CompositeInstruction transition(freespace_profile);
       transition.setDescription("transition_from_end");
       transition.push_back(plan_f1);
       program.push_back(transition);
@@ -209,10 +211,10 @@ inline CompositeInstruction rasterOnlyExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), -0.3, 0.8) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      CompositeInstruction transition;
+      CompositeInstruction transition(freespace_profile);
       transition.setDescription("transition_from_end");
       transition.push_back(plan_f1);
       program.push_back(transition);

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_manager_example.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_manager_example.cpp
@@ -90,7 +90,7 @@ int main()
   // --------------------
   auto freespace_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
   auto transition_taskflow_generator = createFreespaceTaskflow(FreespaceTaskflowParams());
-  auto raster_taskflow_generator = createCartesianTaskflow(true);
+  auto raster_taskflow_generator = createCartesianTaskflow(CartesianTaskflowParams());
   RasterProcessManager raster_manager(std::move(freespace_taskflow_generator),
                                       std::move(transition_taskflow_generator),
                                       std::move(raster_taskflow_generator));

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_waad_dt_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_waad_dt_example_program.h
@@ -34,9 +34,12 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 /** @brief Create an example raster program with approach and departure along with dual transitions */
-inline CompositeInstruction rasterWAADDTExampleProgram()
+inline CompositeInstruction rasterWAADDTExampleProgram(const std::string& freespace_profile = DEFAULT_PROFILE_KEY,
+                                                       const std::string& approach_profile = "APPROACH",
+                                                       const std::string& process_profile = "PROCESS",
+                                                       const std::string& departure_profile = "DEPARTURE")
 {
-  CompositeInstruction program("raster_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+  CompositeInstruction program(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
   // Start Joint Position for the program
   std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6" };
@@ -48,9 +51,9 @@ inline CompositeInstruction rasterWAADDTExampleProgram()
                                    Eigen::Quaterniond(0, 0, -1.0, 0));
 
   // Define from start composite instruction
-  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f0.setDescription("from_start_plan");
-  CompositeInstruction from_start;
+  CompositeInstruction from_start(freespace_profile);
   from_start.setDescription("from_start");
   from_start.push_back(plan_f0);
   program.push_back(from_start);
@@ -80,42 +83,42 @@ inline CompositeInstruction rasterWAADDTExampleProgram()
     Waypoint wpd = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.3, 0.85) *
                                      Eigen::Quaterniond(0, 0, -1.0, 0));
 
-    CompositeInstruction approach_segment;
-    CompositeInstruction process_segment;
-    CompositeInstruction departure_segment;
+    CompositeInstruction approach_segment(approach_profile);
+    CompositeInstruction process_segment(process_profile);
+    CompositeInstruction departure_segment(departure_profile);
     approach_segment.setDescription("Raster Approach #" + std::to_string(i + 1));
     process_segment.setDescription("Raster Process #" + std::to_string(i + 1));
     departure_segment.setDescription("Raster Departure #" + std::to_string(i + 1));
     if (i == 0 || i == 2)
     {
       // Approach
-      approach_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "APPROACH"));
+      approach_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, approach_profile));
 
       // Process
-      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "PROCESS"));
+      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, process_profile));
 
       // Departure
-      departure_segment.push_back(PlanInstruction(wpd, PlanInstructionType::LINEAR, "DEPARTURE"));
+      departure_segment.push_back(PlanInstruction(wpd, PlanInstructionType::LINEAR, departure_profile));
     }
     else
     {
       // Approach
-      approach_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "APPROACH"));
+      approach_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, approach_profile));
 
-      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "PROCESS"));
+      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, process_profile));
 
       // Departure
-      departure_segment.push_back(PlanInstruction(wpa, PlanInstructionType::LINEAR, "DEPARTURE"));
+      departure_segment.push_back(PlanInstruction(wpa, PlanInstructionType::LINEAR, departure_profile));
     }
 
     CompositeInstruction raster_segment;
@@ -135,17 +138,17 @@ inline CompositeInstruction rasterWAADDTExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + (i * 0.1), -0.3, 0.85) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      PlanInstruction plan_f1_dt(wp_dt, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1_dt(wp_dt, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1_dt.setDescription("transition_to_start_plan");
 
-      CompositeInstruction transition_from_end;
+      CompositeInstruction transition_from_end(freespace_profile);
       transition_from_end.setDescription("transition_from_end");
       transition_from_end.push_back(plan_f1);
 
-      CompositeInstruction transition_to_start;
+      CompositeInstruction transition_to_start(freespace_profile);
       transition_to_start.setDescription("transition_to_start");
       transition_to_start.push_back(plan_f1_dt);
 
@@ -164,17 +167,17 @@ inline CompositeInstruction rasterWAADDTExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + (i * 0.1), 0.3, 0.85) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      PlanInstruction plan_f1_dt(wp_dt, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1_dt(wp_dt, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1_dt.setDescription("transition_to_start_plan");
 
-      CompositeInstruction transition_from_end;
+      CompositeInstruction transition_from_end(freespace_profile);
       transition_from_end.setDescription("transition_from_end");
       transition_from_end.push_back(plan_f1);
 
-      CompositeInstruction transition_to_start;
+      CompositeInstruction transition_to_start(freespace_profile);
       transition_to_start.setDescription("transition_to_start");
       transition_to_start.push_back(plan_f1_dt);
 
@@ -185,9 +188,9 @@ inline CompositeInstruction rasterWAADDTExampleProgram()
     }
   }
 
-  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f2.setDescription("to_end_plan");
-  CompositeInstruction to_end;
+  CompositeInstruction to_end(freespace_profile);
   to_end.setDescription("to_end");
   to_end.push_back(plan_f2);
   program.push_back(to_end);

--- a/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_waad_example_program.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/examples/raster_waad_example_program.h
@@ -34,9 +34,12 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 /** @brief Create an example raster program with approach and departure */
-inline CompositeInstruction rasterWAADExampleProgram()
+inline CompositeInstruction rasterWAADExampleProgram(const std::string& freespace_profile = DEFAULT_PROFILE_KEY,
+                                                     const std::string& approach_profile = "APPROACH",
+                                                     const std::string& process_profile = "PROCESS",
+                                                     const std::string& departure_profile = "DEPARTURE")
 {
-  CompositeInstruction program("raster_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
+  CompositeInstruction program(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator"));
 
   // Start Joint Position for the program
   std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6" };
@@ -48,9 +51,9 @@ inline CompositeInstruction rasterWAADExampleProgram()
                                    Eigen::Quaterniond(0, 0, -1.0, 0));
 
   // Define from start composite instruction
-  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f0.setDescription("from_start_plan");
-  CompositeInstruction from_start;
+  CompositeInstruction from_start(freespace_profile);
   from_start.setDescription("from_start");
   from_start.push_back(plan_f0);
   program.push_back(from_start);
@@ -80,42 +83,42 @@ inline CompositeInstruction rasterWAADExampleProgram()
     Waypoint wpd = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(x, 0.3, 0.85) *
                                      Eigen::Quaterniond(0, 0, -1.0, 0));
 
-    CompositeInstruction approach_segment;
-    CompositeInstruction process_segment;
-    CompositeInstruction departure_segment;
+    CompositeInstruction approach_segment(approach_profile);
+    CompositeInstruction process_segment(process_profile);
+    CompositeInstruction departure_segment(departure_profile);
     approach_segment.setDescription("Raster Approach #" + std::to_string(i + 1));
     process_segment.setDescription("Raster Process #" + std::to_string(i + 1));
     departure_segment.setDescription("Raster Departure #" + std::to_string(i + 1));
     if (i == 0 || i == 2)
     {
       // Approach
-      approach_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "APPROACH"));
+      approach_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, approach_profile));
 
       // Process
-      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "PROCESS"));
+      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, process_profile));
 
       // Departure
-      departure_segment.push_back(PlanInstruction(wpd, PlanInstructionType::LINEAR, "DEPARTURE"));
+      departure_segment.push_back(PlanInstruction(wpd, PlanInstructionType::LINEAR, departure_profile));
     }
     else
     {
       // Approach
-      approach_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, "APPROACH"));
+      approach_segment.push_back(PlanInstruction(wp7, PlanInstructionType::LINEAR, approach_profile));
 
-      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, "PROCESS"));
-      process_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, "PROCESS"));
+      process_segment.push_back(PlanInstruction(wp6, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp5, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp4, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp3, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp2, PlanInstructionType::LINEAR, process_profile));
+      process_segment.push_back(PlanInstruction(wp1, PlanInstructionType::LINEAR, process_profile));
 
       // Departure
-      departure_segment.push_back(PlanInstruction(wpa, PlanInstructionType::LINEAR, "DEPARTURE"));
+      departure_segment.push_back(PlanInstruction(wpa, PlanInstructionType::LINEAR, departure_profile));
     }
 
     CompositeInstruction raster_segment;
@@ -131,10 +134,10 @@ inline CompositeInstruction rasterWAADExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), 0.3, 0.85) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp7, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      CompositeInstruction transition;
+      CompositeInstruction transition(freespace_profile);
       transition.setDescription("transition_from_end");
       transition.push_back(plan_f1);
       program.push_back(transition);
@@ -145,19 +148,19 @@ inline CompositeInstruction rasterWAADExampleProgram()
           CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8 + ((i + 1) * 0.1), -0.3, 0.85) *
                             Eigen::Quaterniond(0, 0, -1.0, 0));
 
-      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+      PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, freespace_profile);
       plan_f1.setDescription("transition_from_end_plan");
 
-      CompositeInstruction transition;
+      CompositeInstruction transition(freespace_profile);
       transition.setDescription("transition_from_end");
       transition.push_back(plan_f1);
       program.push_back(transition);
     }
   }
 
-  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  PlanInstruction plan_f2(swp1, PlanInstructionType::FREESPACE, freespace_profile);
   plan_f2.setDescription("to_end_plan");
-  CompositeInstruction to_end;
+  CompositeInstruction to_end(freespace_profile);
   to_end.setDescription("to_end");
   to_end.push_back(plan_f2);
   program.push_back(to_end);

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/seed_min_length_process_generator.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/process_generators/seed_min_length_process_generator.h
@@ -1,0 +1,84 @@
+/**
+ * @file seed_length_process_generator.h
+ * @brief Process generator for processing the seed so it meets a minimum length. Planners like trajopt need
+ * at least 10 states in the trajectory to perform velocity, accelleration and jerk smoothing.
+ *
+ * @author Levi Armstrong
+ * @date November 2. 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_PROCESS_MANAGERS_SEED_MIN_LENGTH_PROCESS_GENERATOR_H
+#define TESSERACT_PROCESS_MANAGERS_SEED_MIN_LENGTH_PROCESS_GENERATOR_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <vector>
+#include <atomic>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_process_managers/process_generator.h>
+
+namespace tesseract_planning
+{
+class SeedMinLengthProcessGenerator : public ProcessGenerator
+{
+public:
+  using UPtr = std::unique_ptr<SeedMinLengthProcessGenerator>;
+
+  SeedMinLengthProcessGenerator(std::string name = "Seed Min Length");
+
+  SeedMinLengthProcessGenerator(long min_length, std::string name = "Seed Min Length");
+
+  ~SeedMinLengthProcessGenerator() override = default;
+  SeedMinLengthProcessGenerator(const SeedMinLengthProcessGenerator&) = delete;
+  SeedMinLengthProcessGenerator& operator=(const SeedMinLengthProcessGenerator&) = delete;
+  SeedMinLengthProcessGenerator(SeedMinLengthProcessGenerator&&) = delete;
+  SeedMinLengthProcessGenerator& operator=(SeedMinLengthProcessGenerator&&) = delete;
+
+  const std::string& getName() const override;
+
+  std::function<void()> generateTask(ProcessInput input) override;
+
+  std::function<int()> generateConditionalTask(ProcessInput input) override;
+
+  bool getAbort() const override;
+
+  void setAbort(bool abort) override;
+
+private:
+  /** @brief If true, all tasks return immediately. Workaround for https://github.com/taskflow/taskflow/issues/201 */
+  std::atomic<bool> abort_{ false };
+
+  std::string name_;
+
+  long min_length_{ 10 };
+
+  int conditionalProcess(ProcessInput input) const;
+
+  void process(ProcessInput input) const;
+
+  void subdivide(CompositeInstruction& composite,
+                 const CompositeInstruction& current_composite,
+                 Instruction& start_instruction,
+                 int subdivisions) const;
+};
+}  // namespace tesseract_planning
+
+#endif  // TESSERACT_PROCESS_MANAGERS_SEED_MIN_LENGTH_PROCESS_GENERATOR_H

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/cartesian_taskflow.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/cartesian_taskflow.h
@@ -33,13 +33,20 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createCartesianTaskflow(
-    bool create_seed,
-    const SimplePlannerPlanProfileMap& simple_plan_profiles = SimplePlannerPlanProfileMap(),
-    const SimplePlannerCompositeProfileMap& simple_composite_profiles = SimplePlannerCompositeProfileMap(),
-    const DescartesPlanProfileMap<double>& descartes_plan_profiles = DescartesPlanProfileMap<double>(),
-    const TrajOptPlanProfileMap& trajopt_plan_profiles = TrajOptPlanProfileMap(),
-    const TrajOptCompositeProfileMap& trajopt_composite_profiles = TrajOptCompositeProfileMap());
-}
+struct CartesianTaskflowParams
+{
+  bool enable_simple_planner{ true };
+  bool enable_post_contact_discrete_check{ false };
+  bool enable_post_contact_continuous_check{ true };
+  bool enable_time_parameterization{ true };
+  SimplePlannerPlanProfileMap simple_plan_profiles;
+  SimplePlannerCompositeProfileMap simple_composite_profiles;
+  DescartesPlanProfileMap<double> descartes_plan_profiles;
+  TrajOptPlanProfileMap trajopt_plan_profiles;
+  TrajOptCompositeProfileMap trajopt_composite_profiles;
+};
+
+GraphTaskflow::UPtr createCartesianTaskflow(CartesianTaskflowParams params);
+}  // namespace tesseract_planning
 
 #endif  // TESSERACT_PROCESS_MANAGERS_CARTESIAN_TASKFLOW_H

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/ompl_taskflow.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/ompl_taskflow.h
@@ -32,11 +32,18 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createOMPLTaskflow(
-    bool create_seed,
-    const SimplePlannerPlanProfileMap& simple_plan_profiles = SimplePlannerPlanProfileMap(),
-    const SimplePlannerCompositeProfileMap& simple_composite_profiles = SimplePlannerCompositeProfileMap(),
-    const OMPLPlanProfileMap& ompl_plan_profiles = OMPLPlanProfileMap());
-}
+struct OMPLTaskflowParams
+{
+  bool enable_simple_planner{ true };
+  bool enable_post_contact_discrete_check{ false };
+  bool enable_post_contact_continuous_check{ true };
+  bool enable_time_parameterization{ true };
+  SimplePlannerPlanProfileMap simple_plan_profiles;
+  SimplePlannerCompositeProfileMap simple_composite_profiles;
+  OMPLPlanProfileMap ompl_plan_profiles;
+};
+
+GraphTaskflow::UPtr createOMPLTaskflow(OMPLTaskflowParams params);
+}  // namespace tesseract_planning
 
 #endif  // TESSERACT_PROCESS_MANAGERS_OMPL_TASKFLOW_H

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/trajopt_taskflow.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/taskflows/trajopt_taskflow.h
@@ -32,11 +32,18 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createTrajOptTaskflow(
-    bool create_seed,
-    const SimplePlannerPlanProfileMap& simple_plan_profiles = SimplePlannerPlanProfileMap(),
-    const SimplePlannerCompositeProfileMap& simple_composite_profiles = SimplePlannerCompositeProfileMap(),
-    const TrajOptPlanProfileMap& trajopt_plan_profiles = TrajOptPlanProfileMap(),
-    const TrajOptCompositeProfileMap& trajopt_composite_profiles = TrajOptCompositeProfileMap());
-}
+struct TrajOptTaskflowParams
+{
+  bool enable_simple_planner{ true };
+  bool enable_post_contact_discrete_check{ false };
+  bool enable_post_contact_continuous_check{ true };
+  bool enable_time_parameterization{ true };
+  SimplePlannerPlanProfileMap simple_plan_profiles;
+  SimplePlannerCompositeProfileMap simple_composite_profiles;
+  TrajOptPlanProfileMap trajopt_plan_profiles;
+  TrajOptCompositeProfileMap trajopt_composite_profiles;
+};
+
+GraphTaskflow::UPtr createTrajOptTaskflow(TrajOptTaskflowParams params);
+}  // namespace tesseract_planning
 #endif  // TESSERACT_PROCESS_MANAGERS_TRAJOPT_TASKFLOW_H

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/seed_min_length_process_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/process_generators/seed_min_length_process_generator.cpp
@@ -1,0 +1,152 @@
+/**
+ * @file seed_length_process_generator.cpp
+ * @brief Process generator for processing the seed so it meets a minimum length. Planners like trajopt need
+ * at least 10 states in the trajectory to perform velocity, accelleration and jerk smoothing.
+ *
+ * @author Levi Armstrong
+ * @date November 2. 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <console_bridge/console.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_process_managers/process_generators/seed_min_length_process_generator.h>
+#include <tesseract_motion_planners/core/utils.h>
+#include <tesseract_command_language/utils/get_instruction_utils.h>
+
+namespace tesseract_planning
+{
+SeedMinLengthProcessGenerator::SeedMinLengthProcessGenerator(std::string name) : name_(std::move(name)) {}
+
+SeedMinLengthProcessGenerator::SeedMinLengthProcessGenerator(long min_length, std::string name)
+  : name_(std::move(name)), min_length_(min_length)
+{
+  if (min_length_ <= 1)
+  {
+    CONSOLE_BRIDGE_logWarn("SeedMinLengthProcessGenerator: The min length must be greater than 1, setting to default.");
+    min_length_ = 10;
+  }
+}
+
+const std::string& SeedMinLengthProcessGenerator::getName() const { return name_; }
+
+std::function<void()> SeedMinLengthProcessGenerator::generateTask(ProcessInput input)
+{
+  return [=]() { process(input); };
+}
+
+std::function<int()> SeedMinLengthProcessGenerator::generateConditionalTask(ProcessInput input)
+{
+  return [=]() { return conditionalProcess(input); };
+}
+
+int SeedMinLengthProcessGenerator::conditionalProcess(ProcessInput input) const
+{
+  if (abort_)
+    return 0;
+
+  // Check that inputs are valid
+  Instruction* input_results = input.getResults();
+  if (!isCompositeInstruction(*input_results))
+  {
+    CONSOLE_BRIDGE_logError("Input seed to SeedMinLengthProcessGenerator must be a composite instruction");
+    return 0;
+  }
+
+  CompositeInstruction& results = *(input_results->cast<CompositeInstruction>());
+  long cnt = getMoveInstructionCount(results);
+  if (cnt >= min_length_)
+    return 1;
+
+  Instruction start_instruction = results.getStartInstruction();
+  int subdivisions = static_cast<int>(std::ceil(static_cast<double>(min_length_) / static_cast<double>(cnt))) + 1;
+
+  CompositeInstruction new_results(results.getProfile(), results.getOrder(), results.getManipulatorInfo());
+  new_results.setDescription(results.getDescription());
+  new_results.setStartInstruction(results.getStartInstruction());
+
+  subdivide(new_results, results, start_instruction, subdivisions);
+  results = new_results;
+
+  CONSOLE_BRIDGE_logDebug("Seed Min Length Process Generator Succeeded!");
+  return 1;
+}
+
+void SeedMinLengthProcessGenerator::process(ProcessInput input) const { conditionalProcess(input); }
+
+bool SeedMinLengthProcessGenerator::getAbort() const { return abort_; }
+void SeedMinLengthProcessGenerator::setAbort(bool abort) { abort_ = abort; }
+
+void SeedMinLengthProcessGenerator::subdivide(CompositeInstruction& composite,
+                                              const CompositeInstruction& current_composite,
+                                              Instruction& start_instruction,
+                                              int subdivisions) const
+{
+  for (const Instruction& i : current_composite)
+  {
+    assert(!isPlanInstruction(i));
+    if (isCompositeInstruction(i))
+    {
+      const CompositeInstruction* cc = i.cast_const<CompositeInstruction>();
+      CompositeInstruction new_cc(cc->getProfile(), cc->getOrder(), cc->getManipulatorInfo());
+      new_cc.setDescription(cc->getDescription());
+      new_cc.setStartInstruction(cc->getStartInstruction());
+
+      subdivide(new_cc, *cc, start_instruction, subdivisions);
+      composite.push_back(new_cc);
+    }
+    else if (isMoveInstruction(i))
+    {
+      assert(isMoveInstruction(start_instruction));
+      const MoveInstruction* mi0 = start_instruction.cast_const<MoveInstruction>();
+      const MoveInstruction* mi1 = i.cast_const<MoveInstruction>();
+
+      assert(isStateWaypoint(mi0->getWaypoint()));
+      assert(isStateWaypoint(mi1->getWaypoint()));
+      const StateWaypoint* swp0 = mi0->getWaypoint().cast_const<StateWaypoint>();
+      const StateWaypoint* swp1 = mi1->getWaypoint().cast_const<StateWaypoint>();
+
+      // Linearly interpolate in joint space
+      Eigen::MatrixXd states = interpolate(swp0->position, swp1->position, subdivisions);
+
+      // Convert to MoveInstructions
+      for (long i = 1; i < states.cols(); ++i)
+      {
+        MoveInstruction move_instruction(StateWaypoint(swp1->joint_names, states.col(i)), mi1->getMoveType());
+        move_instruction.setManipulatorInfo(mi1->getManipulatorInfo());
+        move_instruction.setDescription(mi1->getDescription());
+        move_instruction.setProfile(mi1->getProfile());
+        composite.push_back(move_instruction);
+      }
+
+      start_instruction = i;
+    }
+    else
+    {
+      assert(!isPlanInstruction(i));
+      composite.push_back(i);
+    }
+  }
+}
+
+}  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/cartesian_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/cartesian_taskflow.cpp
@@ -26,7 +26,9 @@
 #include <tesseract_process_managers/taskflows/cartesian_taskflow.h>
 #include <tesseract_process_managers/process_generators/motion_planner_process_generator.h>
 #include <tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h>
+#include <tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h>
 #include <tesseract_process_managers/process_generators/iterative_spline_parameterization_process_generator.h>
+#include <tesseract_process_managers/process_generators/seed_min_length_process_generator.h>
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
 
@@ -38,12 +40,7 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createCartesianTaskflow(bool create_seed,
-                                            const SimplePlannerPlanProfileMap& simple_plan_profiles,
-                                            const SimplePlannerCompositeProfileMap& simple_composite_profiles,
-                                            const DescartesPlanProfileMap<double>& descartes_plan_profiles,
-                                            const TrajOptPlanProfileMap& trajopt_plan_profiles,
-                                            const TrajOptCompositeProfileMap& trajopt_composite_profiles)
+GraphTaskflow::UPtr createCartesianTaskflow(CartesianTaskflowParams params)
 {
   auto graph = std::make_unique<GraphTaskflow>();
 
@@ -53,39 +50,57 @@ GraphTaskflow::UPtr createCartesianTaskflow(bool create_seed,
 
   // Setup Interpolator
   int interpolator_idx{ -1 };
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
     auto interpolator = std::make_shared<SimpleMotionPlanner>("Interpolator");
-    interpolator->plan_profiles = simple_plan_profiles;
-    interpolator->composite_profiles = simple_composite_profiles;
+    interpolator->plan_profiles = params.simple_plan_profiles;
+    interpolator->composite_profiles = params.simple_composite_profiles;
     auto interpolator_generator = std::make_unique<MotionPlannerProcessGenerator>(interpolator);
     interpolator_idx = graph->addNode(std::move(interpolator_generator), GraphTaskflow::NodeType::CONDITIONAL);
   }
 
+  // Setup Seed Min Length Process Generator
+  // This is required because trajopt requires a minimum length trajectory. This is used to correct the seed if it is
+  // to short.
+  auto seed_min_length_generator = std::make_unique<SeedMinLengthProcessGenerator>();
+  int seed_min_length_idx = graph->addNode(std::move(seed_min_length_generator), GraphTaskflow::NodeType::CONDITIONAL);
+
   // Setup Descartes
   auto descartes_planner = std::make_shared<DescartesMotionPlanner<double>>();
   descartes_planner->problem_generator = &DefaultDescartesProblemGenerator<double>;
-  descartes_planner->plan_profiles = descartes_plan_profiles;
+  descartes_planner->plan_profiles = params.descartes_plan_profiles;
   auto descartes_generator = std::make_unique<MotionPlannerProcessGenerator>(descartes_planner);
   int descartes_idx = graph->addNode(std::move(descartes_generator), GraphTaskflow::NodeType::CONDITIONAL);
 
   // Setup TrajOpt
   auto trajopt_planner = std::make_shared<TrajOptMotionPlanner>();
   trajopt_planner->problem_generator = &DefaultTrajoptProblemGenerator;
-  trajopt_planner->plan_profiles = trajopt_plan_profiles;
-  trajopt_planner->composite_profiles = trajopt_composite_profiles;
+  trajopt_planner->plan_profiles = params.trajopt_plan_profiles;
+  trajopt_planner->composite_profiles = params.trajopt_composite_profiles;
   auto trajopt_generator = std::make_unique<MotionPlannerProcessGenerator>(trajopt_planner);
   int trajopt_idx = graph->addNode(std::move(trajopt_generator), GraphTaskflow::NodeType::CONDITIONAL);
 
   // Add Final Continuous Contact Check of trajectory
-  auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
-  int contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int contact_check_idx{ -1 };
+  if (params.enable_post_contact_continuous_check)
+  {
+    auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
+  else if (params.enable_post_contact_discrete_check)
+  {
+    auto contact_check_generator = std::make_unique<DiscreteContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   // Time parameterization trajectory
-  auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
-  int time_parameterization_idx =
-      graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
-
+  int time_parameterization_idx{ -1 };
+  if (params.enable_time_parameterization)
+  {
+    auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
+    time_parameterization_idx =
+        graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
   /////////////////
   /// Add Edges ///
   /////////////////
@@ -95,23 +110,40 @@ GraphTaskflow::UPtr createCartesianTaskflow(bool create_seed,
   auto ERROR_CALLBACK = GraphTaskflow::DestinationChannel::ERROR_CALLBACK;
   auto DONE_CALLBACK = GraphTaskflow::DestinationChannel::DONE_CALLBACK;
 
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
-    graph->addEdge(interpolator_idx, ON_SUCCESS, descartes_idx, PROCESS_NODE);
+    graph->addEdge(interpolator_idx, ON_SUCCESS, seed_min_length_idx, PROCESS_NODE);
     graph->addEdge(interpolator_idx, ON_FAILURE, -1, ERROR_CALLBACK);
   }
+
+  graph->addEdge(seed_min_length_idx, ON_SUCCESS, descartes_idx, PROCESS_NODE);
+  graph->addEdge(seed_min_length_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
   graph->addEdge(descartes_idx, ON_SUCCESS, trajopt_idx, PROCESS_NODE);
   graph->addEdge(descartes_idx, ON_FAILURE, -1, ERROR_CALLBACK);
 
-  graph->addEdge(trajopt_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
   graph->addEdge(trajopt_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+    graph->addEdge(trajopt_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
+  else if (params.enable_time_parameterization)
+    graph->addEdge(trajopt_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+  else
+    graph->addEdge(trajopt_idx, ON_SUCCESS, -1, DONE_CALLBACK);
 
-  graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
-  graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+  {
+    graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+    if (params.enable_time_parameterization)
+      graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+    else
+      graph->addEdge(contact_check_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+  }
 
-  graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
-  graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_time_parameterization)
+  {
+    graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+    graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  }
 
   return graph;
 }

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/ompl_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/ompl_taskflow.cpp
@@ -26,6 +26,7 @@
 #include <tesseract_process_managers/taskflows/ompl_taskflow.h>
 #include <tesseract_process_managers/process_generators/motion_planner_process_generator.h>
 #include <tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h>
+#include <tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h>
 #include <tesseract_process_managers/process_generators/iterative_spline_parameterization_process_generator.h>
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
@@ -35,10 +36,7 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createOMPLTaskflow(bool create_seed,
-                                       const SimplePlannerPlanProfileMap& simple_plan_profiles,
-                                       const SimplePlannerCompositeProfileMap& simple_composite_profiles,
-                                       const OMPLPlanProfileMap& ompl_plan_profiles)
+GraphTaskflow::UPtr createOMPLTaskflow(OMPLTaskflowParams params)
 {
   auto graph = std::make_unique<GraphTaskflow>();
 
@@ -48,11 +46,11 @@ GraphTaskflow::UPtr createOMPLTaskflow(bool create_seed,
 
   // Setup Interpolator
   int interpolator_idx{ -1 };
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
     auto interpolator = std::make_shared<SimpleMotionPlanner>("Interpolator");
-    interpolator->plan_profiles = simple_plan_profiles;
-    interpolator->composite_profiles = simple_composite_profiles;
+    interpolator->plan_profiles = params.simple_plan_profiles;
+    interpolator->composite_profiles = params.simple_composite_profiles;
     auto interpolator_generator = std::make_unique<MotionPlannerProcessGenerator>(interpolator);
     interpolator_idx = graph->addNode(std::move(interpolator_generator), GraphTaskflow::NodeType::CONDITIONAL);
   }
@@ -60,18 +58,31 @@ GraphTaskflow::UPtr createOMPLTaskflow(bool create_seed,
   // Setup OMPL
   auto ompl_planner = std::make_shared<OMPLMotionPlanner>();
   ompl_planner->problem_generator = &DefaultOMPLProblemGenerator;
-  ompl_planner->plan_profiles = ompl_plan_profiles;
+  ompl_planner->plan_profiles = params.ompl_plan_profiles;
   auto ompl_generator = std::make_unique<MotionPlannerProcessGenerator>(ompl_planner);
   int ompl_idx = graph->addNode(std::move(ompl_generator), GraphTaskflow::NodeType::CONDITIONAL);
 
   // Add Final Continuous Contact Check of trajectory
-  auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
-  int contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int contact_check_idx{ -1 };
+  if (params.enable_post_contact_continuous_check)
+  {
+    auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
+  else if (params.enable_post_contact_discrete_check)
+  {
+    auto contact_check_generator = std::make_unique<DiscreteContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   // Time parameterization trajectory
-  auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
-  int time_parameterization_idx =
-      graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int time_parameterization_idx{ -1 };
+  if (params.enable_time_parameterization)
+  {
+    auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
+    time_parameterization_idx =
+        graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   /////////////////
   /// Add Edges ///
@@ -82,20 +93,34 @@ GraphTaskflow::UPtr createOMPLTaskflow(bool create_seed,
   auto ERROR_CALLBACK = GraphTaskflow::DestinationChannel::ERROR_CALLBACK;
   auto DONE_CALLBACK = GraphTaskflow::DestinationChannel::DONE_CALLBACK;
 
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
     graph->addEdge(interpolator_idx, ON_SUCCESS, ompl_idx, PROCESS_NODE);
     graph->addEdge(interpolator_idx, ON_FAILURE, -1, ERROR_CALLBACK);
   }
 
-  graph->addEdge(ompl_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
   graph->addEdge(ompl_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+    graph->addEdge(ompl_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
+  else if (params.enable_time_parameterization)
+    graph->addEdge(ompl_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+  else
+    graph->addEdge(ompl_idx, ON_SUCCESS, -1, DONE_CALLBACK);
 
-  graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
-  graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+  {
+    graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+    if (params.enable_time_parameterization)
+      graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+    else
+      graph->addEdge(contact_check_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+  }
 
-  graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
-  graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_time_parameterization)
+  {
+    graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+    graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  }
 
   return graph;
 }

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/trajopt_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflows/trajopt_taskflow.cpp
@@ -27,7 +27,9 @@
 #include <tesseract_process_managers/taskflows/trajopt_taskflow.h>
 #include <tesseract_process_managers/process_generators/motion_planner_process_generator.h>
 #include <tesseract_process_managers/process_generators/continuous_contact_check_process_generator.h>
+#include <tesseract_process_managers/process_generators/discrete_contact_check_process_generator.h>
 #include <tesseract_process_managers/process_generators/iterative_spline_parameterization_process_generator.h>
+#include <tesseract_process_managers/process_generators/seed_min_length_process_generator.h>
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
 
@@ -36,11 +38,7 @@
 
 namespace tesseract_planning
 {
-GraphTaskflow::UPtr createTrajOptTaskflow(bool create_seed,
-                                          const SimplePlannerPlanProfileMap& simple_plan_profiles,
-                                          const SimplePlannerCompositeProfileMap& simple_composite_profiles,
-                                          const TrajOptPlanProfileMap& trajopt_plan_profiles,
-                                          const TrajOptCompositeProfileMap& trajopt_composite_profiles)
+GraphTaskflow::UPtr createTrajOptTaskflow(TrajOptTaskflowParams params)
 {
   auto graph = std::make_unique<GraphTaskflow>();
 
@@ -50,31 +48,50 @@ GraphTaskflow::UPtr createTrajOptTaskflow(bool create_seed,
 
   // Setup Interpolator
   int interpolator_idx{ -1 };
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
     auto interpolator = std::make_shared<SimpleMotionPlanner>("Interpolator");
-    interpolator->plan_profiles = simple_plan_profiles;
-    interpolator->composite_profiles = simple_composite_profiles;
+    interpolator->plan_profiles = params.simple_plan_profiles;
+    interpolator->composite_profiles = params.simple_composite_profiles;
     auto interpolator_generator = std::make_unique<MotionPlannerProcessGenerator>(interpolator);
     interpolator_idx = graph->addNode(std::move(interpolator_generator), GraphTaskflow::NodeType::CONDITIONAL);
   }
 
+  // Setup Seed Min Length Process Generator
+  // This is required because trajopt requires a minimum length trajectory. This is used to correct the seed if it is
+  // to short.
+  auto seed_min_length_generator = std::make_unique<SeedMinLengthProcessGenerator>();
+  int seed_min_length_idx = graph->addNode(std::move(seed_min_length_generator), GraphTaskflow::NodeType::CONDITIONAL);
+
   // Setup TrajOpt
   auto trajopt_planner = std::make_shared<TrajOptMotionPlanner>();
   trajopt_planner->problem_generator = &DefaultTrajoptProblemGenerator;
-  trajopt_planner->plan_profiles = trajopt_plan_profiles;
-  trajopt_planner->composite_profiles = trajopt_composite_profiles;
+  trajopt_planner->plan_profiles = params.trajopt_plan_profiles;
+  trajopt_planner->composite_profiles = params.trajopt_composite_profiles;
   auto trajopt_generator = std::make_unique<MotionPlannerProcessGenerator>(trajopt_planner);
   int trajopt_idx = graph->addNode(std::move(trajopt_generator), GraphTaskflow::NodeType::CONDITIONAL);
 
   // Add Final Continuous Contact Check of trajectory
-  auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
-  int contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int contact_check_idx{ -1 };
+  if (params.enable_post_contact_continuous_check)
+  {
+    auto contact_check_generator = std::make_unique<ContinuousContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
+  else if (params.enable_post_contact_discrete_check)
+  {
+    auto contact_check_generator = std::make_unique<DiscreteContactCheckProcessGenerator>();
+    contact_check_idx = graph->addNode(std::move(contact_check_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   // Time parameterization trajectory
-  auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
-  int time_parameterization_idx =
-      graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  int time_parameterization_idx{ -1 };
+  if (params.enable_time_parameterization)
+  {
+    auto time_parameterization_generator = std::make_unique<IterativeSplineParameterizationProcessGenerator>();
+    time_parameterization_idx =
+        graph->addNode(std::move(time_parameterization_generator), GraphTaskflow::NodeType::CONDITIONAL);
+  }
 
   /////////////////
   /// Add Edges ///
@@ -84,20 +101,37 @@ GraphTaskflow::UPtr createTrajOptTaskflow(bool create_seed,
   auto PROCESS_NODE = GraphTaskflow::DestinationChannel::PROCESS_NODE;
   auto ERROR_CALLBACK = GraphTaskflow::DestinationChannel::ERROR_CALLBACK;
   auto DONE_CALLBACK = GraphTaskflow::DestinationChannel::DONE_CALLBACK;
-  if (create_seed)
+  if (params.enable_simple_planner)
   {
-    graph->addEdge(interpolator_idx, ON_SUCCESS, trajopt_idx, PROCESS_NODE);
+    graph->addEdge(interpolator_idx, ON_SUCCESS, seed_min_length_idx, PROCESS_NODE);
     graph->addEdge(interpolator_idx, ON_FAILURE, -1, ERROR_CALLBACK);
   }
 
-  graph->addEdge(trajopt_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
+  graph->addEdge(seed_min_length_idx, ON_SUCCESS, trajopt_idx, PROCESS_NODE);
+  graph->addEdge(seed_min_length_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+
   graph->addEdge(trajopt_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+    graph->addEdge(trajopt_idx, ON_SUCCESS, contact_check_idx, PROCESS_NODE);
+  else if (params.enable_time_parameterization)
+    graph->addEdge(trajopt_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+  else
+    graph->addEdge(trajopt_idx, ON_SUCCESS, -1, DONE_CALLBACK);
 
-  graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
-  graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_post_contact_continuous_check || params.enable_post_contact_discrete_check)
+  {
+    graph->addEdge(contact_check_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+    if (params.enable_time_parameterization)
+      graph->addEdge(contact_check_idx, ON_SUCCESS, time_parameterization_idx, PROCESS_NODE);
+    else
+      graph->addEdge(contact_check_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+  }
 
-  graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
-  graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  if (params.enable_time_parameterization)
+  {
+    graph->addEdge(time_parameterization_idx, ON_SUCCESS, -1, DONE_CALLBACK);
+    graph->addEdge(time_parameterization_idx, ON_FAILURE, -1, ERROR_CALLBACK);
+  }
 
   return graph;
 }

--- a/tesseract/tesseract_planning/tesseract_process_managers/test/CMakeLists.txt
+++ b/tesseract/tesseract_planning/tesseract_process_managers/test/CMakeLists.txt
@@ -41,4 +41,5 @@ target_clang_tidy(${PROJECT_NAME}_unit ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} EN
 target_cxx_version(${PROJECT_NAME}_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})
 target_code_coverage(${PROJECT_NAME}_unit ALL EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_TESTING})
 add_gtest_discover_tests(${PROJECT_NAME}_unit)
+add_dependencies(${PROJECT_NAME}_unit ${PROJECT_NAME})
 add_dependencies(run_tests ${PROJECT_NAME}_unit)


### PR DESCRIPTION
This rebases PR #398 on master

I ran into issues getting this to fully function as the default because TrajOpt requires a minimum set states for joint velocity, acceleration, and jerk smoothing. This is also an issue with the interpolate and assign components but the defaults handled but you end up with a large number of states because this was manager a the plan instruction where the number of states were set. I looked at adding a composite profile for the simple planner but it quickly became difficult especially when you got to the raster planners because the simple planner is not aware of how the program would be broken up. Instead I created a process generator to handle this which increases the seed length only in the case where TrajOpt is used in the task flow. This check the input seed size and if it does not meet the minimum length it subdivides the trajectory until the min length is meet. @mpowelson 

![image](https://user-images.githubusercontent.com/9803128/98130434-db11f880-1e7f-11eb-91ce-2f87236f6cab.png)

