### PR TITLE
Add vertex evaluator to descartes

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
@@ -40,13 +40,15 @@ namespace tesseract_planning
 class MotionPlanner
 {
 public:
+  using Ptr = std::shared_ptr<MotionPlanner>;
+  using ConstPtr = std::shared_ptr<const MotionPlanner>;
   /** @brief Construct a basic planner */
   MotionPlanner(std::string name) : name_(std::move(name)) {}
   virtual ~MotionPlanner() = default;
-  MotionPlanner(const MotionPlanner&) = default;
-  MotionPlanner& operator=(const MotionPlanner&) = default;
-  MotionPlanner(MotionPlanner&&) = default;
-  MotionPlanner& operator=(MotionPlanner&&) = default;
+  MotionPlanner(const MotionPlanner&) = delete;
+  MotionPlanner& operator=(const MotionPlanner&) = delete;
+  MotionPlanner(MotionPlanner&&) = delete;
+  MotionPlanner& operator=(MotionPlanner&&) = delete;
 
   /** @brief Get the name of this planner */
   const std::string& getName() const { return name_; }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/planner.h
@@ -43,7 +43,7 @@ public:
   using Ptr = std::shared_ptr<MotionPlanner>;
   using ConstPtr = std::shared_ptr<const MotionPlanner>;
   /** @brief Construct a basic planner */
-  MotionPlanner(std::string name) : name_(std::move(name)) {}
+  MotionPlanner() = default;
   virtual ~MotionPlanner() = default;
   MotionPlanner(const MotionPlanner&) = delete;
   MotionPlanner& operator=(const MotionPlanner&) = delete;
@@ -51,7 +51,7 @@ public:
   MotionPlanner& operator=(MotionPlanner&&) = delete;
 
   /** @brief Get the name of this planner */
-  const std::string& getName() const { return name_; }
+  virtual const std::string& getName() const = 0;
 
   /**
    * @brief Solve the planner request problem
@@ -74,8 +74,8 @@ public:
   /** @brief Clear the data structures used by the planner */
   virtual void clear() = 0;
 
-protected:
-  std::string name_; /**< @brief The name of this planner */
+  /** @brief Clone the motion planner */
+  virtual MotionPlanner::Ptr clone() const = 0;
 };
 }  // namespace tesseract_planning
 #endif  // TESSERACT_PLANNING_PLANNER_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
@@ -32,10 +32,10 @@ public:
   DescartesMotionPlanner(std::string name = "DESCARTES");
 
   ~DescartesMotionPlanner() override = default;
-  DescartesMotionPlanner(const DescartesMotionPlanner&) = default;
-  DescartesMotionPlanner& operator=(const DescartesMotionPlanner&) = default;
-  DescartesMotionPlanner(DescartesMotionPlanner&&) noexcept = default;
-  DescartesMotionPlanner& operator=(DescartesMotionPlanner&&) noexcept = default;
+  DescartesMotionPlanner(const DescartesMotionPlanner&) = delete;
+  DescartesMotionPlanner& operator=(const DescartesMotionPlanner&) = delete;
+  DescartesMotionPlanner(DescartesMotionPlanner&&) noexcept = delete;
+  DescartesMotionPlanner& operator=(DescartesMotionPlanner&&) noexcept = delete;
 
   DescartesProblemGeneratorFn<FloatType> problem_generator;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_motion_planner.h
@@ -29,13 +29,14 @@ class DescartesMotionPlanner : public MotionPlanner
 {
 public:
   /** @brief Construct a basic planner */
-  DescartesMotionPlanner(std::string name = "DESCARTES");
-
+  DescartesMotionPlanner();
   ~DescartesMotionPlanner() override = default;
   DescartesMotionPlanner(const DescartesMotionPlanner&) = delete;
   DescartesMotionPlanner& operator=(const DescartesMotionPlanner&) = delete;
   DescartesMotionPlanner(DescartesMotionPlanner&&) noexcept = delete;
   DescartesMotionPlanner& operator=(DescartesMotionPlanner&&) noexcept = delete;
+
+  const std::string& getName() const override;
 
   DescartesProblemGeneratorFn<FloatType> problem_generator;
 
@@ -65,8 +66,11 @@ public:
 
   void clear() override;
 
+  MotionPlanner::Ptr clone() const override;
+
 private:
   /** @brief The planners status codes */
+  std::string name_{ "DESCARTES" };
   std::shared_ptr<const DescartesMotionPlannerStatusCategory> status_category_;
 };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_robot_sampler.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_robot_sampler.h
@@ -62,7 +62,7 @@ public:
                         typename descartes_light::CollisionInterface<FloatType>::Ptr collision,
                         const Eigen::Isometry3d& tcp,
                         bool allow_collision,
-                        DescartesIsValidFn<FloatType> is_valid);
+                        typename DescartesVertexEvaluator<FloatType>::Ptr is_valid);
 
   bool sample(std::vector<FloatType>& solution_set) override;
 
@@ -75,7 +75,8 @@ private:
   bool allow_collision_;    /**< @brief If true and no valid solution was found it will return the best of the worst */
   int dof_;                 /**< @brief The number of joints in the robot */
   Eigen::VectorXd ik_seed_; /**< @brief The seed for inverse kinematics which is zeros */
-  DescartesIsValidFn<FloatType> is_valid_; /**< @brief This is a user defined function to filter out solution */
+  typename DescartesVertexEvaluator<FloatType>::Ptr is_valid_; /**< @brief This is the vertex evaluator to filter out
+                                                                  solution */
 
   /**
    * @brief Check if a solution is passes collision test

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_vertex_evaluator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_vertex_evaluator.h
@@ -1,0 +1,79 @@
+/**
+ * @file descartes_vertex_evaluator.h
+ * @brief Tesseract Descartes Vertex Evaluator
+ *
+ * @author Levi Armstrong
+ * @date June 25, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_DESCARTES_VERTEX_EVALUATOR_H
+#define TESSERACT_MOTION_PLANNERS_DESCARTES_VERTEX_EVALUATOR_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <Eigen/Geometry>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_planning
+{
+template <typename FloatType>
+class DescartesVertexEvaluator
+{
+public:
+  using Ptr = typename std::shared_ptr<DescartesVertexEvaluator<FloatType>>;
+  DescartesVertexEvaluator() = default;
+  virtual ~DescartesVertexEvaluator() = default;
+  DescartesVertexEvaluator(const DescartesVertexEvaluator&) = delete;
+  DescartesVertexEvaluator& operator=(const DescartesVertexEvaluator&) = delete;
+  DescartesVertexEvaluator(DescartesVertexEvaluator&&) = delete;
+  DescartesVertexEvaluator& operator=(DescartesVertexEvaluator&&) = delete;
+
+  /**
+   * @brief Determines whether the vertex is valid and, if so, its cost.
+   * @param vertex The vertex to consider
+   * @return True if vertex is valid, false otherwise. The relative cost associated with the vertex
+   */
+  virtual bool operator()(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& vertex) const = 0;
+};
+
+template <typename FloatType>
+class DescartesJointLimitsVertexEvaluator : public DescartesVertexEvaluator<FloatType>
+{
+public:
+  using Ptr = typename std::shared_ptr<DescartesJointLimitsVertexEvaluator<FloatType>>;
+  DescartesJointLimitsVertexEvaluator(Eigen::MatrixX2d limits) : limits_(std::move(limits)) {}
+
+  bool operator()(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& vertex) const override
+  {
+    assert(limits_.rows() == vertex.size());
+
+    for (int i = 0; i < limits_.rows(); ++i)
+      if ((vertex(i) < limits_(i, 0)) || (vertex(i) > limits_(i, 1)))
+        return false;
+
+    return true;
+  }
+
+protected:
+  Eigen::MatrixX2d limits_;
+};
+}  // namespace tesseract_planning
+
+#endif  // TESSERACT_MOTION_PLANNERS_DESCARTES_VERTEX_EVALUATOR_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -54,10 +54,16 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 template <typename FloatType>
-DescartesMotionPlanner<FloatType>::DescartesMotionPlanner(std::string name)
-  : MotionPlanner(name), status_category_(std::make_shared<const DescartesMotionPlannerStatusCategory>(name))
+DescartesMotionPlanner<FloatType>::DescartesMotionPlanner()
+  : status_category_(std::make_shared<const DescartesMotionPlannerStatusCategory>(name_))
 {
   plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<DescartesDefaultPlanProfile<FloatType>>();
+}
+
+template <typename FloatType>
+const std::string& DescartesMotionPlanner<FloatType>::getName() const
+{
+  return name_;
 }
 
 template <typename FloatType>
@@ -228,6 +234,12 @@ bool DescartesMotionPlanner<FloatType>::terminate()
 template <typename FloatType>
 void DescartesMotionPlanner<FloatType>::clear()
 {
+}
+
+template <typename FloatType>
+MotionPlanner::Ptr DescartesMotionPlanner<FloatType>::clone() const
+{
+  return std::make_shared<DescartesMotionPlanner<FloatType>>();
 }
 
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_robot_sampler.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_robot_sampler.hpp
@@ -45,7 +45,7 @@ DescartesRobotSampler<FloatType>::DescartesRobotSampler(
     typename descartes_light::CollisionInterface<FloatType>::Ptr collision,
     const Eigen::Isometry3d& tcp,
     bool allow_collision,
-    DescartesIsValidFn<FloatType> is_valid)
+    typename DescartesVertexEvaluator<FloatType>::Ptr is_valid)
   : target_pose_(target_pose)
   , target_pose_sampler_(std::move(target_pose_sampler))
   , robot_kinematics_(std::move(robot_kinematics))
@@ -104,7 +104,7 @@ bool DescartesRobotSampler<FloatType>::ikAt(std::vector<FloatType>& solution_set
     std::vector<FloatType> full_sol;
     full_sol.insert(end(full_sol), std::make_move_iterator(sol), std::make_move_iterator(sol + robot_dof));
 
-    if ((is_valid_ != nullptr) && !is_valid_(Eigen::Map<Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>(
+    if ((is_valid_ != nullptr) && !(*is_valid_)(Eigen::Map<Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>(
                                       full_sol.data(), static_cast<long>(full_sol.size()))))
       continue;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
@@ -35,8 +35,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/descartes/descartes_utils.h>
 #include <tesseract_motion_planners/descartes/types.h>
 
-#include <descartes_light/interface/edge_evaluator.h>
-
 namespace tesseract_planning
 {
 template <typename FloatType>
@@ -58,6 +56,9 @@ public:
     return tesseract_common::VectorIsometry3d({ tool_pose });
   };
   DescartesEdgeEvaluatorAllocatorFn<FloatType> edge_evaluator{ nullptr };
+
+  // If not provided it adds a joint limit is valid function
+  DescartesVertexEvaluatorAllocatorFn<FloatType> vertex_evaluator{ nullptr };
   double timing_constraint = std::numeric_limits<FloatType>::max();
 
   // Applied to sampled states
@@ -68,11 +69,8 @@ public:
   bool enable_edge_collision{ false };
   double edge_collision_saftey_margin{ 0 };
   double edge_longest_valid_segment_length = 0.1;
-
   int num_threads{ 1 };
-
   bool allow_collision{ false };
-  DescartesIsValidFn<FloatType> is_valid;  // If not provided it adds a joint limit is valid function
   bool debug{ false };
 
   void apply(DescartesProblem<FloatType>& prob,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/types.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/types.h
@@ -31,6 +31,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
 #include <functional>
 #include <descartes_light/interface/edge_evaluator.h>
+#include <tesseract_motion_planners/descartes/descartes_vertex_evaluator.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/descartes/descartes_problem.h>
@@ -38,13 +39,14 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 /**
- * @brief This is used for passing a function to tesseract descartes samplers that filters out invalid solutions.
+ * @brief This is used for tesseract descartes samplers that filters out invalid solutions.
  *
  * Example: This would be used to filter out solution outside of custom joint limits.
  *
  */
 template <typename FloatType>
-using DescartesIsValidFn = std::function<bool(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1> >&)>;
+using DescartesVertexEvaluatorAllocatorFn =
+    std::function<typename DescartesVertexEvaluator<FloatType>::Ptr(const DescartesProblem<FloatType>&)>;
 
 /**
  * @brief This is used to create edge evaluator within tesseract, to allow thread safe creation of descartes edge

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/ompl_motion_planner.h
@@ -56,7 +56,9 @@ class OMPLMotionPlanner : public MotionPlanner
 {
 public:
   /** @brief Construct a planner */
-  OMPLMotionPlanner(std::string name = "OMPL");
+  OMPLMotionPlanner();
+
+  const std::string& getName() const override;
 
   OMPLProblemGeneratorFn problem_generator;
 
@@ -95,7 +97,12 @@ public:
 
   void clear() override;
 
+  MotionPlanner::Ptr clone() const override;
+
 protected:
+  /** @brief Name of planner */
+  std::string name_{ "OMPL" };
+
   /** @brief The planners status codes */
   std::shared_ptr<const OMPLMotionPlannerStatusCategory> status_category_;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/simple_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/simple_motion_planner.h
@@ -52,13 +52,15 @@ public:
   using ConstPtr = std::shared_ptr<const SimpleMotionPlanner>;
 
   /** @brief Construct a basic planner */
-  SimpleMotionPlanner(std::string name = "SIMPLE_PLANNER");
-
+  SimpleMotionPlanner();
+  SimpleMotionPlanner(const std::string& name);
   ~SimpleMotionPlanner() override = default;
   SimpleMotionPlanner(const SimpleMotionPlanner&) = delete;
   SimpleMotionPlanner& operator=(const SimpleMotionPlanner&) = delete;
   SimpleMotionPlanner(SimpleMotionPlanner&&) = delete;
   SimpleMotionPlanner& operator=(SimpleMotionPlanner&&) = delete;
+
+  const std::string& getName() const override;
 
   /**
    * @brief The available composite profiles
@@ -95,7 +97,10 @@ public:
 
   void clear() override;
 
+  MotionPlanner::Ptr clone() const override;
+
 protected:
+  std::string name_{ "SIMPLE_PLANNER" };
   std::shared_ptr<const SimpleMotionPlannerStatusCategory> status_category_; /** @brief The planners status codes */
 
   MoveInstruction getStartInstruction(const PlannerRequest& request,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/simple_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/simple_motion_planner.h
@@ -55,10 +55,10 @@ public:
   SimpleMotionPlanner(std::string name = "SIMPLE_PLANNER");
 
   ~SimpleMotionPlanner() override = default;
-  SimpleMotionPlanner(const SimpleMotionPlanner&) = default;
-  SimpleMotionPlanner& operator=(const SimpleMotionPlanner&) = default;
-  SimpleMotionPlanner(SimpleMotionPlanner&&) = default;
-  SimpleMotionPlanner& operator=(SimpleMotionPlanner&&) = default;
+  SimpleMotionPlanner(const SimpleMotionPlanner&) = delete;
+  SimpleMotionPlanner& operator=(const SimpleMotionPlanner&) = delete;
+  SimpleMotionPlanner(SimpleMotionPlanner&&) = delete;
+  SimpleMotionPlanner& operator=(SimpleMotionPlanner&&) = delete;
 
   /**
    * @brief The available composite profiles

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
@@ -47,13 +47,15 @@ class TrajOptMotionPlanner : public MotionPlanner
 {
 public:
   /** @brief Construct a basic planner */
-  TrajOptMotionPlanner(std::string name = "TRAJOPT");
+  TrajOptMotionPlanner();
 
   ~TrajOptMotionPlanner() override = default;
   TrajOptMotionPlanner(const TrajOptMotionPlanner&) = delete;
   TrajOptMotionPlanner& operator=(const TrajOptMotionPlanner&) = delete;
   TrajOptMotionPlanner(TrajOptMotionPlanner&&) = delete;
   TrajOptMotionPlanner& operator=(TrajOptMotionPlanner&&) = delete;
+
+  const std::string& getName() const override;
 
   TrajOptProblemGeneratorFn problem_generator;
 
@@ -98,7 +100,10 @@ public:
 
   void clear() override;
 
+  MotionPlanner::Ptr clone() const override;
+
 protected:
+  std::string name_{ "TRAJOPT" };
   std::shared_ptr<const TrajOptMotionPlannerStatusCategory> status_category_; /** @brief The planners status codes */
 };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
@@ -50,10 +50,10 @@ public:
   TrajOptMotionPlanner(std::string name = "TRAJOPT");
 
   ~TrajOptMotionPlanner() override = default;
-  TrajOptMotionPlanner(const TrajOptMotionPlanner&) = default;
-  TrajOptMotionPlanner& operator=(const TrajOptMotionPlanner&) = default;
-  TrajOptMotionPlanner(TrajOptMotionPlanner&&) = default;
-  TrajOptMotionPlanner& operator=(TrajOptMotionPlanner&&) = default;
+  TrajOptMotionPlanner(const TrajOptMotionPlanner&) = delete;
+  TrajOptMotionPlanner& operator=(const TrajOptMotionPlanner&) = delete;
+  TrajOptMotionPlanner(TrajOptMotionPlanner&&) = delete;
+  TrajOptMotionPlanner& operator=(TrajOptMotionPlanner&&) = delete;
 
   TrajOptProblemGeneratorFn problem_generator;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/package.xml
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/package.xml
@@ -24,6 +24,7 @@
   <depend>trajopt_sco</depend>
 
   <test_depend>gtest</test_depend>
+  <test_depend>tesseract_support</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/ompl_motion_planner.cpp
@@ -87,11 +87,13 @@ bool checkGoalState(const ompl::base::ProblemDefinitionPtr& prob_def,
 }
 
 /** @brief Construct a basic planner */
-OMPLMotionPlanner::OMPLMotionPlanner(std::string name)
-  : MotionPlanner(std::move(name)), status_category_(std::make_shared<const OMPLMotionPlannerStatusCategory>(name_))
+OMPLMotionPlanner::OMPLMotionPlanner()
+  : status_category_(std::make_shared<const OMPLMotionPlannerStatusCategory>(name_))
 {
   plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<OMPLDefaultPlanProfile>();
 }
+
+const std::string& OMPLMotionPlanner::getName() const { return name_; }
 
 bool OMPLMotionPlanner::terminate()
 {
@@ -281,6 +283,8 @@ tesseract_common::StatusCode OMPLMotionPlanner::solve(const PlannerRequest& requ
 }
 
 void OMPLMotionPlanner::clear() { parallel_plan_ = nullptr; }
+
+MotionPlanner::Ptr OMPLMotionPlanner::clone() const { return std::make_shared<OMPLMotionPlanner>(); }
 
 bool OMPLMotionPlanner::checkUserInput(const PlannerRequest& request) const
 {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -69,11 +69,19 @@ std::string SimpleMotionPlannerStatusCategory::message(int code) const
   }
 }
 
-SimpleMotionPlanner::SimpleMotionPlanner(std::string name)
-  : MotionPlanner(std::move(name)), status_category_(std::make_shared<const SimpleMotionPlannerStatusCategory>(name_))
+SimpleMotionPlanner::SimpleMotionPlanner()
+  : status_category_(std::make_shared<const SimpleMotionPlannerStatusCategory>(name_))
 {
   plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<SimplePlannerDefaultLVSPlanProfile>();
 }
+
+SimpleMotionPlanner::SimpleMotionPlanner(const std::string& name)
+  : name_(name), status_category_(std::make_shared<const SimpleMotionPlannerStatusCategory>(name_))
+{
+  plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<SimplePlannerDefaultLVSPlanProfile>();
+}
+
+const std::string& SimpleMotionPlanner::getName() const { return name_; }
 
 bool SimpleMotionPlanner::terminate()
 {
@@ -82,6 +90,8 @@ bool SimpleMotionPlanner::terminate()
 }
 
 void SimpleMotionPlanner::clear() {}
+
+MotionPlanner::Ptr SimpleMotionPlanner::clone() const { return std::make_shared<SimpleMotionPlanner>(); }
 
 tesseract_common::StatusCode SimpleMotionPlanner::solve(const PlannerRequest& request,
                                                         PlannerResponse& response,

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -73,12 +73,14 @@ std::string TrajOptMotionPlannerStatusCategory::message(int code) const
   }
 }
 
-TrajOptMotionPlanner::TrajOptMotionPlanner(std::string name)
-  : MotionPlanner(std::move(name)), status_category_(std::make_shared<const TrajOptMotionPlannerStatusCategory>(name_))
+TrajOptMotionPlanner::TrajOptMotionPlanner()
+  : status_category_(std::make_shared<const TrajOptMotionPlannerStatusCategory>(name_))
 {
   plan_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<TrajOptDefaultPlanProfile>();
   composite_profiles[DEFAULT_PROFILE_KEY] = std::make_shared<TrajOptDefaultCompositeProfile>();
 }
+
+const std::string& TrajOptMotionPlanner::getName() const { return name_; }
 
 bool TrajOptMotionPlanner::terminate()
 {
@@ -91,6 +93,8 @@ void TrajOptMotionPlanner::clear()
   params = sco::BasicTrustRegionSQPParameters();
   callbacks.clear();
 }
+
+MotionPlanner::Ptr TrajOptMotionPlanner::clone() const { return std::make_shared<TrajOptMotionPlanner>(); }
 
 tesseract_common::StatusCode TrajOptMotionPlanner::solve(const PlannerRequest& request,
                                                          PlannerResponse& response,


### PR DESCRIPTION
This PR creates a vertex validator and vertex allocator that take a descartes problem similar to the edge evaluator. Also adds missing delete constructors for the motion planners base class.

@mpowelson  I wanted to let you know, in case you are using Descartes planner, this is a breaking change if you are explicitly setting the is_valid for he Descartes profile.