### PR TITLE
Fix issues in LVS Interpolator and Simple Planner

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/simple_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/simple_motion_planner.h
@@ -108,7 +108,7 @@ protected:
                                       const tesseract_kinematics::ForwardKinematics::Ptr& fwd_kin) const;
 
   CompositeInstruction processCompositeInstruction(const CompositeInstruction& instructions,
-                                                   const Waypoint& initial_start_waypoint,
+                                                   Waypoint& start_waypoint,
                                                    const PlannerRequest& request) const;
 };
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/step_generators/lvs_interpolation.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/simple/step_generators/lvs_interpolation.h
@@ -42,16 +42,13 @@ namespace tesseract_planning
  *
  * This function interpolates the motion from start state to end state. Results are stored in StateWaypoint objects.
  *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
  * - the number of steps for the plan will be calculated such that:
  *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
  *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
+ *   - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
+ *     steps is no longer than state_longest_valid_segment_length
+ *   - the max steps from the above calculations will be be compared to the min_steps and the largest will be chosen
+ * - the interpolation will be done in joint space
  *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan
@@ -78,8 +75,17 @@ CompositeInstruction LVSInterpolateStateWaypoint(const JointWaypoint& start,
 /**
  * @brief LVSInterpolateStateWaypoint(JointWaypoint to CartesianWaypoint)
  *
- * This will interpolate joint positions from the start state to the end state, where the norm of all joint movements
- * at each step is no longer than state_longest_valid_segment_length.
+ * - the number of steps for the plan will be calculated such that:
+ *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
+ *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
+ *   - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
+ *     steps is no longer than state_longest_valid_segment_length
+ *   - the max steps from the above calculations will be be compared to the min_steps and the largest will be chosen
+ * - the interpolation will be done based on the condition below
+ *   - Case 1: Joint solution found for end cartesian waypoint
+ *     - It interpolates the joint position from the start to the end state
+ *   - Case 2: Unable to find joint solution for end cartesian waypoint
+ *     - It creates number states based on the steps and sets the value to start joint waypoint
  *
  * @param start The joint state at the start of the plan
  * @param end The cartesian state at the end of the plan
@@ -101,20 +107,21 @@ CompositeInstruction LVSInterpolateStateWaypoint(const JointWaypoint& start,
                                                  int min_steps);
 
 /**
- * @brief LVSInterpolateStateWaypoint(JointWaypoint to JointWaypoint)
+ * @brief LVSInterpolateStateWaypoint(CartesianWaypoint to JointWaypoint)
  *
  * This function interpolates the motion from start state to end state. Results are stored in StateWaypoint objects.
  *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
  * - the number of steps for the plan will be calculated such that:
  *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
  *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
+ *   - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
+ *     steps is no longer than state_longest_valid_segment_length
+ *   - the max steps from the above calculations will be be compared to the min_steps and the largest will be chosen
+ * - the interpolation will be done based on the condition below
+ *   - Case 1: Joint solution found for start cartesian waypoint
+ *     - It interpolates the joint position from the start to the end state
+ *   - Case 2: Unable to find joint solution for start cartesian waypoint
+ *     - It creates number states based on the steps and sets the value to end joint waypoint
  *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan
@@ -139,20 +146,25 @@ CompositeInstruction LVSInterpolateStateWaypoint(const CartesianWaypoint& start,
                                                  int min_steps);
 
 /**
- * @brief LVSInterpolateStateWaypoint(JointWaypoint to JointWaypoint)
+ * @brief LVSInterpolateStateWaypoint(CartesianWaypoint to CartesianWaypoint)
  *
  * This function interpolates the motion from start state to end state. Results are stored in StateWaypoint objects.
  *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
  * - the number of steps for the plan will be calculated such that:
  *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
  *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
+ *   - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
+ *     steps is no longer than state_longest_valid_segment_length
+ *   - the max steps from the above calculations will be be compared to the min_steps and the largest will be chosen
+ * - the interpolation will be done based on the condition below
+ *   - Case 1: Joint solution found for start and end cartesian waypoint
+ *     - It interpolates the joint position from the start to the end state
+ *   - Case 2: Joint solution only found for start cartesian waypoint
+ *     - It creates number states based on the steps and sets the value to found start solution
+ *   - Case 3: Joint solution only found for end cartesian waypoint
+ *     - It creates number states based on the steps and sets the value to found end solution
+ *   - Case 4: No joint solution found for end and start cartesian waypoint
+ *     - It creates number states based on the steps and sets the value to the current state of the environment
  *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan
@@ -181,17 +193,6 @@ CompositeInstruction LVSInterpolateStateWaypoint(const CartesianWaypoint& start,
  *
  * This function interpolates the motion from start state to end state. Results are stored in CartesianWaypoint objects.
  *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
- * - the number of steps for the plan will be calculated such that:
- *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
- *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
- *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan
  * @param base_instruction The base plan instruction
@@ -218,17 +219,6 @@ CompositeInstruction LVSInterpolateCartStateWaypoint(const JointWaypoint& start,
  * @brief LVSInterpolateCartStateWaypoint(JointWaypoint to CartesianWaypoint)
  *
  * This function interpolates the motion from start state to end state. Results are stored in CartesianWaypoint objects.
- *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
- * - the number of steps for the plan will be calculated such that:
- *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
- *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
  *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan
@@ -257,17 +247,6 @@ CompositeInstruction LVSInterpolateCartStateWaypoint(const JointWaypoint& start,
  *
  * This function interpolates the motion from start state to end state. Results are stored in CartesianWaypoint objects.
  *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
- * - the number of steps for the plan will be calculated such that:
- *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
- *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
- *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan
  * @param base_instruction The base plan instruction
@@ -294,17 +273,6 @@ CompositeInstruction LVSInterpolateCartStateWaypoint(const CartesianWaypoint& st
  * @brief LVSInterpolateCartStateWaypoint(CartesianWaypoint to CartesianWaypoint)
  *
  * This function interpolates the motion from start state to end state. Results are stored in CartesianWaypoint objects.
- *
- * CASE 1: The base_instruction type is FREESPACE:
- * - the interpolation will be done in joint space
- * - the number of steps for the plan will be calculated such that the norm of all joint distances between successive
- *   steps is no longer than state_longest_valid_segment_length
- *
- * CASE 2: The base_instrucation type is LINEAR:
- * - the interpolation will be done in cartesian space
- * - the number of steps for the plan will be calculated such that:
- *   - the translational distance between successive steps is no longer than translation_longest_valid_segment
- *   - the rotational distance between successive steps is no longer than rotation_longest_valid_segment
  *
  * @param start The joint state at the start of the plan
  * @param end The joint state at the end of the plan

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -196,10 +196,9 @@ SimpleMotionPlanner::getStartInstruction(const PlannerRequest& request,
 }
 
 CompositeInstruction SimpleMotionPlanner::processCompositeInstruction(const CompositeInstruction& instructions,
-                                                                      const Waypoint& initial_start_waypoint,
+                                                                      Waypoint& start_waypoint,
                                                                       const PlannerRequest& request) const
 {
-  Waypoint start_waypoint = initial_start_waypoint;
   CompositeInstruction seed(instructions.getProfile(), instructions.getOrder(), instructions.getManipulatorInfo());
   for (const auto& instruction : instructions)
   {

--- a/tesseract/tesseract_planning/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/test/tesseract_process_managers_unit.cpp
@@ -191,7 +191,7 @@ TEST_F(TesseractProcessManagerUnit, RasterSimpleMotionPlannerDefaultLVSPlanProfi
 
   // The first plan instruction is the start instruction and every other plan instruction should be converted into
   // ten move instruction.
-  EXPECT_EQ(168, mcnt);
+  EXPECT_EQ(98, mcnt);
   EXPECT_TRUE(response.results.hasStartInstruction());
   EXPECT_FALSE(response.results.getManipulatorInfo().empty());
 }


### PR DESCRIPTION
I noticed odd behavior in the LVS interpolator and Simple Planner. After investigating the LVS interpolator was not correctly handling failure modes for conditions with joint/cartesian, cartesian/joint and cartesian/cartesian. There was also an issue in the simple planner where it was not resetting the start waypoint when processing composite instructions because the variable was being passed as const& instead of by reference. 