### PR TITLE
Update to leverage kinematics setLimits for environment changes

### DIFF
--- a/tesseract/tesseract/src/tesseract.cpp
+++ b/tesseract/tesseract/src/tesseract.cpp
@@ -248,7 +248,7 @@ bool Tesseract::init(const tesseract_environment::Environment& env)
   clear();
 
   environment_ = env.clone();
-  initialized_ = (environment_ != nullptr);
+  initialized_ = (environment_ != nullptr && environment_->checkInitialized());
   if (initialized_)
   {
     init_info_ = std::make_shared<TesseractInitInfo>();
@@ -305,7 +305,13 @@ Tesseract::Ptr Tesseract::clone() const
   return clone;
 }
 
-bool Tesseract::reset() { return init(init_info_); }
+bool Tesseract::reset()
+{
+  if (!initialized_)
+    return false;
+
+  return init(init_info_);
+}
 
 void Tesseract::setResourceLocator(tesseract_scene_graph::ResourceLocator::Ptr locator)
 {

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -125,17 +125,19 @@ public:
     else
     {
       manipulator_manager_->init(scene_graph_, srdf_model->getKinematicsInformation());
-    }
 
-    // Add this to the command history.
-    ++revision_;
-    commands_.push_back(
-        std::make_shared<AddKinematicsInformationCommand>(manipulator_manager_->getKinematicsInformation()));
+      // Add this to the command history.
+      ++revision_;
+      commands_.push_back(
+          std::make_shared<AddKinematicsInformationCommand>(manipulator_manager_->getKinematicsInformation()));
+    }
 
     is_contact_allowed_fn_ = std::bind(&tesseract_scene_graph::SceneGraph::isCollisionAllowed,
                                        scene_graph_,
                                        std::placeholders::_1,
                                        std::placeholders::_2);
+
+    manipulator_manager_->revision_ = revision_;
 
     initialized_ = true;
 
@@ -180,6 +182,10 @@ public:
     return true;
   }
 
+  /**
+   * @brief Clone the environment
+   * @return A clone of the environment
+   */
   Environment::Ptr clone() const;
 
   /**

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/manipulator_manager.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/manipulator_manager.h
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_scene_graph/srdf_model.h>
 #include <tesseract_kinematics/core/forward_kinematics_factory.h>
 #include <tesseract_kinematics/core/inverse_kinematics_factory.h>
+#include <tesseract_environment/core/commands.h>
 
 namespace tesseract_environment
 {
@@ -55,12 +56,6 @@ public:
 
   bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
             tesseract_scene_graph::KinematicsInformation kinematics_information);
-
-  /**
-   * @brief Updates all of the stored solvers
-   * @return True if successful
-   */
-  bool update();
 
   /**
    * @brief This will clone the manager and assign the new environment object
@@ -311,6 +306,7 @@ private:
   std::unordered_map<std::string, tesseract_kinematics::InverseKinematicsFactory::ConstPtr> inv_kin_factories_;
   std::map<std::pair<std::string, std::string>, tesseract_kinematics::InverseKinematics::Ptr> inv_kin_manipulators_;
   std::unordered_map<std::string, tesseract_kinematics::InverseKinematics::Ptr> inv_kin_manipulators_default_;
+  int revision_{ 0 };
 
   bool registerDefaultChainSolver(const std::string& group_name, const tesseract_scene_graph::ChainGroup& chain_group);
   bool registerDefaultJointSolver(const std::string& group_name, const tesseract_scene_graph::JointGroup& joint_group);
@@ -319,6 +315,11 @@ private:
                          const tesseract_scene_graph::OPWKinematicParameters& opw_params);
   bool registerROPSolver(const std::string& group_name, const tesseract_scene_graph::ROPKinematicParameters& rop_group);
   bool registerREPSolver(const std::string& group_name, const tesseract_scene_graph::REPKinematicParameters& rep_group);
+
+  /** @brief Apply environment command to update kinematics if needed */
+  void onEnvironmentChanged(const Commands& commands);
+
+  friend class Environment;
 };
 }  // namespace tesseract_environment
 

--- a/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -76,9 +76,11 @@ Environment::Ptr getEnvironment()
 
   auto env = std::make_shared<Environment>();
   EXPECT_TRUE(env != nullptr);
+  EXPECT_EQ(0, env->getRevision());
 
   bool success = env->init<S>(*scene_graph, srdf);
   EXPECT_TRUE(success);
+  EXPECT_EQ(2, env->getRevision());
 
   // Register contact manager
   EXPECT_TRUE(env->registerDiscreteContactManager(tesseract_collision_bullet::BulletDiscreteBVHManager::name(),

--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
@@ -195,7 +195,7 @@ const tesseract_common::KinematicLimits& IKFastInvKin::getLimits() const { retur
 void IKFastInvKin::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/core/rep_inverse_kinematics.cpp
+++ b/tesseract/tesseract_kinematics/src/core/rep_inverse_kinematics.cpp
@@ -186,7 +186,7 @@ const tesseract_common::KinematicLimits& RobotWithExternalPositionerInvKin::getL
 void RobotWithExternalPositionerInvKin::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/core/rop_inverse_kinematics.cpp
+++ b/tesseract/tesseract_kinematics/src/core/rop_inverse_kinematics.cpp
@@ -186,7 +186,7 @@ const tesseract_common::KinematicLimits& RobotOnPositionerInvKin::getLimits() co
 void RobotOnPositionerInvKin::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_chain.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_chain.cpp
@@ -228,7 +228,7 @@ const tesseract_common::KinematicLimits& KDLFwdKinChain::getLimits() const { ret
 void KDLFwdKinChain::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_tree.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_fwd_kin_tree.cpp
@@ -217,7 +217,7 @@ const tesseract_common::KinematicLimits& KDLFwdKinTree::getLimits() const { retu
 void KDLFwdKinTree::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_lma.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_lma.cpp
@@ -157,7 +157,7 @@ const tesseract_common::KinematicLimits& KDLInvKinChainLMA::getLimits() const { 
 void KDLInvKinChainLMA::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_nr.cpp
+++ b/tesseract/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_nr.cpp
@@ -164,7 +164,7 @@ const tesseract_common::KinematicLimits& KDLInvKinChainNR::getLimits() const { r
 void KDLInvKinChainNR::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 

--- a/tesseract/tesseract_kinematics/src/opw/opw_inv_kin.cpp
+++ b/tesseract/tesseract_kinematics/src/opw/opw_inv_kin.cpp
@@ -117,7 +117,7 @@ const tesseract_common::KinematicLimits& OPWInvKin::getLimits() const { return l
 void OPWInvKin::setLimits(tesseract_common::KinematicLimits limits)
 {
   unsigned int nj = numJoints();
-  if (limits.joint_limits.size() != nj || limits.velocity_limits.size() != nj ||
+  if (limits.joint_limits.rows() != nj || limits.velocity_limits.size() != nj ||
       limits.acceleration_limits.size() != nj)
     throw std::runtime_error("Kinematics limits assigned are invalid!");
 


### PR DESCRIPTION
This update code base to leverage the kinematics setLimits for environment commands that changes kinematic limits. This was required to solve the issue for opw and ikfast which do not store the scene_graph and did not what to change the interface. @mpowelson Do you mind testing to make sure this still works for you? I am currently testing it on my end to confirm it solves the issues we are having related to ikfast kinematics objects not having its limits updated.