### PR TITLE
Fix issue with parsing OPW sign correction from SRDF.

### DIFF
--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
@@ -139,6 +139,8 @@ public:
   JointWaypoint(std::vector<std::string> joint_names, const Eigen::MatrixBase<OtherDerived>& other)
     : waypoint(other), joint_names(std::move(joint_names))
   {
+    if (static_cast<Eigen::Index>(this->joint_names.size()) != this->waypoint.rows())
+      throw std::runtime_error("JointWaypoint: joint_names is not the same size as position!");
   }
 
   JointWaypoint(std::vector<std::string> joint_names, std::initializer_list<double> l)
@@ -148,6 +150,9 @@ public:
     Eigen::Index i = 0;
     for (auto& v : l)
       waypoint(i++) = v;
+
+    if (static_cast<Eigen::Index>(this->joint_names.size()) != this->waypoint.rows())
+      throw std::runtime_error("JointWaypoint: joint_names is not the same size as position!");
   }
 
   ///////////////////

--- a/tesseract/tesseract_planning/tesseract_command_language/src/state_waypoint.cpp
+++ b/tesseract/tesseract_planning/tesseract_command_language/src/state_waypoint.cpp
@@ -38,6 +38,8 @@ namespace tesseract_planning
 StateWaypoint::StateWaypoint(std::vector<std::string> joint_names, const Eigen::Ref<const Eigen::VectorXd>& position)
   : joint_names(std::move(joint_names)), position(position)
 {
+  if (static_cast<Eigen::Index>(this->joint_names.size()) != this->position.size())
+    throw std::runtime_error("StateWaypoint: joint_names is not the same size as position!");
 }
 
 StateWaypoint::StateWaypoint(const tinyxml2::XMLElement& xml_element)

--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_opw_kinematics.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_opw_kinematics.h
@@ -124,7 +124,19 @@ inline GroupOPWKinematics parseGroupOPWKinematics(const tesseract_scene_graph::S
 
       // No need to check return values because the tokens are verified above
       for (std::size_t i = 0; i < 6; ++i)
-        tesseract_common::toNumeric<signed char>(tokens[i], group_opw->second.sign_corrections[i]);
+      {
+        int sc{ 0 };
+        tesseract_common::toNumeric<int>(tokens[i], sc);
+        if (sc == 1)
+          group_opw->second.sign_corrections[i] = 1;
+        else if (sc == -1)
+          group_opw->second.sign_corrections[i] = -1;
+        else
+        {
+          CONSOLE_BRIDGE_logError("OPW Group '%s' has incorrect sign correction values!", group_name_string.c_str());
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR also adds some error checking for Joint and State waypoint to make sure joint names and positions are the same length. 