### PR TITLE
Make getShortestPath const

### DIFF
--- a/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
+++ b/tesseract/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
@@ -369,7 +369,7 @@ public:
    */
   void saveDOT(const std::string& path) const;
 
-  Path getShortestPath(const std::string& root, const std::string& tip);
+  Path getShortestPath(const std::string& root, const std::string& tip) const;
 
   // static inline Graph copyGraph(const Graph& graph)
   //{

--- a/tesseract/tesseract_scene_graph/src/graph.cpp
+++ b/tesseract/tesseract_scene_graph/src/graph.cpp
@@ -464,9 +464,9 @@ void SceneGraph::saveDOT(const std::string& path) const
   dot_file << "}";
 }
 
-SceneGraph::Path SceneGraph::getShortestPath(const std::string& root, const std::string& tip)
+SceneGraph::Path SceneGraph::getShortestPath(const std::string& root, const std::string& tip) const
 {
-  const auto& graph = static_cast<const Graph&>(*this);
+  const Graph& graph = *this;
   Vertex s = getVertex(root);
 
   std::map<Vertex, Vertex> predicessor_map;


### PR DESCRIPTION
Indeed, it does not (and should not) modify the underlying graph.

I noticed this while trying to compute link paths on an existing environment, where the SceneGraph is `const`. I'm not sure why it wasn't const in the first place, so my suggestion might not be valid. In any case don't hesitate to modify this branch as you see fit.