### PR TITLE
Add forgotten include in opw_inv_kin.h

### DIFF
--- a/tesseract/tesseract_kinematics/include/tesseract_kinematics/opw/opw_inv_kin.h
+++ b/tesseract/tesseract_kinematics/include/tesseract_kinematics/opw/opw_inv_kin.h
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_kinematics/core/inverse_kinematics.h>
+#include <console_bridge/console.h>
 
 namespace tesseract_kinematics
 {


### PR DESCRIPTION
Indeed, the header uses CONSOLE_BRIDGE_logError but does not include the
relevant header, which means that including only that header causes
compilation errors.

I encountered this while trying to write a simple program that would only load some OPW kinematics parameters and check them... Again, please feel free to modify that branch to suit your liking!