### PR TITLE
Clean up warnings related to setContactDistanceThreshold

### DIFF
--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
@@ -115,6 +115,10 @@ public:
 
   void setCollisionMarginData(CollisionMarginData collision_margin_data) override;
 
+  void setDefaultCollisionMarginData(double default_collision_margin) override;
+
+  void setPairCollisionMarginData(const std::string& name1, const std::string& name2, double collision_margin) override;
+
   double getContactDistanceThreshold() const override;
 
   const CollisionMarginData& getCollisionMarginData() const override;
@@ -151,6 +155,9 @@ private:
 
   /** @brief Filter collision objects before broadphase check */
   TesseractOverlapFilterCallback broadphase_overlap_cb_;
+
+  /** @brief This function will update internal data when margin data has changed */
+  void onCollisionMarginDataChanged();
 };
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
@@ -119,6 +119,10 @@ public:
 
   const CollisionMarginData& getCollisionMarginData() const override;
 
+  void setDefaultCollisionMarginData(double default_collision_margin) override;
+
+  void setPairCollisionMarginData(const std::string& name1, const std::string& name2, double collision_margin) override;
+
   void setIsContactAllowedFn(IsContactAllowedFn fn) override;
 
   IsContactAllowedFn getIsContactAllowedFn() const override;
@@ -148,6 +152,9 @@ private:
    * so it can be used to exit collision checking for compound shapes.
    */
   ContactTestData contact_test_data_;
+
+  /** @brief This function will update internal data when margin data has changed */
+  void onCollisionMarginDataChanged();
 };
 
 }  // namespace tesseract_collision_bullet

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
@@ -104,6 +104,10 @@ public:
 
   void setCollisionMarginData(CollisionMarginData collision_margin_data) override;
 
+  void setDefaultCollisionMarginData(double default_collision_margin) override;
+
+  void setPairCollisionMarginData(const std::string& name1, const std::string& name2, double collision_margin) override;
+
   double getContactDistanceThreshold() const override;
 
   const CollisionMarginData& getCollisionMarginData() const override;
@@ -139,6 +143,9 @@ private:
 
   /** @brief Filter collision objects before broadphase check */
   TesseractOverlapFilterCallback broadphase_overlap_cb_;
+
+  /** @brief This function will update internal data when margin data has changed */
+  void onCollisionMarginDataChanged();
 };
 
 }  // namespace tesseract_collision_bullet

--- a/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
@@ -104,6 +104,10 @@ public:
 
   void setCollisionMarginData(CollisionMarginData collision_margin_data) override;
 
+  void setDefaultCollisionMarginData(double default_collision_margin) override;
+
+  void setPairCollisionMarginData(const std::string& name1, const std::string& name2, double collision_margin) override;
+
   double getContactDistanceThreshold() const override;
 
   const CollisionMarginData& getCollisionMarginData() const override;
@@ -136,6 +140,9 @@ private:
    * so it can be used to exit collision checking for compound shapes.
    */
   ContactTestData contact_test_data_;
+
+  /** @brief This function will update internal data when margin data has changed */
+  void onCollisionMarginDataChanged();
 };
 
 }  // namespace tesseract_collision_bullet

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/continuous_contact_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/continuous_contact_manager.h
@@ -216,6 +216,26 @@ public:
   virtual void setCollisionMarginData(CollisionMarginData collision_margin_data) = 0;
 
   /**
+   * @brief Set the default collision margin
+   * @param default_collision_margin New default collision margin
+   */
+  virtual void setDefaultCollisionMarginData(double default_collision_margin) = 0;
+
+  /**
+   * @brief Set the margin for a given contact pair
+   *
+   * The order of the object names does not matter, that is handled internal to
+   * the class.
+   *
+   * @param obj1 The first object name. Order doesn't matter
+   * @param obj2 The Second object name. Order doesn't matter
+   * @param collision_margin contacts with distance < collision_margin are considered in collision
+   */
+  virtual void setPairCollisionMarginData(const std::string& name1,
+                                          const std::string& name2,
+                                          double collision_margin) = 0;
+
+  /**
    * @brief Get the contact distance threshold
    * @return The contact distance
    */

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/discrete_contact_manager.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/discrete_contact_manager.h
@@ -167,6 +167,26 @@ public:
   virtual void setCollisionMarginData(CollisionMarginData collision_margin_data) = 0;
 
   /**
+   * @brief Set the default collision margin
+   * @param default_collision_margin New default collision margin
+   */
+  virtual void setDefaultCollisionMarginData(double default_collision_margin) = 0;
+
+  /**
+   * @brief Set the margin for a given contact pair
+   *
+   * The order of the object names does not matter, that is handled internal to
+   * the class.
+   *
+   * @param obj1 The first object name. Order doesn't matter
+   * @param obj2 The Second object name. Order doesn't matter
+   * @param collision_margin contacts with distance < collision_margin are considered in collision
+   */
+  virtual void setPairCollisionMarginData(const std::string& name1,
+                                          const std::string& name2,
+                                          double collision_margin) = 0;
+
+  /**
    * @brief Get the contact distance threshold
    * @return The contact distance
    */

--- a/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/types.h
@@ -226,7 +226,7 @@ struct CollisionMarginData
    * @brief Set the default collision margin
    * @param default_collision_margin New default collision margin
    */
-  void setDefaultCollisionMarginData(const double& default_collision_margin)
+  void setDefaultCollisionMarginData(double default_collision_margin)
   {
     default_collision_margin_ = default_collision_margin;
     if (default_collision_margin_ > max_collision_margin_)
@@ -243,7 +243,7 @@ struct CollisionMarginData
    * @param obj2 The Second object name. Order doesn't matter
    * @param collision_margin contacts with distance < collision_margin are considered in collision
    */
-  void setPairCollisionMarginData(const std::string& obj1, const std::string& obj2, const double& collision_margin)
+  void setPairCollisionMarginData(const std::string& obj1, const std::string& obj2, double collision_margin)
   {
     auto key = tesseract_common::makeOrderedLinkPair(obj1, obj2);
     lookup_table_[key] = collision_margin;
@@ -263,7 +263,7 @@ struct CollisionMarginData
    * @param obj2 The second object name
    * @return A Vector2d[Contact Distance Threshold, Coefficient]
    */
-  const double& getPairCollisionMarginData(const std::string& obj1, const std::string& obj2) const
+  double getPairCollisionMarginData(const std::string& obj1, const std::string& obj2) const
   {
     auto key = tesseract_common::makeOrderedLinkPair(obj1, obj2);
     const auto it = lookup_table_.find(key);
@@ -283,7 +283,7 @@ struct CollisionMarginData
    *
    * @return Max contact distance threshold
    */
-  const double& getMaxCollisionMargin() const { return max_collision_margin_; }
+  double getMaxCollisionMargin() const { return max_collision_margin_; }
 
   /**
    * @brief Increment all margins by input amount. Useful for inflating or reducing margins

--- a/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -104,6 +104,10 @@ public:
 
   void setCollisionMarginData(CollisionMarginData collision_margin_data) override;
 
+  void setDefaultCollisionMarginData(double default_collision_margin) override;
+
+  void setPairCollisionMarginData(const std::string& name1, const std::string& name2, double collision_margin) override;
+
   double getContactDistanceThreshold() const override;
 
   const CollisionMarginData& getCollisionMarginData() const override;
@@ -139,6 +143,9 @@ private:
 
   /** @brief This is used to store dynamic collision objects to update */
   std::vector<CollisionObjectRawPtr> dynamic_update_;
+
+  /** @brief This function will update internal data when margin data has changed */
+  void onCollisionMarginDataChanged();
 };
 
 }  // namespace tesseract_collision_fcl

--- a/tesseract/tesseract_collision/src/bullet/bullet_cast_bvh_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_cast_bvh_manager.cpp
@@ -411,45 +411,26 @@ const std::vector<std::string>& BulletCastBVHManager::getActiveCollisionObjects(
 void BulletCastBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
   contact_test_data_.collision_margin_data = collision_margin_data;
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& co : link2cow_)
-  {
-    COW::Ptr& cow = co.second;
-    cow->setContactProcessingThreshold(
-        static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin()));
-    if (cow->getBroadphaseHandle())
-      updateBroadphaseAABB(cow, broadphase_, dispatcher_);
-  }
+void BulletCastBVHManager::setDefaultCollisionMarginData(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMarginData(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& co : link2castcow_)
-  {
-    COW::Ptr& cow = co.second;
-    cow->setContactProcessingThreshold(
-        static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin()));
-    if (cow->getBroadphaseHandle())
-      updateBroadphaseAABB(cow, broadphase_, dispatcher_);
-  }
+void BulletCastBVHManager::setPairCollisionMarginData(const std::string& name1,
+                                                      const std::string& name2,
+                                                      double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setPairCollisionMarginData(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
 }
 
 void BulletCastBVHManager::setContactDistanceThreshold(double contact_distance)
 {
-  contact_test_data_.collision_margin_data = CollisionMarginData(contact_distance);
-
-  for (auto& co : link2cow_)
-  {
-    COW::Ptr& cow = co.second;
-    cow->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
-    if (cow->getBroadphaseHandle())
-      updateBroadphaseAABB(cow, broadphase_, dispatcher_);
-  }
-
-  for (auto& co : link2castcow_)
-  {
-    COW::Ptr& cow = co.second;
-    cow->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
-    if (cow->getBroadphaseHandle())
-      updateBroadphaseAABB(cow, broadphase_, dispatcher_);
-  }
+  setDefaultCollisionMarginData(contact_distance);
 }
 
 double BulletCastBVHManager::getContactDistanceThreshold() const
@@ -507,5 +488,26 @@ void BulletCastBVHManager::addCollisionObject(COW::Ptr cow)
                                                              selected_cow->m_collisionFilterMask,
                                                              dispatcher_.get()));
 }
+
+void BulletCastBVHManager::onCollisionMarginDataChanged()
+{
+  btScalar margin = static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin());
+  for (auto& co : link2cow_)
+  {
+    COW::Ptr& cow = co.second;
+    cow->setContactProcessingThreshold(margin);
+    if (cow->getBroadphaseHandle())
+      updateBroadphaseAABB(cow, broadphase_, dispatcher_);
+  }
+
+  for (auto& co : link2castcow_)
+  {
+    COW::Ptr& cow = co.second;
+    cow->setContactProcessingThreshold(margin);
+    if (cow->getBroadphaseHandle())
+      updateBroadphaseAABB(cow, broadphase_, dispatcher_);
+  }
+}
+
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/bullet/bullet_cast_simple_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_cast_simple_manager.cpp
@@ -329,25 +329,26 @@ const std::vector<std::string>& BulletCastSimpleManager::getActiveCollisionObjec
 void BulletCastSimpleManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
   contact_test_data_.collision_margin_data = collision_margin_data;
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& co : link2cow_)
-    co.second->setContactProcessingThreshold(
-        static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin()));
+void BulletCastSimpleManager::setDefaultCollisionMarginData(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMarginData(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& co : link2castcow_)
-    co.second->setContactProcessingThreshold(
-        static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin()));
+void BulletCastSimpleManager::setPairCollisionMarginData(const std::string& name1,
+                                                         const std::string& name2,
+                                                         double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setPairCollisionMarginData(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
 }
 
 void BulletCastSimpleManager::setContactDistanceThreshold(double contact_distance)
 {
-  contact_test_data_.collision_margin_data = CollisionMarginData(contact_distance);
-
-  for (auto& co : link2cow_)
-    co.second->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
-
-  for (auto& co : link2castcow_)
-    co.second->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
+  setDefaultCollisionMarginData(contact_distance);
 }
 
 double BulletCastSimpleManager::getContactDistanceThreshold() const
@@ -446,5 +447,16 @@ void BulletCastSimpleManager::addCollisionObject(COW::Ptr cow)
   else
     cows_.push_back(cow);
 }
+
+void BulletCastSimpleManager::onCollisionMarginDataChanged()
+{
+  btScalar margin = static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin());
+  for (auto& co : link2cow_)
+    co.second->setContactProcessingThreshold(margin);
+
+  for (auto& co : link2castcow_)
+    co.second->setContactProcessingThreshold(margin);
+}
+
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
@@ -232,28 +232,26 @@ const std::vector<std::string>& BulletDiscreteBVHManager::getActiveCollisionObje
 void BulletDiscreteBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
   contact_test_data_.collision_margin_data = collision_margin_data;
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& co : link2cow_)
-  {
-    COW::Ptr& cow = co.second;
-    cow->setContactProcessingThreshold(
-        static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin()));
-    assert(cow->getBroadphaseHandle() != nullptr);
-    updateBroadphaseAABB(cow, broadphase_, dispatcher_);
-  }
+void BulletDiscreteBVHManager::setDefaultCollisionMarginData(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMarginData(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteBVHManager::setPairCollisionMarginData(const std::string& name1,
+                                                          const std::string& name2,
+                                                          double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setPairCollisionMarginData(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
 }
 
 void BulletDiscreteBVHManager::setContactDistanceThreshold(double contact_distance)
 {
-  contact_test_data_.collision_margin_data = CollisionMarginData(contact_distance);
-
-  for (auto& co : link2cow_)
-  {
-    COW::Ptr& cow = co.second;
-    cow->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
-    assert(cow->getBroadphaseHandle() != nullptr);
-    updateBroadphaseAABB(cow, broadphase_, dispatcher_);
-  }
+  setDefaultCollisionMarginData(contact_distance);
 }
 
 double BulletDiscreteBVHManager::getContactDistanceThreshold() const
@@ -292,6 +290,18 @@ void BulletDiscreteBVHManager::addCollisionObject(COW::Ptr cow)
 
   // Add collision object to broadphase
   addCollisionObjectToBroadphase(cow, broadphase_, dispatcher_);
+}
+
+void BulletDiscreteBVHManager::onCollisionMarginDataChanged()
+{
+  btScalar margin = static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin());
+  for (auto& co : link2cow_)
+  {
+    COW::Ptr& cow = co.second;
+    cow->setContactProcessingThreshold(margin);
+    assert(cow->getBroadphaseHandle() != nullptr);
+    updateBroadphaseAABB(cow, broadphase_, dispatcher_);
+  }
 }
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/bullet/bullet_discrete_simple_manager.cpp
+++ b/tesseract/tesseract_collision/src/bullet/bullet_discrete_simple_manager.cpp
@@ -214,18 +214,26 @@ const std::vector<std::string>& BulletDiscreteSimpleManager::getActiveCollisionO
 void BulletDiscreteSimpleManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
   contact_test_data_.collision_margin_data = collision_margin_data;
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& co : link2cow_)
-    co.second->setContactProcessingThreshold(
-        static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin()));
+void BulletDiscreteSimpleManager::setDefaultCollisionMarginData(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMarginData(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteSimpleManager::setPairCollisionMarginData(const std::string& name1,
+                                                             const std::string& name2,
+                                                             double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setPairCollisionMarginData(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
 }
 
 void BulletDiscreteSimpleManager::setContactDistanceThreshold(double contact_distance)
 {
-  contact_test_data_.collision_margin_data = CollisionMarginData(contact_distance);
-
-  for (auto& co : link2cow_)
-    co.second->setContactProcessingThreshold(static_cast<btScalar>(contact_distance));
+  setDefaultCollisionMarginData(contact_distance);
 }
 
 double BulletDiscreteSimpleManager::getContactDistanceThreshold() const
@@ -318,5 +326,13 @@ void BulletDiscreteSimpleManager::addCollisionObject(COW::Ptr cow)
   else
     cows_.push_back(cow);
 }
+
+void BulletDiscreteSimpleManager::onCollisionMarginDataChanged()
+{
+  btScalar margin = static_cast<btScalar>(contact_test_data_.collision_margin_data.getMaxCollisionMargin());
+  for (auto& co : link2cow_)
+    co.second->setContactProcessingThreshold(margin);
+}
+
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
+++ b/tesseract/tesseract_collision/src/fcl/fcl_discrete_managers.cpp
@@ -266,55 +266,26 @@ const std::vector<std::string>& FCLDiscreteBVHManager::getActiveCollisionObjects
 void FCLDiscreteBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
   collision_margin_data_ = collision_margin_data;
-  static_update_.clear();
-  dynamic_update_.clear();
+  onCollisionMarginDataChanged();
+}
 
-  for (auto& cow : link2cow_)
-  {
-    cow.second->setContactDistanceThreshold(collision_margin_data_.getMaxCollisionMargin() / 2.0);
-    std::vector<CollisionObjectRawPtr>& co = cow.second->getCollisionObjectsRaw();
-    if (cow.second->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
-    {
-      static_update_.insert(static_update_.end(), co.begin(), co.end());
-    }
-    else
-    {
-      dynamic_update_.insert(dynamic_update_.end(), co.begin(), co.end());
-    }
-  }
+void FCLDiscreteBVHManager::setDefaultCollisionMarginData(double default_collision_margin)
+{
+  collision_margin_data_.setDefaultCollisionMarginData(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
 
-  if (!static_update_.empty())
-    static_manager_->update(static_update_);
-
-  if (!dynamic_update_.empty())
-    dynamic_manager_->update(dynamic_update_);
+void FCLDiscreteBVHManager::setPairCollisionMarginData(const std::string& name1,
+                                                       const std::string& name2,
+                                                       double collision_margin)
+{
+  collision_margin_data_.setPairCollisionMarginData(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
 }
 
 void FCLDiscreteBVHManager::setContactDistanceThreshold(double contact_distance)
 {
-  collision_margin_data_ = CollisionMarginData(contact_distance);
-  static_update_.clear();
-  dynamic_update_.clear();
-
-  for (auto& cow : link2cow_)
-  {
-    cow.second->setContactDistanceThreshold(collision_margin_data_.getMaxCollisionMargin() / 2.0);
-    std::vector<CollisionObjectRawPtr>& co = cow.second->getCollisionObjectsRaw();
-    if (cow.second->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
-    {
-      static_update_.insert(static_update_.end(), co.begin(), co.end());
-    }
-    else
-    {
-      dynamic_update_.insert(dynamic_update_.end(), co.begin(), co.end());
-    }
-  }
-
-  if (!static_update_.empty())
-    static_manager_->update(static_update_);
-
-  if (!dynamic_update_.empty())
-    dynamic_manager_->update(dynamic_update_);
+  setDefaultCollisionMarginData(contact_distance);
 }
 
 double FCLDiscreteBVHManager::getContactDistanceThreshold() const
@@ -407,6 +378,32 @@ void FCLDiscreteBVHManager::addCollisionObject(COW::Ptr cow)
   // This causes a refit on the bvh tree.
   dynamic_manager_->update();
   static_manager_->update();
+}
+
+void FCLDiscreteBVHManager::onCollisionMarginDataChanged()
+{
+  static_update_.clear();
+  dynamic_update_.clear();
+
+  for (auto& cow : link2cow_)
+  {
+    cow.second->setContactDistanceThreshold(collision_margin_data_.getMaxCollisionMargin() / 2.0);
+    std::vector<CollisionObjectRawPtr>& co = cow.second->getCollisionObjectsRaw();
+    if (cow.second->m_collisionFilterGroup == CollisionFilterGroups::StaticFilter)
+    {
+      static_update_.insert(static_update_.end(), co.begin(), co.end());
+    }
+    else
+    {
+      dynamic_update_.insert(dynamic_update_.end(), co.begin(), co.end());
+    }
+  }
+
+  if (!static_update_.empty())
+    static_manager_->update(static_update_);
+
+  if (!dynamic_update_.empty())
+    dynamic_manager_->update(dynamic_update_);
 }
 }  // namespace tesseract_collision_fcl
 }  // namespace tesseract_collision

--- a/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -82,6 +82,7 @@ public:
     joint_names_.clear();
     active_link_names_.clear();
     active_joint_names_.clear();
+    collision_margin_data_ = tesseract_collision::CollisionMarginData();
 
     if (!scene_graph_->insertSceneGraph(scene_graph))
     {
@@ -641,6 +642,7 @@ protected:
   std::vector<std::string> active_joint_names_;                   /**< A vector of active joint names */
   tesseract_collision::IsContactAllowedFn is_contact_allowed_fn_; /**< The function used to determine if two objects are
                                                                      allowed in collision */
+  tesseract_collision::CollisionMarginData collision_margin_data_;        /**< The collision margin data */
   tesseract_collision::DiscreteContactManager::Ptr discrete_manager_;     /**< The discrete contact manager object */
   tesseract_collision::ContinuousContactManager::Ptr continuous_manager_; /**< The continuous contact manager object */
   std::string discrete_manager_name_;   /**< Name of active descrete contact manager */

--- a/tesseract/tesseract_planning/tesseract_motion_planners/CMakeLists.txt
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/CMakeLists.txt
@@ -144,6 +144,7 @@ add_library(${PROJECT_NAME}_trajopt
   src/trajopt/trajopt_utils.cpp
   src/trajopt/profile/trajopt_default_plan_profile.cpp
   src/trajopt/profile/trajopt_default_composite_profile.cpp
+  src/trajopt/profile/trajopt_default_solver_profile.cpp
   src/trajopt/problem_generators/default_problem_generator.cpp
   src/trajopt/serialize.cpp
   src/trajopt/deserialize.cpp)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/descartes_collision.hpp
@@ -112,7 +112,7 @@ FloatType DescartesCollision<FloatType>::distance(const FloatType* pos, std::siz
   bool in_contact = checkTrajectoryState(results, *contact_manager_, env_state, config);
 
   if (!in_contact)
-    return static_cast<FloatType>(contact_manager_->getContactDistanceThreshold());
+    return static_cast<FloatType>(contact_manager_->getCollisionMarginData().getMaxCollisionMargin());
 
   return static_cast<FloatType>(results.begin()->begin()->second[0].distance);
 }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/problem_generators/default_problem_generator.h
@@ -39,7 +39,8 @@ namespace tesseract_planning
 trajopt::TrajOptProb::Ptr DefaultTrajoptProblemGenerator(const std::string& name,
                                                          const PlannerRequest& request,
                                                          const TrajOptPlanProfileMap& plan_profiles,
-                                                         const TrajOptCompositeProfileMap& composite_profiles);
+                                                         const TrajOptCompositeProfileMap& composite_profiles,
+                                                         const TrajOptSolverProfileMap& solver_profiles);
 
 }  // namespace tesseract_planning
 #endif

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/profile/trajopt_default_solver_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/profile/trajopt_default_solver_profile.h
@@ -1,0 +1,52 @@
+/**
+ * @file trajopt_default_solver_profile.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @date December 13, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_TRAJOPT_DEFAULT_SOLVER_PROFILE_H
+#define TESSERACT_MOTION_PLANNERS_TRAJOPT_DEFAULT_SOLVER_PROFILE_H
+
+#include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
+#include <trajopt_sco/solver_interface.hpp>
+
+namespace tesseract_planning
+{
+/** @brief The contains the default solver parameters available for setting up TrajOpt */
+class TrajOptDefaultSolverProfile : public TrajOptSolverProfile
+{
+public:
+  using Ptr = std::shared_ptr<TrajOptDefaultSolverProfile>;
+  using ConstPtr = std::shared_ptr<const TrajOptDefaultSolverProfile>;
+
+  /** @brief The Convex solver to use */
+  sco::ModelType convex_solver{ sco::ModelType::OSQP };
+
+  /** @brief Optimization paramters */
+  sco::BasicTrustRegionSQPParameters opt_info;
+
+  void apply(trajopt::ProblemConstructionInfo& pci) const override;
+
+  tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const override;
+};
+}  // namespace tesseract_planning
+#endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_DEFAULT_SOLVER_PROFILE_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/profile/trajopt_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/profile/trajopt_profile.h
@@ -77,6 +77,18 @@ public:
   virtual tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const = 0;
 };
 
+class TrajOptSolverProfile
+{
+public:
+  using Ptr = std::shared_ptr<TrajOptSolverProfile>;
+  using ConstPtr = std::shared_ptr<const TrajOptSolverProfile>;
+
+  virtual void apply(trajopt::ProblemConstructionInfo& pci) const = 0;
+
+  virtual tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const = 0;
+};
+
+using TrajOptSolverProfileMap = std::unordered_map<std::string, TrajOptSolverProfile::ConstPtr>;
 using TrajOptCompositeProfileMap = std::unordered_map<std::string, TrajOptCompositeProfile::ConstPtr>;
 using TrajOptPlanProfileMap = std::unordered_map<std::string, TrajOptPlanProfile::ConstPtr>;
 }  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/trajopt/trajopt_motion_planner.h
@@ -41,7 +41,8 @@ class TrajOptMotionPlannerStatusCategory;
 using TrajOptProblemGeneratorFn = std::function<trajopt::TrajOptProb::Ptr(const std::string&,
                                                                           const PlannerRequest&,
                                                                           const TrajOptPlanProfileMap&,
-                                                                          const TrajOptCompositeProfileMap&)>;
+                                                                          const TrajOptCompositeProfileMap&,
+                                                                          const TrajOptSolverProfileMap&)>;
 
 class TrajOptMotionPlanner : public MotionPlanner
 {
@@ -60,19 +61,23 @@ public:
   TrajOptProblemGeneratorFn problem_generator;
 
   /**
+   * @brief The available solver profiles
+   * @details This is used to look up solver parameters by the planner
+   */
+  TrajOptSolverProfileMap solver_profiles;
+
+  /**
    * @brief The available composite profiles
-   *
-   * Composite instruction is a way to namespace or organize your planning problem. The composite instruction has a
-   * profile which is used for applying multy waypoint costs and constraints like joint smoothing, collision avoidance,
-   * and velocity smoothing.
+   * @details Composite instruction is a way to namespace or organize your planning problem. The composite instruction
+   * has a profile which is used for applying multy waypoint costs and constraints like joint smoothing, collision
+   * avoidance, and velocity smoothing.
    */
   TrajOptCompositeProfileMap composite_profiles;
 
   /**
    * @brief The available plan profiles
-   *
-   * Plan instruction profiles are used to control waypoint specific information like fixed waypoint, toleranced
-   * waypoint, corner distance waypoint, etc.
+   * @details Plan instruction profiles are used to control waypoint specific information like fixed waypoint,
+   * toleranced waypoint, corner distance waypoint, etc.
    */
   TrajOptPlanProfileMap plan_profiles;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/continuous_motion_validator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/continuous_motion_validator.cpp
@@ -55,7 +55,7 @@ ContinuousMotionValidator::ContinuousMotionValidator(const ompl::base::SpaceInfo
   links_ = adj_map.getActiveLinkNames();
 
   continuous_contact_manager_->setActiveCollisionObjects(links_);
-  continuous_contact_manager_->setContactDistanceThreshold(collision_safety_margin);
+  continuous_contact_manager_->setDefaultCollisionMarginData(collision_safety_margin);
 }
 
 bool ContinuousMotionValidator::checkMotion(const ompl::base::State* s1, const ompl::base::State* s2) const

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/profile/ompl_default_plan_profile.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/profile/ompl_default_plan_profile.cpp
@@ -283,7 +283,7 @@ void OMPLDefaultPlanProfile::setup(OMPLProblem& prob) const
   prob.max_solutions = max_solutions;
   prob.simplify = simplify;
   prob.optimize = optimize;
-  prob.contact_checker->setContactDistanceThreshold(collision_safety_margin);
+  prob.contact_checker->setDefaultCollisionMarginData(collision_safety_margin);
 
   tesseract_environment::Environment::ConstPtr env = prob.tesseract->getEnvironment();
   const std::vector<std::string>& joint_names = prob.manip_fwd_kin->getJointNames();

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/state_collision_validator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/state_collision_validator.cpp
@@ -55,7 +55,7 @@ StateCollisionValidator::StateCollisionValidator(const ompl::base::SpaceInformat
   links_ = adj_map.getActiveLinkNames();
 
   contact_manager_->setActiveCollisionObjects(links_);
-  contact_manager_->setContactDistanceThreshold(collision_safety_margin);
+  contact_manager_->setDefaultCollisionMarginData(collision_safety_margin);
 }
 
 bool StateCollisionValidator::isValid(const ompl::base::State* state) const

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/profile/trajopt_default_solver_profile.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/profile/trajopt_default_solver_profile.cpp
@@ -1,0 +1,39 @@
+/**
+ * @file trajopt_default_solver_profile.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @date December 13, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_motion_planners/trajopt/profile/trajopt_default_solver_profile.h>
+
+namespace tesseract_planning
+{
+void TrajOptDefaultSolverProfile::apply(trajopt::ProblemConstructionInfo& pci) const
+{
+  pci.basic_info.convex_solver = convex_solver;
+  pci.opt_info = opt_info;
+}
+
+tinyxml2::XMLElement* TrajOptDefaultSolverProfile::toXML(tinyxml2::XMLDocument& /*doc*/) const { return nullptr; }
+
+}  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/trajopt_motion_planner.cpp
@@ -123,7 +123,7 @@ tesseract_common::StatusCode TrajOptMotionPlanner::solve(const PlannerRequest& r
 
     try
     {
-      problem = problem_generator(name_, request, plan_profiles, composite_profiles);
+      problem = problem_generator(name_, request, plan_profiles, composite_profiles, solver_profiles);
     }
     catch (std::exception& e)
     {

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/trajopt_planner_tests.cpp
@@ -185,8 +185,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptPlannerBooleanFlagsJointJoint)  // N
     composite_profile->smooth_jerks = t3;
     composite_profile->collision_constraint_config.enabled = t4;
     composite_profile->collision_cost_config.enabled = t4;
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointVelEqCost>(problem->getCosts())), t1);
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointAccEqCost>(problem->getCosts())), t2);
@@ -243,8 +246,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointJoint)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -256,8 +262,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointJoint)  // NOLINT
   }
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -318,8 +327,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointCart)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -332,8 +344,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceJointCart)  // NOLINT
 
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -398,8 +413,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartJoint)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -412,8 +430,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartJoint)  // NOLINT
 
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -478,8 +499,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartCart)  // NOLINT
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
   {
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -491,8 +515,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptFreespaceCartCart)  // NOLINT
   }
   {
     plan_profile->term_type = trajopt::TermType::TT_COST;
-    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                       request,
+                                                                       test_planner.plan_profiles,
+                                                                       test_planner.composite_profiles,
+                                                                       test_planner.solver_profiles);
 
     EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
         problem->getConstraints())));
@@ -573,8 +600,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptPlannerBooleanFlagsCartCart)  // NOL
     composite_profile->collision_constraint_config.enabled = t4;
     composite_profile->collision_cost_config.enabled = t4;
 
-    problem = DefaultTrajoptProblemGenerator(
-        test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+    problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                             request,
+                                             test_planner.plan_profiles,
+                                             test_planner.composite_profiles,
+                                             test_planner.solver_profiles);
 
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointVelEqCost>(problem->getCosts())), t1);
     EXPECT_EQ((tesseract_tests::vectorContainsType<sco::Cost::Ptr, trajopt::JointAccEqCost>(problem->getCosts())), t2);
@@ -645,8 +675,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayJointConstraint)  // NOLINT
   request.tesseract = tesseract_ptr_;
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
-  trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-      test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+  trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                     request,
+                                                                     test_planner.plan_profiles,
+                                                                     test_planner.composite_profiles,
+                                                                     test_planner.solver_profiles);
 
   EXPECT_TRUE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
       problem->getConstraints())));
@@ -713,8 +746,11 @@ TEST_F(TesseractPlanningTrajoptUnit, TrajoptArrayJointCost)  // NOLINT
   request.tesseract = tesseract_ptr_;
   request.env_state = tesseract_ptr_->getEnvironment()->getCurrentState();
 
-  trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(
-      test_planner.getName(), request, test_planner.plan_profiles, test_planner.composite_profiles);
+  trajopt::TrajOptProb::Ptr problem = DefaultTrajoptProblemGenerator(test_planner.getName(),
+                                                                     request,
+                                                                     test_planner.plan_profiles,
+                                                                     test_planner.composite_profiles,
+                                                                     test_planner.solver_profiles);
   EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::JointPosEqConstraint>(
       problem->getConstraints())));
   EXPECT_FALSE((tesseract_tests::vectorContainsType<sco::Constraint::Ptr, trajopt::TrajOptConstraintFromErrFunc>(

--- a/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
+++ b/tesseract/tesseract_planning/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
@@ -124,7 +124,7 @@ public:
   void enableTaskflowProfiling();
 
   /** @brief This remove the Taskflow profiling observer from the executor if one exists */
-  void disableTskflowProfiling();
+  void disableTaskflowProfiling();
 
   /**
    * @brief Get the profile dictionary associated with the planning server

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/core/process_planning_server.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/core/process_planning_server.cpp
@@ -182,7 +182,7 @@ void ProcessPlanningServer::enableTaskflowProfiling()
     profile_observer_ = executor_->make_observer<tf::TFProfObserver>();
 }
 
-void ProcessPlanningServer::disableTskflowProfiling()
+void ProcessPlanningServer::disableTaskflowProfiling()
 {
   if (profile_observer_ != nullptr)
   {

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflow_generators/cartesian_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflow_generators/cartesian_taskflow.cpp
@@ -137,6 +137,9 @@ TaskflowContainer CartesianTaskflow::generateTaskflow(ProcessInput input,
 
     if (input.profiles->hasProfileEntry<TrajOptCompositeProfile>())
       trajopt_planner->composite_profiles = input.profiles->getProfileEntry<TrajOptCompositeProfile>();
+
+    if (input.profiles->hasProfileEntry<TrajOptSolverProfile>())
+      trajopt_planner->solver_profiles = input.profiles->getProfileEntry<TrajOptSolverProfile>();
   }
   ProcessGenerator::UPtr trajopt_generator = std::make_unique<MotionPlannerProcessGenerator>(trajopt_planner);
   trajopt_task.work(trajopt_generator->generateConditionalTask(input, trajopt_task.hash_value()));

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflow_generators/freespace_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflow_generators/freespace_taskflow.cpp
@@ -134,6 +134,9 @@ TaskflowContainer FreespaceTaskflow::generateTaskflow(ProcessInput input,
 
     if (input.profiles->hasProfileEntry<TrajOptCompositeProfile>())
       trajopt_planner->composite_profiles = input.profiles->getProfileEntry<TrajOptCompositeProfile>();
+
+    if (input.profiles->hasProfileEntry<TrajOptSolverProfile>())
+      trajopt_planner->solver_profiles = input.profiles->getProfileEntry<TrajOptSolverProfile>();
   }
   ProcessGenerator::UPtr trajopt_generator = std::make_unique<MotionPlannerProcessGenerator>(trajopt_planner);
   trajopt_task.work(trajopt_generator->generateConditionalTask(input, trajopt_task.hash_value()));
@@ -170,6 +173,9 @@ TaskflowContainer FreespaceTaskflow::generateTaskflow(ProcessInput input,
 
       if (input.profiles->hasProfileEntry<TrajOptCompositeProfile>())
         trajopt_planner2->composite_profiles = input.profiles->getProfileEntry<TrajOptCompositeProfile>();
+
+      if (input.profiles->hasProfileEntry<TrajOptSolverProfile>())
+        trajopt_planner2->solver_profiles = input.profiles->getProfileEntry<TrajOptSolverProfile>();
     }
     ProcessGenerator::UPtr trajopt_generator2 = std::make_unique<MotionPlannerProcessGenerator>(trajopt_planner2);
     trajopt_second_task.work(trajopt_generator2->generateConditionalTask(input, trajopt_second_task.hash_value()));

--- a/tesseract/tesseract_planning/tesseract_process_managers/src/taskflow_generators/trajopt_taskflow.cpp
+++ b/tesseract/tesseract_planning/tesseract_process_managers/src/taskflow_generators/trajopt_taskflow.cpp
@@ -117,6 +117,9 @@ TaskflowContainer TrajOptTaskflow::generateTaskflow(ProcessInput input,
 
     if (input.profiles->hasProfileEntry<TrajOptCompositeProfile>())
       trajopt_planner->composite_profiles = input.profiles->getProfileEntry<TrajOptCompositeProfile>();
+
+    if (input.profiles->hasProfileEntry<TrajOptSolverProfile>())
+      trajopt_planner->solver_profiles = input.profiles->getProfileEntry<TrajOptSolverProfile>();
   }
   ProcessGenerator::UPtr trajopt_generator = std::make_unique<MotionPlannerProcessGenerator>(trajopt_planner);
   trajopt_task.work(trajopt_generator->generateConditionalTask(input, trajopt_task.hash_value()));


### PR DESCRIPTION
This PR also add two additional setters to the Collision Base Class `setDefaultCollisionMarginData` and `setPairCollisionMarginData` making it a little easier to set collision margin data. 

Also fixes the handling of collision margin data in environment.