### PR TITLE
Fix error message IKFast -> OPW

### DIFF
--- a/tesseract/tesseract_kinematics/src/opw/opw_inv_kin.cpp
+++ b/tesseract/tesseract_kinematics/src/opw/opw_inv_kin.cpp
@@ -86,7 +86,7 @@ bool OPWInvKin::calcInvKin(Eigen::VectorXd& /*solutions*/,
                            const Eigen::Ref<const Eigen::VectorXd>& /*seed*/,
                            const std::string& /*link_name*/) const
 {
-  throw std::runtime_error("IKFastInvKin::calcInvKin(Eigen::VectorXd&, const Eigen::Isometry3d&, const "
+  throw std::runtime_error("OPWInvKin::calcInvKin(Eigen::VectorXd&, const Eigen::Isometry3d&, const "
                            "Eigen::Ref<const Eigen::VectorXd>&, const std::string&) Not Supported!");
 }
 


### PR DESCRIPTION
The error message when attempting to use a non-implemented method in OPWInvKin mentions IKFastInvKin, so update that as it's probably a copy-paste error.