### PR TITLE
Update planners to use CollisionCheckConfig

### DIFF
--- a/tesseract/tesseract_common/cmake/tesseract_macros.cmake
+++ b/tesseract/tesseract_common/cmake/tesseract_macros.cmake
@@ -49,7 +49,41 @@ macro(tesseract_variables)
   set(TESSERACT_COMPILE_OPTIONS_PUBLIC "")
   set(TESSERACT_COMPILE_OPTIONS_PRIVATE "")
   if (NOT TESSERACT_ENABLE_TESTING AND NOT TESSERACT_ENABLE_TESTING_ALL)
-    set(TESSERACT_CLANG_TIDY_ARGS "-header-filter=.*" "-line-filter=[{'name':'EnvironmentMonitorDynamicReconfigureConfig.h','lines':[[9999999,9999999]]}, {'name':'.h'}, {'name':'.hpp'}]" "-checks=-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-avoid-goto,cppcoreguidelines-c-copy-assignment-signature,cppcoreguidelines-interfaces-global-init,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-no-malloc,cppcoreguidelines-slicing,cppcoreguidelines-special-member-functions,misc-*,-misc-non-private-member-variables-in-classes,modernize-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,performance-*,readability-avoid-const-params-in-decls,readability-container-size-empty,readability-delete-null-pointer,readability-deleted-default,readability-else-after-return,readability-function-size,readability-identifier-naming,readability-inconsistent-declaration-parameter-name,readability-misleading-indentation,readability-misplaced-array-index,readability-non-const-parameter,readability-redundant-*,readability-simplify-*,readability-static-*,readability-string-compare,readability-uniqueptr-delete-release,readability-rary-objects")
+    set(TESSERACT_CLANG_TIDY_ARGS "-header-filter=.*"
+      "-line-filter=[{'name':'EnvironmentMonitorDynamicReconfigureConfig.h','lines':[[9999999,9999999]]}, {'name':'.h'}, {'name':'.hpp'}]"
+      "-checks=-*, \
+      clang-analyzer-*, \
+      bugprone-*, \
+      cppcoreguidelines-avoid-goto, \
+      cppcoreguidelines-c-copy-assignment-signature, \
+      cppcoreguidelines-interfaces-global-init, \
+      cppcoreguidelines-narrowing-conversions, \
+      cppcoreguidelines-no-malloc, \
+      cppcoreguidelines-slicing, \
+      cppcoreguidelines-special-member-functions, \
+      misc-*, \
+      -misc-non-private-member-variables-in-classes, \
+      modernize-*, \
+      -modernize-use-trailing-return-type, \
+      -modernize-use-nodiscard, \
+      performance-*, \
+      readability-avoid-const-params-in-decls, \
+      readability-container-size-empty, \
+      readability-delete-null-pointer, \
+      readability-deleted-default, \
+      readability-else-after-return, \
+      readability-function-size, \
+      readability-identifier-naming, \
+      readability-inconsistent-declaration-parameter-name, \
+      readability-misleading-indentation, \
+      readability-misplaced-array-index, \
+      readability-non-const-parameter, \
+      readability-redundant-*, \
+      readability-simplify-*, \
+      readability-static-*, \
+      readability-string-compare, \
+      readability-uniqueptr-delete-release, \
+      readability-rary-objects")
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       set(TESSERACT_COMPILE_OPTIONS_PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion -Wno-sign-compare -Wnon-virtual-dtor)
       set(TESSERACT_COMPILE_OPTIONS_PUBLIC -mno-avx)
@@ -63,7 +97,73 @@ macro(tesseract_variables)
       message(WARNING "${CMAKE_CXX_COMPILER_ID} Unsupported compiler detected.")
     endif()
   else()
-    set(TESSERACT_CLANG_TIDY_ARGS "-header-filter=.*" "-line-filter=[{'name':'EnvironmentMonitorDynamicReconfigureConfig.h','lines':[[9999999,9999999]]}, {'name':'.h'}, {'name':'.hpp'}]" "-checks=-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-avoid-goto,cppcoreguidelines-c-copy-assignment-signature,cppcoreguidelines-interfaces-global-init,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-no-malloc,cppcoreguidelines-slicing,cppcoreguidelines-special-member-functions,misc-*,-misc-non-private-member-variables-in-classes,modernize-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,performance-*,readability-avoid-const-params-in-decls,readability-container-size-empty,readability-delete-null-pointer,readability-deleted-default,readability-else-after-return,readability-function-size,readability-identifier-naming,readability-inconsistent-declaration-parameter-name,readability-misleading-indentation,readability-misplaced-array-index,readability-non-const-parameter,readability-redundant-*,readability-simplify-*,readability-static-*,readability-string-compare,readability-uniqueptr-delete-release,readability-rary-objects" "-warnings-as-errors=-*,clang-analyzer-*,bugprone-*,cppcoreguidelines-avoid-goto,cppcoreguidelines-c-copy-assignment-signature,cppcoreguidelines-interfaces-global-init,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-no-malloc,cppcoreguidelines-slicing,cppcoreguidelines-special-member-functions,misc-*,-misc-non-private-member-variables-in-classes,modernize-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,performance-*,readability-avoid-const-params-in-decls,readability-container-size-empty,readability-delete-null-pointer,readability-deleted-default,readability-else-after-return,readability-function-size,readability-identifier-naming,readability-inconsistent-declaration-parameter-name,readability-misleading-indentation,readability-misplaced-array-index,readability-non-const-parameter,readability-redundant-*,readability-simplify-*,readability-static-*,readability-string-compare,readability-uniqueptr-delete-release,readability-rary-objects")
+    set(TESSERACT_CLANG_TIDY_ARGS "-header-filter=.*"
+      "-line-filter=[{'name':'EnvironmentMonitorDynamicReconfigureConfig.h','lines':[[9999999,9999999]]}, {'name':'.h'}, {'name':'.hpp'}]"
+      "-checks=-*, \
+      clang-analyzer-*, \
+      bugprone-*, \
+      cppcoreguidelines-avoid-goto, \
+      cppcoreguidelines-c-copy-assignment-signature, \
+      cppcoreguidelines-interfaces-global-init, \
+      cppcoreguidelines-narrowing-conversions, \
+      cppcoreguidelines-no-malloc, \
+      cppcoreguidelines-slicing, \
+      cppcoreguidelines-special-member-functions, \
+      misc-*, \
+      -misc-non-private-member-variables-in-classes, \
+      modernize-*, \
+      -modernize-use-trailing-return-type, \
+      -modernize-use-nodiscard, \
+      performance-*, \
+      readability-avoid-const-params-in-decls, \
+      readability-container-size-empty, \
+      readability-delete-null-pointer, \
+      readability-deleted-default, \
+      readability-else-after-return, \
+      readability-function-size, \
+      readability-identifier-naming, \
+      readability-inconsistent-declaration-parameter-name, \
+      readability-misleading-indentation, \
+      readability-misplaced-array-index, \
+      readability-non-const-parameter, \
+      readability-redundant-*, \
+      readability-simplify-*, \
+      readability-static-*, \
+      readability-string-compare, \
+      readability-uniqueptr-delete-release, \
+      readability-rary-objects" "-warnings-as-errors=-*, \
+      clang-analyzer-*, \
+      bugprone-*, \
+      cppcoreguidelines-avoid-goto, \
+      cppcoreguidelines-c-copy-assignment-signature, \
+      cppcoreguidelines-interfaces-global-init, \
+      cppcoreguidelines-narrowing-conversions, \
+      cppcoreguidelines-no-malloc, \
+      cppcoreguidelines-slicing, \
+      cppcoreguidelines-special-member-functions, \
+      misc-*, \
+      -misc-non-private-member-variables-in-classes, \
+      modernize-*, \
+      -modernize-use-trailing-return-type, \
+      -modernize-use-nodiscard, \
+      performance-*, \
+      readability-avoid-const-params-in-decls, \
+      readability-container-size-empty, \
+      readability-delete-null-pointer, \
+      readability-deleted-default, \
+      readability-else-after-return, \
+      readability-function-size, \
+      readability-identifier-naming, \
+      readability-inconsistent-declaration-parameter-name, \
+      readability-misleading-indentation, \
+      readability-misplaced-array-index, \
+      readability-non-const-parameter, \
+      readability-redundant-*, \
+      readability-simplify-*, \
+      readability-static-*, \
+      readability-string-compare, \
+      readability-uniqueptr-delete-release, \
+      readability-rary-objects")
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       set(TESSERACT_COMPILE_OPTIONS_PRIVATE -Werror=all -Werror=extra -Werror=conversion -Werror=sign-conversion -Wno-sign-compare -Werror=non-virtual-dtor)
       set(TESSERACT_COMPILE_OPTIONS_PUBLIC -mno-avx)

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/descartes_collision.h
@@ -46,7 +46,7 @@ public:
    * @param collision_env The collision Environment
    * @param active_links The list of active links
    * @param joint_names The list of joint names in the order that the data will be provided to the validate function.
-   * @param collision_safety_margin The minimum distance allowed from a collision object
+   * @param edge_collision_check_config Config used to set up collision checking
    * @param longest_valid_segment_length Used to check collisions between two state if norm(state0-state1) >
    * longest_valid_segment_length.
    * @param debug If true, this print debug information to the terminal
@@ -54,7 +54,8 @@ public:
   DescartesCollision(const tesseract_environment::Environment::ConstPtr& collision_env,
                      std::vector<std::string> active_links,
                      std::vector<std::string> joint_names,
-                     double collision_safety_margin = 0.025,
+                     tesseract_collision::CollisionCheckConfig collision_check_config =
+                         tesseract_collision::CollisionCheckConfig{ 0.025 },
                      bool debug = false);
   ~DescartesCollision() override = default;
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/profile/descartes_default_plan_profile.hpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/impl/profile/descartes_default_plan_profile.hpp
@@ -57,8 +57,9 @@ DescartesDefaultPlanProfile<FloatType>::DescartesDefaultPlanProfile(const tinyxm
   if (vertex_collisions_element)
   {
     const tinyxml2::XMLElement* enabled_element = vertex_collisions_element->FirstChildElement("Enabled");
-    const tinyxml2::XMLElement* coll_safety_margin_element = vertex_collisions_element->FirstChildElement("CollisionSaf"
-                                                                                                          "etyMargin");
+    //    const tinyxml2::XMLElement* coll_safety_margin_element =
+    //    vertex_collisions_element->FirstChildElement("CollisionSaf"
+    //                                                                                                          "etyMargin");
 
     if (enabled_element)
     {
@@ -67,19 +68,22 @@ DescartesDefaultPlanProfile<FloatType>::DescartesDefaultPlanProfile(const tinyxm
         throw std::runtime_error("DescartesPlanProfile: VertexCollisions: Error parsing Enabled string");
     }
 
-    if (coll_safety_margin_element)
-    {
-      std::string coll_safety_margin_string;
-      status = tesseract_common::QueryStringText(coll_safety_margin_element, coll_safety_margin_string);
-      if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-        throw std::runtime_error("DescartesPlanProfile: VertexCollisions:: Error parsing CollisionSafetyMargin string");
+    /** @todo Update XML */
+    //    if (coll_safety_margin_element)
+    //    {
+    //      std::string coll_safety_margin_string;
+    //      status = tesseract_common::QueryStringText(coll_safety_margin_element, coll_safety_margin_string);
+    //      if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    //        throw std::runtime_error("DescartesPlanProfile: VertexCollisions:: Error parsing CollisionSafetyMargin
+    //        string");
 
-      if (!tesseract_common::isNumeric(coll_safety_margin_string))
-        throw std::runtime_error("DescartesPlanProfile: VertexCollisions:: CollisionSafetyMargin is not a numeric "
-                                 "values.");
+    //      if (!tesseract_common::isNumeric(coll_safety_margin_string))
+    //        throw std::runtime_error("DescartesPlanProfile: VertexCollisions:: CollisionSafetyMargin is not a numeric
+    //        "
+    //                                 "values.");
 
-      tesseract_common::toNumeric<double>(coll_safety_margin_string, collision_safety_margin);
-    }
+    //      tesseract_common::toNumeric<double>(coll_safety_margin_string, collision_safety_margin);
+    //    }
   }
 
   if (edge_collisions_element)
@@ -181,7 +185,7 @@ void DescartesDefaultPlanProfile<FloatType>::apply(DescartesProblem<FloatType>& 
   typename descartes_light::CollisionInterface<FloatType>::Ptr ci = nullptr;
   if (enable_collision)
     ci = std::make_shared<DescartesCollision<FloatType>>(
-        prob.env, active_links, prob.manip_inv_kin->getJointNames(), collision_safety_margin, debug);
+        prob.env, active_links, prob.manip_inv_kin->getJointNames(), vertex_collision_check_config, debug);
 
   Eigen::Isometry3d manip_baselink_to_waypoint = Eigen::Isometry3d::Identity();
   if (it == active_links.end())
@@ -314,9 +318,9 @@ tinyxml2::XMLElement* DescartesDefaultPlanProfile<FloatType>::toXML(tinyxml2::XM
   vertex_collisions_enabled->SetText(enable_collision);
   vertex_collisions->InsertEndChild(vertex_collisions_enabled);
 
-  tinyxml2::XMLElement* vertex_collisions_safety_margin = doc.NewElement("CollisionSafetyMargin");
-  vertex_collisions_safety_margin->SetText(collision_safety_margin);
-  vertex_collisions->InsertEndChild(vertex_collisions_safety_margin);
+  //  tinyxml2::XMLElement* vertex_collisions_safety_margin = doc.NewElement("CollisionSafetyMargin");
+  //  vertex_collisions_safety_margin->SetText(collision_safety_margin);
+  //  vertex_collisions->InsertEndChild(vertex_collisions_safety_margin);
 
   xml_descartes->InsertEndChild(vertex_collisions);
 

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h
@@ -72,11 +72,11 @@ public:
 
   // Applied to sampled states
   bool enable_collision{ true };
-  double collision_safety_margin{ 0 };
+  tesseract_collision::CollisionCheckConfig vertex_collision_check_config{ 0 };
 
   // Applied during edge evaluation
   bool enable_edge_collision{ false };
-  tesseract_collision::CollisionCheckConfig edge_collision_check_config;
+  tesseract_collision::CollisionCheckConfig edge_collision_check_config{ 0 };
   int num_threads{ 1 };
   bool allow_collision{ false };
   bool debug{ false };

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/continuous_motion_validator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/continuous_motion_validator.h
@@ -47,7 +47,7 @@ public:
                             ompl::base::StateValidityCheckerPtr state_validator,
                             const tesseract_environment::Environment::ConstPtr& env,
                             tesseract_kinematics::ForwardKinematics::ConstPtr kin,
-                            double collision_safety_margin,
+                            const tesseract_collision::CollisionMarginData& collision_margin_data,
                             OMPLStateExtractor extractor);
 
   bool checkMotion(const ompl::base::State* s1, const ompl::base::State* s2) const override;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
@@ -105,11 +105,10 @@ public:
   /** @brief If true, collision checking will be enabled. Default: true*/
   bool collision_check = true;
 
+  tesseract_collision::CollisionMarginData collision_margin_data;
+
   /** @brief If true, use continuous collision checking */
   bool collision_continuous = false;
-
-  /** @brief Max distance over which collisions are checked */
-  double collision_safety_margin = 0.00;
 
   /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
    * to be considered valid in post checking of trajectory returned by trajopt.

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/state_collision_validator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/ompl/state_collision_validator.h
@@ -45,7 +45,7 @@ public:
   StateCollisionValidator(const ompl::base::SpaceInformationPtr& space_info,
                           tesseract_environment::Environment::ConstPtr env,
                           tesseract_kinematics::ForwardKinematics::ConstPtr kin,
-                          double collision_safety_margin,
+                          const tesseract_collision::CollisionMarginData& collision_margin_data,
                           OMPLStateExtractor extractor);
 
   bool isValid(const ompl::base::State* state) const override;

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/continuous_motion_validator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/continuous_motion_validator.cpp
@@ -33,12 +33,13 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-ContinuousMotionValidator::ContinuousMotionValidator(const ompl::base::SpaceInformationPtr& space_info,
-                                                     ompl::base::StateValidityCheckerPtr state_validator,
-                                                     const tesseract_environment::Environment::ConstPtr& env,
-                                                     tesseract_kinematics::ForwardKinematics::ConstPtr kin,
-                                                     double collision_safety_margin,
-                                                     OMPLStateExtractor extractor)
+ContinuousMotionValidator::ContinuousMotionValidator(
+    const ompl::base::SpaceInformationPtr& space_info,
+    ompl::base::StateValidityCheckerPtr state_validator,
+    const tesseract_environment::Environment::ConstPtr& env,
+    tesseract_kinematics::ForwardKinematics::ConstPtr kin,
+    const tesseract_collision::CollisionMarginData& collision_margin_data,
+    OMPLStateExtractor extractor)
   : MotionValidator(space_info)
   , state_validator_(std::move(state_validator))
   , state_solver_(env->getStateSolver())
@@ -55,7 +56,7 @@ ContinuousMotionValidator::ContinuousMotionValidator(const ompl::base::SpaceInfo
   links_ = adj_map.getActiveLinkNames();
 
   continuous_contact_manager_->setActiveCollisionObjects(links_);
-  continuous_contact_manager_->setDefaultCollisionMarginData(collision_safety_margin);
+  continuous_contact_manager_->setCollisionMarginData(collision_margin_data);
 }
 
 bool ContinuousMotionValidator::checkMotion(const ompl::base::State* s1, const ompl::base::State* s2) const

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/profile/ompl_default_plan_profile.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/profile/ompl_default_plan_profile.cpp
@@ -57,7 +57,8 @@ OMPLDefaultPlanProfile::OMPLDefaultPlanProfile(const tinyxml2::XMLElement& xml_e
   const tinyxml2::XMLElement* planners_element = xml_element.FirstChildElement("Planners");
   const tinyxml2::XMLElement* collision_check_element = xml_element.FirstChildElement("CollisionCheck");
   const tinyxml2::XMLElement* collision_continuous_element = xml_element.FirstChildElement("CollisionContinuous");
-  const tinyxml2::XMLElement* collision_safety_margin_element = xml_element.FirstChildElement("CollisionSafetyMargin");
+  //  const tinyxml2::XMLElement* collision_safety_margin_element =
+  //  xml_element.FirstChildElement("CollisionSafetyMargin");
   const tinyxml2::XMLElement* longest_valid_segment_fraction_element = xml_element.FirstChildElement("LongestValidSegme"
                                                                                                      "ntFraction");
   const tinyxml2::XMLElement* longest_valid_segment_length_element = xml_element.FirstChildElement("LongestValidSegment"
@@ -234,18 +235,19 @@ OMPLDefaultPlanProfile::OMPLDefaultPlanProfile(const tinyxml2::XMLElement& xml_e
       throw std::runtime_error("OMPLPlanProfile: Error parsing CollisionContinuous string");
   }
 
-  if (collision_safety_margin_element)
-  {
-    std::string collision_safety_margin_string;
-    status = tesseract_common::QueryStringText(collision_safety_margin_element, collision_safety_margin_string);
-    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
-      throw std::runtime_error("OMPLPlanProfile: Error parsing CollisionSafetyMargin string");
+  /// @todo Update XML
+  //  if (collision_safety_margin_element)
+  //  {
+  //    std::string collision_safety_margin_string;
+  //    status = tesseract_common::QueryStringText(collision_safety_margin_element, collision_safety_margin_string);
+  //    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+  //      throw std::runtime_error("OMPLPlanProfile: Error parsing CollisionSafetyMargin string");
 
-    if (!tesseract_common::isNumeric(collision_safety_margin_string))
-      throw std::runtime_error("OMPLPlanProfile: CollisionSafetyMargin is not a numeric values.");
+  //    if (!tesseract_common::isNumeric(collision_safety_margin_string))
+  //      throw std::runtime_error("OMPLPlanProfile: CollisionSafetyMargin is not a numeric values.");
 
-    tesseract_common::toNumeric<double>(collision_safety_margin_string, collision_safety_margin);
-  }
+  //    tesseract_common::toNumeric<double>(collision_safety_margin_string, collision_safety_margin);
+  //  }
 
   if (longest_valid_segment_fraction_element)
   {
@@ -283,7 +285,7 @@ void OMPLDefaultPlanProfile::setup(OMPLProblem& prob) const
   prob.max_solutions = max_solutions;
   prob.simplify = simplify;
   prob.optimize = optimize;
-  prob.contact_checker->setDefaultCollisionMarginData(collision_safety_margin);
+  prob.contact_checker->setCollisionMarginData(collision_margin_data);
 
   const std::vector<std::string>& joint_names = prob.manip_fwd_kin->getJointNames();
   const auto dof = prob.manip_fwd_kin->numJoints();
@@ -580,9 +582,10 @@ tinyxml2::XMLElement* OMPLDefaultPlanProfile::toXML(tinyxml2::XMLDocument& doc) 
   xml_collision_continuous->SetText(collision_continuous);
   xml_ompl->InsertEndChild(xml_collision_continuous);
 
-  tinyxml2::XMLElement* xml_collision_safety_margin = doc.NewElement("CollisionSafetyMargin");
-  xml_collision_safety_margin->SetText(collision_safety_margin);
-  xml_ompl->InsertEndChild(xml_collision_safety_margin);
+  /// @todo Update XML
+  //  tinyxml2::XMLElement* xml_collision_safety_margin = doc.NewElement("CollisionSafetyMargin");
+  //  xml_collision_safety_margin->SetText(collision_safety_margin);
+  //  xml_ompl->InsertEndChild(xml_collision_safety_margin);
 
   tinyxml2::XMLElement* xml_long_valid_seg_frac = doc.NewElement("LongestValidSegmentFraction");
   xml_long_valid_seg_frac->SetText(longest_valid_segment_fraction);
@@ -616,7 +619,7 @@ OMPLDefaultPlanProfile::processStateValidator(OMPLProblem& prob,
   if (collision_check && !collision_continuous)
   {
     auto svc = std::make_shared<StateCollisionValidator>(
-        prob.simple_setup->getSpaceInformation(), env, kin, collision_safety_margin, prob.extractor);
+        prob.simple_setup->getSpaceInformation(), env, kin, collision_margin_data, prob.extractor);
     csvc->addStateValidator(svc);
   }
   prob.simple_setup->setStateValidityChecker(csvc);
@@ -645,7 +648,7 @@ void OMPLDefaultPlanProfile::processMotionValidator(ompl::base::StateValidityChe
                                                          svc_without_collision,
                                                          env,
                                                          kin,
-                                                         collision_safety_margin,
+                                                         collision_margin_data,
                                                          prob.extractor);
       }
       else

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/state_collision_validator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/state_collision_validator.cpp
@@ -37,7 +37,7 @@ namespace tesseract_planning
 StateCollisionValidator::StateCollisionValidator(const ompl::base::SpaceInformationPtr& space_info,
                                                  tesseract_environment::Environment::ConstPtr env,
                                                  tesseract_kinematics::ForwardKinematics::ConstPtr kin,
-                                                 double collision_safety_margin,
+                                                 const tesseract_collision::CollisionMarginData& collision_margin_data,
                                                  OMPLStateExtractor extractor)
   : StateValidityChecker(space_info)
   , env_(std::move(env))
@@ -55,7 +55,7 @@ StateCollisionValidator::StateCollisionValidator(const ompl::base::SpaceInformat
   links_ = adj_map.getActiveLinkNames();
 
   contact_manager_->setActiveCollisionObjects(links_);
-  contact_manager_->setDefaultCollisionMarginData(collision_safety_margin);
+  contact_manager_->setCollisionMarginData(collision_margin_data);
 }
 
 bool StateCollisionValidator::isValid(const ompl::base::State* state) const

--- a/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/test/ompl_planner_tests.cpp
@@ -199,7 +199,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespacePlannerUnit)
 
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
-  plan_profile->collision_safety_margin = 0.025;
+  plan_profile->collision_margin_data.setDefaultCollisionMarginData(0.025);
   plan_profile->planning_time = 10;
   plan_profile->max_solutions = 2;
   plan_profile->longest_valid_segment_fraction = 0.01;
@@ -349,7 +349,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespaceCartesianGoalPlannerUnit)
 
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
-  plan_profile->collision_safety_margin = 0.02;
+  plan_profile->collision_margin_data.setDefaultCollisionMarginData(0.02);
   plan_profile->planning_time = 10;
   plan_profile->max_solutions = 2;
   plan_profile->longest_valid_segment_fraction = 0.01;
@@ -438,7 +438,7 @@ TYPED_TEST(OMPLTestFixture, OMPLFreespaceCartesianStartPlannerUnit)
 
   // Create Profiles
   auto plan_profile = std::make_shared<OMPLDefaultPlanProfile>();
-  plan_profile->collision_safety_margin = 0.02;
+  plan_profile->collision_margin_data.setDefaultCollisionMarginData(0.02);
   plan_profile->planning_time = 10;
   plan_profile->max_solutions = 2;
   plan_profile->longest_valid_segment_fraction = 0.01;


### PR DESCRIPTION
I did not update trajopt because it has its own data structure. While we could go through and update it, I'd rather just focus on getting the ifopt planner working.

Similarly I added the ContactMarginData to OMPL but did not use the CollisionCheckConfig since OMPL handles LVS itself. I thought it would be confusing to have 2 longest valid segment terms where only one gets used.

Closes #427