### PR TITLE
Add support for external tcp attached to kinematic link

### DIFF
--- a/tesseract/tesseract_common/include/tesseract_common/manipulator_info.h
+++ b/tesseract/tesseract_common/include/tesseract_common/manipulator_info.h
@@ -48,9 +48,9 @@ public:
   /**
    * @brief Tool Center Point Defined by name
    * @param name The tool center point name
-   * @param external The external TCP is used when the robot is holding the part verus the tool.
-   * @note External should also be set to true your kinematic object which includes say a robot and
-   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * @param external The external TCP is used when the robot is holding the part versus the tool.
+   * @note External should also be set to true when your kinematic object includes a robot and
+   * positioner, where the positioner has the tool and the robot is holding the part. Basically
    * anytime the tool is not attached to the tip link of the kinematic chain.
    */
   ToolCenterPoint(const std::string& name, bool external = false);
@@ -58,10 +58,10 @@ public:
   /**
    * @brief Tool Center Point Defined by transform
    * @param transform The tool center point transform
-   * @param external The external TCP is used when the robot is holding the part verus the tool.
+   * @param external The external TCP is used when the robot is holding the part versus the tool.
    * @param external_frame If empty assumed relative to world, otherwise the provided tcp is relative to this link.
-   * @note External should also be set to true your kinematic object which includes say a robot and
-   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * @note External should also be set to true when your kinematic object includes a robot and
+   * positioner, where the positioner has the tool and the robot is holding the part. Basically
    * anytime the tool is not attached to the tip link of the kinematic chain.
    */
   ToolCenterPoint(const Eigen::Isometry3d& transform, bool external = false, std::string external_frame = "");
@@ -86,9 +86,9 @@ public:
 
   /**
    * @brief Check if tool center point is and external tcp which mean it is not defined
-   * @details The external TCP is used when the robot is holding the part verus the tool.
-   * External should also be set to true your kinematic object which includes say a robot and
-   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * @details The external TCP is used when the robot is holding the part versus the tool.
+   * External should also be set to true when your kinematic object includes a robot and
+   * positioner, where the positioner has the tool and the robot is holding the part. Basically
    * anytime the tool is not attached to the tip link of the kinematic chain.
    * @return True if and external TCP, otherwise the false
    */
@@ -137,9 +137,9 @@ protected:
   Eigen::Isometry3d transform_;
 
   /**
-   * @brief The external TCP is used when the robot is holding the part verus the tool.
-   * @details External should also be set to true your kinematic object which includes say a robot and
-   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * @brief The external TCP is used when the robot is holding the part versus the tool.
+   * @details External should also be set to true when your kinematic object includes a robot and
+   * positioner, where the positioner has the tool and the robot is holding the part. Basically
    * anytime the tool is not attached to the tip link of the kinematic chain.
    */
   bool external_{ false };

--- a/tesseract/tesseract_common/include/tesseract_common/manipulator_info.h
+++ b/tesseract/tesseract_common/include/tesseract_common/manipulator_info.h
@@ -49,6 +49,9 @@ public:
    * @brief Tool Center Point Defined by name
    * @param name The tool center point name
    * @param external The external TCP is used when the robot is holding the part verus the tool.
+   * @note External should also be set to true your kinematic object which includes say a robot and
+   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * anytime the tool is not attached to the tip link of the kinematic chain.
    */
   ToolCenterPoint(const std::string& name, bool external = false);
 
@@ -56,8 +59,12 @@ public:
    * @brief Tool Center Point Defined by transform
    * @param transform The tool center point transform
    * @param external The external TCP is used when the robot is holding the part verus the tool.
+   * @param external_frame If empty assumed relative to world, otherwise the provided tcp is relative to this link.
+   * @note External should also be set to true your kinematic object which includes say a robot and
+   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * anytime the tool is not attached to the tip link of the kinematic chain.
    */
-  ToolCenterPoint(const Eigen::Isometry3d& transform, bool external = false);
+  ToolCenterPoint(const Eigen::Isometry3d& transform, bool external = false, std::string external_frame = "");
 
   /**
    * @brief The Tool Center Point is empty
@@ -80,6 +87,9 @@ public:
   /**
    * @brief Check if tool center point is and external tcp which mean it is not defined
    * @details The external TCP is used when the robot is holding the part verus the tool.
+   * External should also be set to true your kinematic object which includes say a robot and
+   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * anytime the tool is not attached to the tip link of the kinematic chain.
    * @return True if and external TCP, otherwise the false
    */
   bool isExternal() const;
@@ -87,8 +97,16 @@ public:
   /**
    * @brief Set the external property
    * @param value True if external tool center point, otherwise false
+   * @param external_frame If an external tcp was defined as an Isometry then an external can be provided. If empty
+   * assumed relative to world.
    */
-  void setExternal(bool value);
+  void setExternal(bool value, std::string external_frame);
+
+  /**
+   * @brief If an external tcp was defined as an Isometry then an external frame can be provided.
+   * If empty assumed relative to world.
+   */
+  const std::string& getExternalFrame() const;
 
   /**
    * @brief Get the tool center point name
@@ -109,6 +127,7 @@ public:
     ret_val &= (name_ == other.name_);
     ret_val &= (transform_.isApprox(transform_, 1e-5));
     ret_val &= (external_ == other.external_);
+    ret_val &= (external_frame_ == other.external_frame_);
     return ret_val;
   }
 
@@ -117,8 +136,19 @@ protected:
   std::string name_;
   Eigen::Isometry3d transform_;
 
-  /** @brief The external TCP is used when the robot is holding the part verus the tool. */
+  /**
+   * @brief The external TCP is used when the robot is holding the part verus the tool.
+   * @details External should also be set to true your kinematic object which includes say a robot and
+   * positioner, and the positioner has the tool and the robot is holding the part. Basically
+   * anytime the tool is not attached to the tip link of the kinematic chain.
+   */
   bool external_{ false };
+
+  /**
+   * @brief If an external tcp was defined as an Isometry then an external can be provided. If empty assumed relative to
+   * world.
+   */
+  std::string external_frame_;
 };
 
 /**

--- a/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/utils/utils.h
+++ b/tesseract/tesseract_planning/tesseract_command_language/include/tesseract_command_language/utils/utils.h
@@ -68,6 +68,34 @@ const std::vector<std::string>& getJointNames(const Waypoint& waypoint);
 Eigen::VectorXd getJointPosition(const std::vector<std::string>& joint_names, const Waypoint& waypoint);
 
 /**
+ * @brief Format the waypoints joint ordered by the provided joint names
+ *
+ * Throws if waypoint does not directly contain that information
+ *
+ * Also this is an expensive call so the motion planners do not leverage this and they expect the order through out
+ * the program all match.
+ *
+ * @param joint_names The joint names defining the order desired
+ * @param waypoint The waypoint to format
+ * @return True if formating was required, otherwise false.
+ */
+bool formatJointPosition(const std::vector<std::string>& joint_names, Waypoint& waypoint);
+
+/**
+ * @brief Check the waypoints joint order against the provided joint names
+ *
+ * Throws if waypoint does not directly contain that information
+ *
+ * Also this is an expensive call so the motion planners do not leverage this and they expect the order through out
+ * the program all match.
+ *
+ * @param joint_names The joint names defining the order desired
+ * @param waypoint The waypoint to check format
+ * @return True if waypoint format is correct, otherwise false.
+ */
+bool checkJointPositionFormat(const std::vector<std::string>& joint_names, const Waypoint& waypoint);
+
+/**
  * @brief Set the joint position for waypoints that contain that information
  * @param waypoint Waypoint to set
  * @param position Joint position

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/core/utils.h
@@ -183,6 +183,14 @@ bool contactCheckProgram(std::vector<tesseract_collision::ContactResultMap>& con
 CompositeInstruction generateNaiveSeed(const CompositeInstruction& composite_instructions,
                                        const tesseract_environment::Environment& env);
 
+/**
+ * @brief This formats the joint and state waypoints to align with the kinematics object
+ * @param composite_instructions The input program to format
+ * @param env The environment information
+ * @return True if the program required formating.
+ */
+bool formatProgram(CompositeInstruction& composite_instructions, const tesseract_environment::Environment& env);
+
 }  // namespace tesseract_planning
 
 #endif  // TESSERACT_PLANNING_UTILS_H

--- a/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/include/tesseract_motion_planners/descartes/problem_generators/default_problem_generator.h
@@ -134,6 +134,7 @@ DefaultDescartesProblemGenerator(const std::string& name,
   }
   else if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
   {
+    assert(checkJointPositionFormat(prob->manip_fwd_kin->getJointNames(), start_waypoint));
     const Eigen::VectorXd& position = getJointPosition(start_waypoint);
     cur_plan_profile->apply(*prob, position, *start_instruction, composite_mi, active_links, index);
   }
@@ -187,6 +188,7 @@ DefaultDescartesProblemGenerator(const std::string& name,
           }
           else if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
           {
+            assert(checkJointPositionFormat(prob->manip_fwd_kin->getJointNames(), start_waypoint));
             const Eigen::VectorXd& position = getJointPosition(start_waypoint);
             if (!prob->manip_fwd_kin->calcFwdKin(prev_pose, position))
               throw std::runtime_error("DescartesMotionPlannerConfig: failed to solve forward kinematics!");
@@ -214,6 +216,7 @@ DefaultDescartesProblemGenerator(const std::string& name,
         }
         else if (isJointWaypoint(plan_instruction->getWaypoint()) || isStateWaypoint(plan_instruction->getWaypoint()))
         {
+          assert(checkJointPositionFormat(prob->manip_fwd_kin->getJointNames(), plan_instruction->getWaypoint()));
           const Eigen::VectorXd& cur_position = getJointPosition(plan_instruction->getWaypoint());
           Eigen::Isometry3d cur_pose = Eigen::Isometry3d::Identity();
           if (!prob->manip_fwd_kin->calcFwdKin(cur_pose, cur_position))
@@ -228,6 +231,7 @@ DefaultDescartesProblemGenerator(const std::string& name,
           }
           else if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
           {
+            assert(checkJointPositionFormat(prob->manip_fwd_kin->getJointNames(), start_waypoint));
             const Eigen::VectorXd& position = getJointPosition(start_waypoint);
             if (!prob->manip_fwd_kin->calcFwdKin(prev_pose, position))
               throw std::runtime_error("DescartesMotionPlannerConfig: failed to solve forward kinematics!");
@@ -262,6 +266,7 @@ DefaultDescartesProblemGenerator(const std::string& name,
       {
         if (isJointWaypoint(plan_instruction->getWaypoint()) || isStateWaypoint(plan_instruction->getWaypoint()))
         {
+          assert(checkJointPositionFormat(prob->manip_fwd_kin->getJointNames(), plan_instruction->getWaypoint()));
           const Eigen::VectorXd& cur_position = getJointPosition(plan_instruction->getWaypoint());
 
           // Descartes does not support freespace so it will only include the plan instruction state, then in

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/core/utils.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/core/utils.cpp
@@ -508,6 +508,7 @@ void generateNaiveSeedHelper(CompositeInstruction& composite_instructions,
 
       if (isStateWaypoint(base_instruction->getWaypoint()))
       {
+        assert(checkJointPositionFormat(fwd_kin->getJointNames(), base_instruction->getWaypoint()));
         MoveInstruction move_instruction(base_instruction->getWaypoint(), move_type);
         move_instruction.setManipulatorInfo(base_instruction->getManipulatorInfo());
         move_instruction.setDescription(base_instruction->getDescription());
@@ -516,6 +517,7 @@ void generateNaiveSeedHelper(CompositeInstruction& composite_instructions,
       }
       else if (isJointWaypoint(base_instruction->getWaypoint()))
       {
+        assert(checkJointPositionFormat(fwd_kin->getJointNames(), base_instruction->getWaypoint()));
         const auto* jwp = base_instruction->getWaypoint().cast<JointWaypoint>();
         MoveInstruction move_instruction(StateWaypoint(jwp->joint_names, jwp->waypoint), move_type);
         move_instruction.setManipulatorInfo(base_instruction->getManipulatorInfo());
@@ -553,7 +555,7 @@ CompositeInstruction generateNaiveSeed(const CompositeInstruction& composite_ins
   std::string profile;
   if (isPlanInstruction(seed.getStartInstruction()))
   {
-    const auto* pi = seed.getStartInstruction().cast<PlanInstruction>();
+    const auto* pi = seed.getStartInstruction().cast_const<PlanInstruction>();
     wp = pi->getWaypoint();
     base_mi = pi->getManipulatorInfo();
     description = pi->getDescription();
@@ -561,7 +563,7 @@ CompositeInstruction generateNaiveSeed(const CompositeInstruction& composite_ins
   }
   else if (isMoveInstruction(seed.getStartInstruction()))
   {
-    const auto* pi = seed.getStartInstruction().cast<MoveInstruction>();
+    const auto* pi = seed.getStartInstruction().cast_const<MoveInstruction>();
     wp = pi->getWaypoint();
     base_mi = pi->getManipulatorInfo();
     description = pi->getDescription();
@@ -576,6 +578,7 @@ CompositeInstruction generateNaiveSeed(const CompositeInstruction& composite_ins
 
   if (isStateWaypoint(wp))
   {
+    assert(checkJointPositionFormat(fwd_kin->getJointNames(), wp));
     MoveInstruction move_instruction(wp, MoveInstructionType::START);
     move_instruction.setManipulatorInfo(base_mi);
     move_instruction.setDescription(description);
@@ -584,6 +587,7 @@ CompositeInstruction generateNaiveSeed(const CompositeInstruction& composite_ins
   }
   else if (isJointWaypoint(wp))
   {
+    assert(checkJointPositionFormat(fwd_kin->getJointNames(), wp));
     const auto* jwp = wp.cast<JointWaypoint>();
     MoveInstruction move_instruction(StateWaypoint(jwp->joint_names, jwp->waypoint), MoveInstructionType::START);
     move_instruction.setManipulatorInfo(base_mi);
@@ -602,5 +606,92 @@ CompositeInstruction generateNaiveSeed(const CompositeInstruction& composite_ins
 
   generateNaiveSeedHelper(seed, env, *env_state, mi);
   return seed;
+}
+
+bool formatProgramHelper(CompositeInstruction& composite_instructions,
+                         const tesseract_environment::Environment& env,
+                         const ManipulatorInfo& manip_info)
+{
+  bool format_required = false;
+  for (auto& i : composite_instructions)
+  {
+    if (isCompositeInstruction(i))
+    {
+      if (formatProgramHelper(*(i.cast<CompositeInstruction>()), env, manip_info))
+        format_required = true;
+    }
+    else if (isPlanInstruction(i))
+    {
+      PlanInstruction* base_instruction = i.cast<PlanInstruction>();
+      ManipulatorInfo mi = manip_info.getCombined(base_instruction->getManipulatorInfo());
+
+      ManipulatorInfo combined_mi = mi.getCombined(base_instruction->getManipulatorInfo());
+      auto fwd_kin = env.getManipulatorManager()->getFwdKinematicSolver(combined_mi.manipulator);
+
+      if (isStateWaypoint(base_instruction->getWaypoint()) || isJointWaypoint(base_instruction->getWaypoint()))
+      {
+        if (formatJointPosition(fwd_kin->getJointNames(), base_instruction->getWaypoint()))
+          format_required = true;
+      }
+    }
+    else if (isMoveInstruction(i))
+    {
+      MoveInstruction* base_instruction = i.cast<MoveInstruction>();
+      ManipulatorInfo mi = manip_info.getCombined(base_instruction->getManipulatorInfo());
+
+      ManipulatorInfo combined_mi = mi.getCombined(base_instruction->getManipulatorInfo());
+      auto fwd_kin = env.getManipulatorManager()->getFwdKinematicSolver(combined_mi.manipulator);
+
+      if (isStateWaypoint(base_instruction->getWaypoint()) || isJointWaypoint(base_instruction->getWaypoint()))
+      {
+        if (formatJointPosition(fwd_kin->getJointNames(), base_instruction->getWaypoint()))
+          format_required = true;
+      }
+    }
+  }
+  return format_required;
+}
+
+bool formatProgram(CompositeInstruction& composite_instructions, const tesseract_environment::Environment& env)
+{
+  if (!composite_instructions.hasStartInstruction())
+    throw std::runtime_error("Top most composite instruction is missing start instruction!");
+
+  bool format_required = false;
+  ManipulatorInfo mi = composite_instructions.getManipulatorInfo();
+
+  if (isPlanInstruction(composite_instructions.getStartInstruction()))
+  {
+    auto* pi = composite_instructions.getStartInstruction().cast<PlanInstruction>();
+
+    ManipulatorInfo start_mi = mi.getCombined(pi->getManipulatorInfo());
+    auto fwd_kin = env.getManipulatorManager()->getFwdKinematicSolver(start_mi.manipulator);
+
+    if (isStateWaypoint(pi->getWaypoint()) || isJointWaypoint(pi->getWaypoint()))
+    {
+      if (formatJointPosition(fwd_kin->getJointNames(), pi->getWaypoint()))
+        format_required = true;
+    }
+  }
+  else if (isMoveInstruction(composite_instructions.getStartInstruction()))
+  {
+    auto* pi = composite_instructions.getStartInstruction().cast<MoveInstruction>();
+
+    ManipulatorInfo start_mi = mi.getCombined(pi->getManipulatorInfo());
+    auto fwd_kin = env.getManipulatorManager()->getFwdKinematicSolver(start_mi.manipulator);
+
+    if (isStateWaypoint(pi->getWaypoint()) || isJointWaypoint(pi->getWaypoint()))
+    {
+      if (formatJointPosition(fwd_kin->getJointNames(), pi->getWaypoint()))
+        format_required = true;
+    }
+  }
+  else
+    throw std::runtime_error("Top most composite instruction start instruction has invalid waypoint type!");
+
+  if (formatProgramHelper(composite_instructions, env, mi))
+    format_required = true;
+
+  return format_required;
 }
 };  // namespace tesseract_planning

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/ompl/problem_generators/default_problem_generator.cpp
@@ -181,6 +181,7 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& nam
       {
         if (isJointWaypoint(plan_instruction->getWaypoint()) || isStateWaypoint(plan_instruction->getWaypoint()))
         {
+          assert(checkJointPositionFormat(manip_fwd_kin_->getJointNames(), plan_instruction->getWaypoint()));
           const Eigen::VectorXd& cur_position = getJointPosition(plan_instruction->getWaypoint());
           cur_plan_profile->applyGoalStates(
               *sub_prob, cur_position, *plan_instruction, composite_mi, active_link_names_, index);
@@ -190,6 +191,7 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& nam
             ompl::base::ScopedState<> start_state(sub_prob->simple_setup->getStateSpace());
             if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
             {
+              assert(checkJointPositionFormat(manip_fwd_kin_->getJointNames(), start_waypoint));
               const Eigen::VectorXd& prev_position = getJointPosition(start_waypoint);
               cur_plan_profile->applyStartStates(
                   *sub_prob, prev_position, *start_instruction, composite_mi, active_link_names_, index);
@@ -225,6 +227,7 @@ std::vector<OMPLProblem::Ptr> DefaultOMPLProblemGenerator(const std::string& nam
             ompl::base::ScopedState<> start_state(sub_prob->simple_setup->getStateSpace());
             if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
             {
+              assert(checkJointPositionFormat(manip_fwd_kin_->getJointNames(), start_waypoint));
               const Eigen::VectorXd& prev_position = getJointPosition(start_waypoint);
               cur_plan_profile->applyStartStates(
                   *sub_prob, prev_position, *start_instruction, composite_mi, active_link_names_, index);

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/simple_motion_planner.cpp
@@ -161,6 +161,7 @@ SimpleMotionPlanner::getStartInstruction(const PlannerRequest& request,
 
     if (isJointWaypoint(start_waypoint))
     {
+      assert(checkJointPositionFormat(fwd_kin->getJointNames(), start_waypoint));
       const auto* jwp = start_waypoint.cast_const<JointWaypoint>();
       start_instruction_seed.setWaypoint(StateWaypoint(jwp->joint_names, *jwp));
     }
@@ -173,6 +174,7 @@ SimpleMotionPlanner::getStartInstruction(const PlannerRequest& request,
     }
     else if (isStateWaypoint(start_waypoint))
     {
+      assert(checkJointPositionFormat(fwd_kin->getJointNames(), start_waypoint));
       start_instruction_seed.setWaypoint(start_waypoint);
     }
     else

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/fixed_size_assign_position.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/simple/step_generators/fixed_size_assign_position.cpp
@@ -83,6 +83,14 @@ CompositeInstruction fixedSizeAssignStateWaypoint(const JointWaypoint& start,
   // Joint waypoints should have joint names
   assert(static_cast<long>(start.joint_names.size()) == start.size());
 
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+
+  assert([=]() {
+    ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
+    auto fwd_kin = request.env->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
+    return checkJointPositionFormat(fwd_kin->getJointNames(), start);
+  }());
+
   return fixedSizeAssignStateWaypoint(start, base_instruction, request, manip_info, steps);
 }
 
@@ -95,6 +103,14 @@ CompositeInstruction fixedSizeAssignStateWaypoint(const CartesianWaypoint& /*sta
 {
   // Joint waypoints should have joint names
   assert(static_cast<long>(end.joint_names.size()) == end.size());
+
+  assert(!(manip_info.empty() && base_instruction.getManipulatorInfo().empty()));
+
+  assert([=]() {
+    ManipulatorInfo mi = manip_info.getCombined(base_instruction.getManipulatorInfo());
+    auto fwd_kin = request.env->getManipulatorManager()->getFwdKinematicSolver(mi.manipulator);
+    return checkJointPositionFormat(fwd_kin->getJointNames(), end);
+  }());
 
   return fixedSizeAssignStateWaypoint(end, base_instruction, request, manip_info, steps);
 }

--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/problem_generators/default_problem_generator.cpp
@@ -128,6 +128,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
   assert(request.seed.hasStartInstruction());
   assert(isMoveInstruction(request.seed.getStartInstruction()));
   const auto* seed_instruction = request.seed.getStartInstruction().cast_const<MoveInstruction>();
+  assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
   seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
   // Add start waypoint
@@ -138,6 +139,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
   }
   else if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
   {
+    assert(checkJointPositionFormat(pci->kin->getJointNames(), start_waypoint));
     const Eigen::VectorXd& position = getJointPosition(start_waypoint);
     start_plan_profile->apply(*pci, position, *start_instruction, composite_mi, active_links, index);
 
@@ -191,6 +193,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
           }
           else if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
           {
+            assert(checkJointPositionFormat(pci->kin->getJointNames(), start_waypoint));
             const Eigen::VectorXd& position = getJointPosition(start_waypoint);
             if (!pci->kin->calcFwdKin(prev_pose, position))
               throw std::runtime_error("TrajOptPlannerUniversalConfig: failed to solve forward kinematics!");
@@ -211,6 +214,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
             // Add seed state
             assert(isMoveInstruction(seed_composite->at(p)));
             const auto* seed_instruction = seed_composite->at(p).cast_const<MoveInstruction>();
+            assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
             seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
             ++index;
@@ -222,12 +226,14 @@ DefaultTrajoptProblemGenerator(const std::string& name,
           // Add seed state
           assert(isMoveInstruction(seed_composite->back()));
           const auto* seed_instruction = seed_composite->back().cast_const<tesseract_planning::MoveInstruction>();
+          assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
           seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
           ++index;
         }
         else if (isJointWaypoint(plan_instruction->getWaypoint()) || isStateWaypoint(plan_instruction->getWaypoint()))
         {
+          assert(checkJointPositionFormat(pci->kin->getJointNames(), plan_instruction->getWaypoint()));
           const Eigen::VectorXd& cur_position = getJointPosition(plan_instruction->getWaypoint());
           Eigen::Isometry3d cur_pose = Eigen::Isometry3d::Identity();
           if (!pci->kin->calcFwdKin(cur_pose, cur_position))
@@ -242,6 +248,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
           }
           else if (isJointWaypoint(start_waypoint) || isStateWaypoint(start_waypoint))
           {
+            assert(checkJointPositionFormat(pci->kin->getJointNames(), start_waypoint));
             const Eigen::VectorXd& position = getJointPosition(start_waypoint);
             if (!pci->kin->calcFwdKin(prev_pose, position))
               throw std::runtime_error("TrajOptPlannerUniversalConfig: failed to solve forward kinematics!");
@@ -262,6 +269,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
             // Add seed state
             assert(isMoveInstruction(seed_composite->at(p)));
             const auto* seed_instruction = seed_composite->at(p).cast_const<MoveInstruction>();
+            assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
             seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
             ++index;
@@ -276,6 +284,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
           // Add seed state
           assert(isMoveInstruction(seed_composite->back()));
           const auto* seed_instruction = seed_composite->back().cast_const<MoveInstruction>();
+          assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
           seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
           ++index;
@@ -289,6 +298,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
       {
         if (isJointWaypoint(plan_instruction->getWaypoint()) || isStateWaypoint(plan_instruction->getWaypoint()))
         {
+          assert(checkJointPositionFormat(pci->kin->getJointNames(), plan_instruction->getWaypoint()));
           const Eigen::VectorXd& cur_position = getJointPosition(plan_instruction->getWaypoint());
 
           // Add intermediate points with path costs and constraints
@@ -297,6 +307,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
             // Add seed state
             assert(isMoveInstruction(seed_composite->at(s)));
             const auto* seed_instruction = seed_composite->at(s).cast_const<MoveInstruction>();
+            assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
             seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
             ++index;
@@ -312,6 +323,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
           // Add seed state
           assert(isMoveInstruction(seed_composite->back()));
           const auto* seed_instruction = seed_composite->back().cast_const<MoveInstruction>();
+          assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
           seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
         }
         else if (isCartesianWaypoint(plan_instruction->getWaypoint()))
@@ -324,6 +336,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
             // Add seed state
             assert(isMoveInstruction(seed_composite->at(s)));
             const auto* seed_instruction = seed_composite->at(s).cast_const<MoveInstruction>();
+            assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
             seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
 
             ++index;
@@ -336,6 +349,7 @@ DefaultTrajoptProblemGenerator(const std::string& name,
           // Add seed state
           assert(isMoveInstruction(seed_composite->back()));
           const auto* seed_instruction = seed_composite->back().cast_const<MoveInstruction>();
+          assert(checkJointPositionFormat(pci->kin->getJointNames(), seed_instruction->getWaypoint()));
           seed_states.push_back(getJointPosition(seed_instruction->getWaypoint()));
         }
         else


### PR DESCRIPTION
This finishes out support for external tcp to support all examples in tesseract_ros_examples.

The last commit addresses issue #498.