### PR TITLE
Utilize `fixed_timesteps` parameter in TrajOpt planner

### DIFF
--- a/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
+++ b/tesseract/tesseract_planning/tesseract_motion_planners/src/trajopt/config/trajopt_planner_default_config.cpp
@@ -64,6 +64,20 @@ std::shared_ptr<trajopt::ProblemConstructionInfo> TrajOptPlannerDefaultConfig::g
   std::vector<int> fixed_steps;
   addWaypoints(pci, fixed_steps);
 
+  // Add the fixed timesteps. TrajOpt will constrain the optimization such that any costs applied at these timesteps
+  // will be ignored. Costs applied to variables at fixed timesteps generally causes solver failures
+  for (auto idx : fixed_steps)
+  {
+    if (idx == 0)
+    {
+      pci.basic_info.start_fixed = true;
+    }
+    else
+    {
+      pci.basic_info.fixed_timesteps.push_back(idx);
+    }
+  }
+
   if (collision_constraint_config.enabled)
     addCollisionConstraint(pci, fixed_steps);
 

--- a/tesseract_python/tesseract_python/swig/trajopt/problem_description.i
+++ b/tesseract_python/tesseract_python/swig/trajopt/problem_description.i
@@ -179,7 +179,7 @@ struct BasicInfo
   int n_steps;
   std::string manip;
   std::string robot;
-  IntVec dofs_fixed;
+  IntVec fixed_timesteps;
   sco::ModelType convex_solver;
   bool use_time;
   double dt_upper_lim;


### PR DESCRIPTION
This PR updates the `TrajoptPlannerDefaultConfig` class to utilize the `fixed_timesteps` parameter of the TrajOpt PCI (added in [this TrajOpt PR](https://github.com/ros-industrial-consortium/trajopt_ros/pull/226), formerly called `dofs_fixed`). This will help prevent solver failures caused by costs being added to timesteps of the optimization where the variables are fixed
