### PR TITLE
Update processResults in tesseract_collision distance check

### DIFF
--- a/tesseract/tesseract_collision/include/tesseract_collision/core/common.h
+++ b/tesseract/tesseract_collision/include/tesseract_collision/core/common.h
@@ -120,7 +120,7 @@ inline ContactResult* processResult(ContactTestData& cdata,
     return nullptr;
 
   if ((cdata.req.calculate_distance || cdata.req.calculate_penetration) &&
-      !(contact.distance < cdata.collision_margin_data.getPairCollisionMarginData(key.first, key.second)))
+      (contact.distance > cdata.collision_margin_data.getPairCollisionMarginData(key.first, key.second)))
     return nullptr;
 
   if (!found)

--- a/tesseract/tesseract_geometry/include/tesseract_geometry/mesh_parser.h
+++ b/tesseract/tesseract_geometry/include/tesseract_geometry/mesh_parser.h
@@ -133,8 +133,8 @@ std::vector<std::shared_ptr<T>> extractMeshData(const aiScene* scene,
       {
         aiVector3D v = transform * a->mNormals[i];
         vertex_normals->push_back(Eigen::Vector3d(static_cast<double>(v.x) * scale(0),
-                                            static_cast<double>(v.y) * scale(1),
-                                            static_cast<double>(v.z) * scale(2)));
+                                                  static_cast<double>(v.y) * scale(1),
+                                                  static_cast<double>(v.z) * scale(2)));
       }
     }
 


### PR DESCRIPTION
The current approach does consider contact if the threshold and the distance are equal. So if the contact threshold is set to zero and the distance is zero this is not considered in contact. This switches the logic so if the threshold and distance are equal then it is considered in contact which is he behavior in the master branch.