### PR TITLE
Add SWIG shared_ptr commands to visualization markers

### DIFF
--- a/tesseract_visualization/include/tesseract_visualization/markers/arrow_marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/arrow_marker.h
@@ -4,6 +4,10 @@
 #include <tesseract_visualization/markers/marker.h>
 #include <tesseract_scene_graph/link.h>
 
+#ifdef SWIG
+%shared_ptr(tesseract_visualization::ArrowMarker)
+#endif  // SWIG
+
 namespace tesseract_visualization
 {
 /**

--- a/tesseract_visualization/include/tesseract_visualization/markers/axis_marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/axis_marker.h
@@ -3,6 +3,10 @@
 
 #include <tesseract_visualization/markers/marker.h>
 
+#ifdef SWIG
+%shared_ptr(tesseract_visualization::AxisMarker)
+#endif  // SWIG
+
 namespace tesseract_visualization
 {
 /** @brief An axis */

--- a/tesseract_visualization/include/tesseract_visualization/markers/contact_results_marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/contact_results_marker.h
@@ -9,6 +9,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_visualization/markers/marker.h>
 #include <tesseract_collision/core/types.h>
 
+#ifdef SWIG
+%shared_ptr(tesseract_visualization::ContactResultsMarker)
+#endif  // SWIG
+
 namespace tesseract_visualization
 {
 /**

--- a/tesseract_visualization/include/tesseract_visualization/markers/geometry_marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/geometry_marker.h
@@ -4,6 +4,10 @@
 #include <tesseract_visualization/markers/marker.h>
 #include <tesseract_geometry/geometry.h>
 
+#ifdef SWIG
+%shared_ptr(tesseract_visualization::GeometryMarker)
+#endif  // SWIG
+
 namespace tesseract_visualization
 {
 /** @brief An geometry marker */

--- a/tesseract_visualization/include/tesseract_visualization/markers/marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/marker.h
@@ -24,6 +24,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#ifdef SWIG
+%shared_ptr(tesseract_visualization::Marker)
+#endif  // SWIG
+
 namespace tesseract_visualization
 {
 enum class MarkerType : int

--- a/tesseract_visualization/include/tesseract_visualization/markers/toolpath_marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/toolpath_marker.h
@@ -9,6 +9,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_visualization/markers/marker.h>
 #include <tesseract_common/types.h>
 
+#ifdef SWIG
+%shared_ptr(tesseract_visualization::ToolpathMarker)
+#endif  // SWIG
 namespace tesseract_visualization
 {
 /** @brief An arrow defined by two points */


### PR DESCRIPTION
These extra commands are needed for the SWIG wrappers.