### PR TITLE
Add ability to construct ROP and REP kinematic solver with different solver names

### DIFF
--- a/tesseract_collision/package.xml
+++ b/tesseract_collision/package.xml
@@ -25,6 +25,7 @@
   <test_depend>benchmark</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>tesseract_scene_graph</test_depend>
+  <test_depend>libomp-dev</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -763,6 +763,9 @@ private:
   Commands getInitCommands(const tesseract_scene_graph::SceneGraph& scene_graph,
                            const tesseract_scene_graph::SRDFModel::ConstPtr& srdf_model = nullptr);
 
+  /** @brief Apply Command Helper which does not lock */
+  bool applyCommandsHelper(const Commands& commands);
+
   // Command Helper function
   bool applyAddCommand(AddLinkCommand::ConstPtr cmd);
   bool applyMoveLinkCommand(const MoveLinkCommand::ConstPtr& cmd);

--- a/tesseract_environment/package.xml
+++ b/tesseract_environment/package.xml
@@ -28,6 +28,7 @@
 
   <test_depend>gtest</test_depend>
   <test_depend>tesseract_support</test_depend>
+  <test_depend>libomp-dev</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/tesseract_environment/src/core/manipulator_manager.cpp
+++ b/tesseract_environment/src/core/manipulator_manager.cpp
@@ -1096,13 +1096,27 @@ bool ManipulatorManager::registerROPSolver(const std::string& group_name,
   }
 
   auto solver = std::make_shared<tesseract_kinematics::RobotOnPositionerInvKin>();
-  if (!solver->init(scene_graph_,
-                    manip_ik_solver,
-                    rop_group.manipulator_reach,
-                    positioner_fk_solver,
-                    positioner_sample_resolution,
-                    group_name))
-    return false;
+  if (rop_group.solver_name.empty())
+  {
+    if (!solver->init(scene_graph_,
+                      manip_ik_solver,
+                      rop_group.manipulator_reach,
+                      positioner_fk_solver,
+                      positioner_sample_resolution,
+                      group_name))
+      return false;
+  }
+  else
+  {
+    if (!solver->init(scene_graph_,
+                      manip_ik_solver,
+                      rop_group.manipulator_reach,
+                      positioner_fk_solver,
+                      positioner_sample_resolution,
+                      group_name,
+                      rop_group.solver_name))
+      return false;
+  }
 
   if (!addInvKinematicSolver(solver))
   {
@@ -1167,13 +1181,27 @@ bool ManipulatorManager::registerREPSolver(const std::string& group_name,
   }
 
   auto solver = std::make_shared<tesseract_kinematics::RobotWithExternalPositionerInvKin>();
-  if (!solver->init(scene_graph_,
-                    manip_ik_solver,
-                    rep_group.manipulator_reach,
-                    positioner_fk_solver,
-                    positioner_sample_resolution,
-                    group_name))
-    return false;
+  if (rep_group.solver_name.empty())
+  {
+    if (!solver->init(scene_graph_,
+                      manip_ik_solver,
+                      rep_group.manipulator_reach,
+                      positioner_fk_solver,
+                      positioner_sample_resolution,
+                      group_name))
+      return false;
+  }
+  else
+  {
+    if (!solver->init(scene_graph_,
+                      manip_ik_solver,
+                      rep_group.manipulator_reach,
+                      positioner_fk_solver,
+                      positioner_sample_resolution,
+                      group_name,
+                      rep_group.solver_name))
+      return false;
+  }
 
   if (!addInvKinematicSolver(solver))
   {

--- a/tesseract_environment/test/CMakeLists.txt
+++ b/tesseract_environment/test/CMakeLists.txt
@@ -1,5 +1,13 @@
 find_package(GTest REQUIRED)
 find_package(tesseract_support REQUIRED)
+find_package(OpenMP REQUIRED)
+if(OPENMP_FOUND)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+else(OPENMP_FOUND)
+  message (STATUS "Not found OpenMP")
+endif()
+
 
 if(NOT TARGET GTest::GTest)
   add_library(GTest::GTest INTERFACE IMPORTED)

--- a/tesseract_kinematics/include/tesseract_kinematics/core/rep_inverse_kinematics.h
+++ b/tesseract_kinematics/include/tesseract_kinematics/core/rep_inverse_kinematics.h
@@ -120,6 +120,8 @@ public:
    * @param positioner
    * @param positioner_sample_resolution
    * @param name The name of the kinematic object
+   * @param solver_name The name given to the solver. This is exposed so you may have same solver with different
+   * sampling resolutions
    * @return True if init() completes successfully
    */
   bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
@@ -127,7 +129,8 @@ public:
             double manipulator_reach,
             ForwardKinematics::Ptr positioner,
             Eigen::VectorXd positioner_sample_resolution,
-            std::string name);
+            std::string name,
+            std::string solver_name = "RobotWithExternalPositionerInvKin");
 
   /**
    * @brief Initializes Inverse Kinematics for a robot on a positioner
@@ -138,6 +141,8 @@ public:
    * @param positioner_sample_resolution
    * @param robot_to_positioner
    * @param name The name of the kinematic object
+   * @param solver_name The name given to the solver. This is exposed so you may have same solver with different
+   * sampling resolutions
    * @return True if init() completes successfully
    */
   bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
@@ -146,7 +151,8 @@ public:
             ForwardKinematics::Ptr positioner,
             Eigen::VectorXd positioner_sample_resolution,
             const Eigen::Isometry3d& robot_to_positioner,
-            std::string name);
+            std::string name,
+            std::string solver_name = "RobotWithExternalPositionerInvKin");
 
   /**
    * @brief Checks if kinematics has been initialized

--- a/tesseract_kinematics/include/tesseract_kinematics/core/rop_inverse_kinematics.h
+++ b/tesseract_kinematics/include/tesseract_kinematics/core/rop_inverse_kinematics.h
@@ -100,6 +100,8 @@ public:
    * @param positioner
    * @param positioner_sample_resolution
    * @param name The name of the kinematic object
+   * @param solver_name The name given to the solver. This is exposed so you may have same solver with different
+   * sampling resolutions
    * @return True if init() completes successfully
    */
   bool init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
@@ -107,7 +109,8 @@ public:
             double manipulator_reach,
             ForwardKinematics::Ptr positioner,
             Eigen::VectorXd positioner_sample_resolution,
-            std::string name);
+            std::string name,
+            std::string solver_name = "RobotOnPositionerInvKin");
 
   /**
    * @brief Checks if kinematics has been initialized

--- a/tesseract_kinematics/src/core/rep_inverse_kinematics.cpp
+++ b/tesseract_kinematics/src/core/rep_inverse_kinematics.cpp
@@ -257,7 +257,8 @@ bool RobotWithExternalPositionerInvKin::init(tesseract_scene_graph::SceneGraph::
                                              double manipulator_reach,
                                              ForwardKinematics::Ptr positioner,
                                              Eigen::VectorXd positioner_sample_resolution,
-                                             std::string name)
+                                             std::string name,
+                                             std::string solver_name)
 {
   if (manipulator == nullptr)
   {
@@ -283,7 +284,8 @@ bool RobotWithExternalPositionerInvKin::init(tesseract_scene_graph::SceneGraph::
               positioner,
               positioner_sample_resolution,
               Eigen::Isometry3d::Identity(),
-              name);
+              name,
+              solver_name);
 }
 
 bool RobotWithExternalPositionerInvKin::init(tesseract_scene_graph::SceneGraph::ConstPtr scene_graph,
@@ -292,9 +294,16 @@ bool RobotWithExternalPositionerInvKin::init(tesseract_scene_graph::SceneGraph::
                                              ForwardKinematics::Ptr positioner,
                                              Eigen::VectorXd positioner_sample_resolution,
                                              const Eigen::Isometry3d& robot_to_positioner,
-                                             std::string name)
+                                             std::string name,
+                                             std::string solver_name)
 {
   initialized_ = false;
+
+  if (solver_name.empty())
+  {
+    CONSOLE_BRIDGE_logError("Solver name nust not be empty.");
+    return false;
+  }
 
   if (scene_graph == nullptr)
   {
@@ -350,6 +359,7 @@ bool RobotWithExternalPositionerInvKin::init(tesseract_scene_graph::SceneGraph::
   manip_base_to_positioner_base_ = robot_to_positioner;
   scene_graph_ = std::move(scene_graph);
   name_ = std::move(name);
+  solver_name_ = std::move(solver_name);
   manip_inv_kin_ = manipulator->clone();
   manip_reach_ = manipulator_reach;
   positioner_fwd_kin_ = positioner->clone();

--- a/tesseract_kinematics/src/core/rop_inverse_kinematics.cpp
+++ b/tesseract_kinematics/src/core/rop_inverse_kinematics.cpp
@@ -215,9 +215,16 @@ bool RobotOnPositionerInvKin::init(tesseract_scene_graph::SceneGraph::ConstPtr s
                                    double manipulator_reach,
                                    ForwardKinematics::Ptr positioner,
                                    Eigen::VectorXd positioner_sample_resolution,
-                                   std::string name)
+                                   std::string name,
+                                   std::string solver_name)
 {
   initialized_ = false;
+
+  if (solver_name.empty())
+  {
+    CONSOLE_BRIDGE_logError("Solver name nust not be empty.");
+    return false;
+  }
 
   if (scene_graph == nullptr)
   {
@@ -268,6 +275,7 @@ bool RobotOnPositionerInvKin::init(tesseract_scene_graph::SceneGraph::ConstPtr s
 
   scene_graph_ = std::move(scene_graph);
   name_ = std::move(name);
+  solver_name_ = std::move(solver_name);
   manip_inv_kin_ = manipulator->clone();
   manip_reach_ = manipulator_reach;
   positioner_fwd_kin_ = positioner->clone();

--- a/tesseract_scene_graph/include/tesseract_scene_graph/kinematics_information.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/kinematics_information.h
@@ -72,6 +72,8 @@ struct OPWKinematicParameters
 
 struct ROPKinematicParameters
 {
+  /** @brief The name of the solver. If empty it will use the default solver name */
+  std::string solver_name;
   std::string manipulator_group;
   std::string manipulator_ik_solver;
   double manipulator_reach;
@@ -82,6 +84,7 @@ struct ROPKinematicParameters
   bool operator==(const ROPKinematicParameters& rhs) const
   {
     bool success = true;
+    success &= (solver_name == rhs.solver_name);
     success &= (manipulator_group == rhs.manipulator_group);
     success &= (manipulator_ik_solver == rhs.manipulator_ik_solver);
     success &= (tesseract_common::almostEqualRelativeAndAbs(manipulator_reach, rhs.manipulator_reach, 1e-6));
@@ -108,6 +111,8 @@ struct ROPKinematicParameters
 
 struct REPKinematicParameters
 {
+  /** @brief The name of the solver. If empty it will use the default solver name */
+  std::string solver_name;
   std::string manipulator_group;
   std::string manipulator_ik_solver;
   double manipulator_reach;
@@ -118,6 +123,7 @@ struct REPKinematicParameters
   bool operator==(const REPKinematicParameters& rhs) const
   {
     bool success = true;
+    success &= (solver_name == rhs.solver_name);
     success &= (manipulator_group == rhs.manipulator_group);
     success &= (manipulator_ik_solver == rhs.manipulator_ik_solver);
     success &= (tesseract_common::almostEqualRelativeAndAbs(manipulator_reach, rhs.manipulator_reach, 1e-6));

--- a/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rep_kinematics.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rep_kinematics.h
@@ -39,6 +39,14 @@ inline GroupREPKinematics parseGroupREPKinematics(const tesseract_scene_graph::S
 
     // get the robot with external positioner group information
     REPKinematicParameters rep_info;
+
+    status = tesseract_common::QueryStringAttribute(xml_element, "solver_name", rep_info.solver_name);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    {
+      CONSOLE_BRIDGE_logInform("REP Group, group_rep element failed to parse 'solver_name' attribute!");
+      continue;
+    }
+
     const tinyxml2::XMLElement* manip_xml = xml_element->FirstChildElement("manipulator");
     if (manip_xml == nullptr)
     {

--- a/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rop_kinematics.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/srdf/group_rop_kinematics.h
@@ -39,6 +39,14 @@ inline GroupROPKinematics parseGroupROPKinematics(const tesseract_scene_graph::S
 
     // get the robot on positioner group information
     ROPKinematicParameters rop_info;
+
+    status = tesseract_common::QueryStringAttribute(xml_element, "solver_name", rop_info.solver_name);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    {
+      CONSOLE_BRIDGE_logInform("REP Group, group_rop element failed to parse 'solver_name' attribute!");
+      continue;
+    }
+
     const tinyxml2::XMLElement* manip_xml = xml_element->FirstChildElement("manipulator");
     if (manip_xml == nullptr)
     {

--- a/tesseract_scene_graph/test/tesseract_scene_graph_srdf_unit.cpp
+++ b/tesseract_scene_graph/test/tesseract_scene_graph_srdf_unit.cpp
@@ -1344,6 +1344,7 @@ TEST(TesseractSceneGraphSRDFUnit, LoadSRDFREPKinematicsUnit)  // NOLINT
   EXPECT_EQ(rep_groups.size(), 1);
 
   REPKinematicParameters params = rep_groups["gantry"];
+  EXPECT_TRUE(params.solver_name.empty());
   EXPECT_EQ(params.manipulator_group, "manipulator");
   EXPECT_EQ(params.manipulator_ik_solver, "OPWInvKin");
   EXPECT_DOUBLE_EQ(params.manipulator_reach, 2.3);
@@ -1352,6 +1353,37 @@ TEST(TesseractSceneGraphSRDFUnit, LoadSRDFREPKinematicsUnit)  // NOLINT
   EXPECT_EQ(params.positioner_sample_resolution.size(), 1);
   EXPECT_TRUE(params.positioner_sample_resolution.find("axis_1") != params.positioner_sample_resolution.end());
   EXPECT_DOUBLE_EQ(params.positioner_sample_resolution["axis_1"], 0.1);
+
+  {  // Test provided name
+    std::string xml_string =
+        R"(<robot name="abb_irb2400">
+             <group_rep group="gantry" solver_name="REPSolver1">
+               <manipulator group="manipulator" ik_solver="OPWInvKin" reach="2.3"/>
+               <positioner group="positioner" fk_solver="KDLFwdKin">
+                 <joint name="axis_1" resolution="0.1"/>
+               </positioner>
+             </group_rep>
+           </robot>)";
+    tinyxml2::XMLDocument xml_doc;
+    EXPECT_TRUE(xml_doc.Parse(xml_string.c_str()) == tinyxml2::XML_SUCCESS);
+
+    tinyxml2::XMLElement* element = xml_doc.FirstChildElement("robot");
+    EXPECT_TRUE(element != nullptr);
+
+    GroupREPKinematics rep_groups = parseGroupREPKinematics(*g, element, std::array<int, 3>({ 1, 0, 0 }));
+    EXPECT_EQ(rep_groups.size(), 1);
+
+    REPKinematicParameters params = rep_groups["gantry"];
+    EXPECT_EQ(params.solver_name, "REPSolver1");
+    EXPECT_EQ(params.manipulator_group, "manipulator");
+    EXPECT_EQ(params.manipulator_ik_solver, "OPWInvKin");
+    EXPECT_DOUBLE_EQ(params.manipulator_reach, 2.3);
+    EXPECT_EQ(params.positioner_group, "positioner");
+    EXPECT_EQ(params.positioner_fk_solver, "KDLFwdKin");
+    EXPECT_EQ(params.positioner_sample_resolution.size(), 1);
+    EXPECT_TRUE(params.positioner_sample_resolution.find("axis_1") != params.positioner_sample_resolution.end());
+    EXPECT_DOUBLE_EQ(params.positioner_sample_resolution["axis_1"], 0.1);
+  }
 
   // Now test failures
   auto is_failure = [g](const std::string& xml_string) {
@@ -1528,6 +1560,7 @@ TEST(TesseractSceneGraphSRDFUnit, LoadSRDFROPKinematicsUnit)  // NOLINT
   EXPECT_EQ(rop_groups.size(), 1);
 
   ROPKinematicParameters params = rop_groups["gantry"];
+  EXPECT_TRUE(params.solver_name.empty());
   EXPECT_EQ(params.manipulator_group, "manipulator");
   EXPECT_EQ(params.manipulator_ik_solver, "OPWInvKin");
   EXPECT_DOUBLE_EQ(params.manipulator_reach, 2.3);
@@ -1536,6 +1569,37 @@ TEST(TesseractSceneGraphSRDFUnit, LoadSRDFROPKinematicsUnit)  // NOLINT
   EXPECT_EQ(params.positioner_sample_resolution.size(), 1);
   EXPECT_TRUE(params.positioner_sample_resolution.find("axis_1") != params.positioner_sample_resolution.end());
   EXPECT_DOUBLE_EQ(params.positioner_sample_resolution["axis_1"], 0.1);
+
+  {  // Now test with name provided
+    std::string xml_string =
+        R"(<robot name="abb_irb2400">
+             <group_rop group="gantry" solver_name="ROPSolver2">
+               <manipulator group="manipulator" ik_solver="OPWInvKin" reach="2.3"/>
+               <positioner group="positioner" fk_solver="KDLFwdKin">
+                 <joint name="axis_1" resolution="0.1"/>
+               </positioner>
+             </group_rop>
+           </robot>)";
+    tinyxml2::XMLDocument xml_doc;
+    EXPECT_TRUE(xml_doc.Parse(xml_string.c_str()) == tinyxml2::XML_SUCCESS);
+
+    tinyxml2::XMLElement* element = xml_doc.FirstChildElement("robot");
+    EXPECT_TRUE(element != nullptr);
+
+    GroupROPKinematics rop_groups = parseGroupROPKinematics(*g, element, std::array<int, 3>({ 1, 0, 0 }));
+    EXPECT_EQ(rop_groups.size(), 1);
+
+    ROPKinematicParameters params = rop_groups["gantry"];
+    EXPECT_EQ(params.solver_name, "ROPSolver2");
+    EXPECT_EQ(params.manipulator_group, "manipulator");
+    EXPECT_EQ(params.manipulator_ik_solver, "OPWInvKin");
+    EXPECT_DOUBLE_EQ(params.manipulator_reach, 2.3);
+    EXPECT_EQ(params.positioner_group, "positioner");
+    EXPECT_EQ(params.positioner_fk_solver, "KDLFwdKin");
+    EXPECT_EQ(params.positioner_sample_resolution.size(), 1);
+    EXPECT_TRUE(params.positioner_sample_resolution.find("axis_1") != params.positioner_sample_resolution.end());
+    EXPECT_DOUBLE_EQ(params.positioner_sample_resolution["axis_1"], 0.1);
+  }
 
   // Now test failures
   auto is_failure = [g](const std::string& xml_string) {


### PR DESCRIPTION
The ROP and REP rely on sampling of the positioner axes so it it nice to have the ability to create to different solvers for the sample manipulator with different sampling resolutions. This enables the ability to construct the ROP and REP kinematics with a provided solver name. Also updates the SRDF to support providing a solver name which is optional.

Edit:
Also include a bug fix Environment applyCommands not correctly locking the mutex.