### PR TITLE
Fixup enforceJointLimits

### DIFF
--- a/tesseract_common/src/kinematic_limits.cpp
+++ b/tesseract_common/src/kinematic_limits.cpp
@@ -53,8 +53,6 @@ bool satisfiesPositionLimits(const Eigen::Ref<const Eigen::VectorXd>& joint_posi
 void enforcePositionLimits(Eigen::Ref<Eigen::VectorXd> joint_positions,
                            const Eigen::Ref<const Eigen::MatrixX2d>& position_limits)
 {
-  joint_positions = (joint_positions.array() > position_limits.col(1).array() ||
-                     joint_positions.array() < position_limits.col(0).array())
-                        .select(position_limits.col(1).array(), joint_positions.array());
+  joint_positions = joint_positions.array().min(position_limits.col(1).array()).max(position_limits.col(0).array());
 }
 }  // namespace tesseract_common

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -702,7 +702,7 @@ TEST(TesseractCommonUnit, anyUnit)
   EXPECT_TRUE(nany_type.cast<tesseract_common::JointState>() == joint_state);
 }
 
-TEST(TesseractCommonUnit, boudsUnit)
+TEST(TesseractCommonUnit, boundsUnit)
 {
   Eigen::VectorXd v = Eigen::VectorXd::Ones(6);
   v = v.array() + std::numeric_limits<float>::epsilon();
@@ -722,6 +722,17 @@ TEST(TesseractCommonUnit, boudsUnit)
   EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
   tesseract_common::enforcePositionLimits(v, limits);
   EXPECT_TRUE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
+
+  // Check that clamp is done correctly on both sides
+  v = Eigen::VectorXd::Constant(6, -2);
+  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
+  tesseract_common::enforcePositionLimits(v, limits);
+  ASSERT_EQ((v - limits.col(0)).norm(), 0);
+
+  v = Eigen::VectorXd::Constant(6, 2);
+  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
+  tesseract_common::enforcePositionLimits(v, limits);
+  ASSERT_EQ((v - limits.col(1)).norm(), 0);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
While browsing recent changes, I noticed a bug in the new enforce_joint_limits function:
Up to now, it would incorrectly apply the upper limit to any position
that's outside the range. For example, a position that's slightly under
the lower limit would get assigned the upper limit. Fix this by using
Eigen's min and max functions, resulting in a proper clamp.

To test this:
```cpp
  Eigen::VectorXd test = Eigen::VectorXd::Constant(6, -2);
  Eigen::MatrixXd limits(6, 2);
  limits.col(0) = Eigen::VectorXd::Constant(6, -1);
  limits.col(1) = Eigen::VectorXd::Constant(6, 1);

  enforcePositionLimits(test, limits);

  std::cout << test.transpose() << std::endl;
```

Before:
```
1 1 1 1 1 1
```
After
```
-1 -1 -1 -1 -1 -1
```