### PR TITLE
Update benchmarks after API change in discrete contact manager

### DIFF
--- a/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/large_dataset_benchmarks.hpp
+++ b/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/large_dataset_benchmarks.hpp
@@ -79,7 +79,7 @@ static void BM_LARGE_DATASET_MULTILINK(benchmark::State& state,
 
   // Check if they are in collision
   checker->setActiveCollisionObjects(link_names);
-  checker->setContactDistanceThreshold(0.1);
+  checker->setCollisionMarginData(CollisionMarginData(0.1));
   checker->setCollisionObjectsTransform(location);
 
   ContactResultVector result_vector;
@@ -169,7 +169,7 @@ static void BM_LARGE_DATASET_SINGLELINK(benchmark::State& state,
 
   // Check if they are in collision
   checker->setActiveCollisionObjects(link_names);
-  checker->setContactDistanceThreshold(0.1);
+  checker->setCollisionMarginData(CollisionMarginData(0.1));
   //  checker->setCollisionObjectsTransform(location);
 
   ContactResultVector result_vector;

--- a/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
+++ b/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
@@ -49,7 +49,7 @@ static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, int nu
     info.contact_manager_->addCollisionObject(name, 0, info.geom1_, info.obj1_poses);
   }
   info.contact_manager_->setActiveCollisionObjects(active_obj);
-  info.contact_manager_->setContactDistanceThreshold(0.5);
+  info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   DiscreteContactManager::Ptr clone;
   for (auto _ : state)
@@ -65,7 +65,7 @@ static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)
   info.contact_manager_->addCollisionObject(std::string("geom2"), 0, info.geom2_, info.obj2_poses);
 
   info.contact_manager_->setActiveCollisionObjects({ "geom1", "geom2" });
-  info.contact_manager_->setContactDistanceThreshold(0.5);
+  info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   ContactResultMap result;
   for (auto _ : state)
@@ -99,7 +99,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE(benchmark::State& state, D
     info.contact_manager_->addCollisionObject(name, 0, info.geom1_, info.obj1_poses);
   }
   info.contact_manager_->setActiveCollisionObjects(active_obj);
-  info.contact_manager_->setContactDistanceThreshold(0.5);
+  info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   for (auto _ : state)
   {
@@ -126,7 +126,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR(benchmark::State& state,
     info.contact_manager_->addCollisionObject(name, 0, info.geom1_, info.obj1_poses);
   }
   info.contact_manager_->setActiveCollisionObjects(active_obj);
-  info.contact_manager_->setContactDistanceThreshold(0.5);
+  info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   std::vector<std::string> selected_links(1);
   for (auto _ : state)
@@ -154,7 +154,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP(benchmark::State& state,
     info.contact_manager_->addCollisionObject(name, 0, info.geom1_, info.obj1_poses);
   }
   info.contact_manager_->setActiveCollisionObjects(active_obj);
-  info.contact_manager_->setContactDistanceThreshold(0.5);
+  info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   tesseract_common::TransformMap selected_link;
   for (auto _ : state)

--- a/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
+++ b/tesseract_collision/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
@@ -39,10 +39,10 @@ struct DiscreteBenchmarkInfo
 };
 
 /** @brief Benchmark that checks the clone method in discrete contact managers*/
-static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, int num_obj)
+static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, std::size_t num_obj)
 {
   std::vector<std::string> active_obj(num_obj);
-  for (int ind = 0; ind < num_obj; ind++)
+  for (std::size_t ind = 0; ind < num_obj; ind++)
   {
     std::string name = "geom_" + std::to_string(ind);
     active_obj.push_back(name);
@@ -82,17 +82,19 @@ static void BM_SELECT_RANDOM_OBJECT(benchmark::State& state, int num_obj)
   int selected_link;
   for (auto _ : state)
   {
-    benchmark::DoNotOptimize(selected_link = rand() % static_cast<int>(num_obj));
+    benchmark::DoNotOptimize(selected_link = rand() % num_obj);
   }
 };
 
 /** @brief Benchmark that checks the setCollisionObjectsTransform(const std::string& name, const Eigen::Isometry3d&
  * pose) method in discrete contact managers*/
-static void BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE(benchmark::State& state, DiscreteBenchmarkInfo info, int num_obj)
+static void BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE(benchmark::State& state,
+                                                      DiscreteBenchmarkInfo info,
+                                                      std::size_t num_obj)
 {
   // Setting up collision objects
   std::vector<std::string> active_obj(num_obj);
-  for (int ind = 0; ind < num_obj; ind++)
+  for (std::size_t ind = 0; ind < num_obj; ind++)
   {
     std::string name = "geom_" + std::to_string(ind);
     active_obj[ind] = name;
@@ -106,7 +108,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE(benchmark::State& state, D
     // Including this seems necessary to insure that a distribution of links is used rather than always searching for
     // the same one. Subtract off approximately BM_SELECT_RANDOM_OBJECT if you need absolute numbers rather than
     // relative.
-    int selected_link = rand() % num_obj;
+    std::size_t selected_link = static_cast<std::size_t>(rand()) % num_obj;
     info.contact_manager_->setCollisionObjectsTransform(active_obj[selected_link], info.obj2_poses[0]);
   }
 };
@@ -134,7 +136,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR(benchmark::State& state,
     // Including this seems necessary to insure that a distribution of links is used rather than always searching for
     // the same one. Subtract off approximately BM_SELECT_RANDOM_OBJECT if you need absolute numbers rather than
     // relative.
-    selected_links[0] = active_obj[rand() % num_obj];
+    selected_links[0] = active_obj[static_cast<std::size_t>(rand()) % num_obj];
     info.contact_manager_->setCollisionObjectsTransform(selected_links, info.obj2_poses);
   }
 };
@@ -161,7 +163,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP(benchmark::State& state,
   {
     // Including this seems necessary to insure that a distribution of links is used rather than always searching for
     // the same one. It might be worth it to manually time these as well if it's really important
-    selected_link[active_obj[rand() % num_obj]] = info.obj2_poses[0];
+    selected_link[active_obj[static_cast<std::size_t>(rand()) % num_obj]] = info.obj2_poses[0];
     info.contact_manager_->setCollisionObjectsTransform(selected_link);
   }
 };


### PR DESCRIPTION
The API for `tesseract_collision::DiscreteContactManager` changed, but benchmark code was not updated accordingly. This PR corrects that oversight and fixes a couple of warnings.

To test locally, simply build and run the benchmarks (e.g., with `--cmake-args -DTESSERACT_ENABLE_BENCHMARKING=Yes`). Presumably, this will allow the benchmarks to be run in CI as well.

On a side note, it would be nice to be able to build the benchmarks without running them immediately, but that's a separate issue.
