### PR TITLE
Fix issues with Bullet Broadphase and Trajectory Player

### DIFF
--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -1188,6 +1188,29 @@ inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
   broadphase->getOverlappingPairCache()->cleanProxyFromPairs(cow->getBroadphaseHandle(), dispatcher.get());
 }
 
+inline void refreshBroadphaseProxy(const COW::Ptr& cow,
+                                   const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                   const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  if (cow->getBroadphaseHandle())
+  {
+    broadphase->destroyProxy(cow->getBroadphaseHandle(), dispatcher.get());
+
+    btVector3 aabb_min, aabb_max;
+    cow->getAABB(aabb_min, aabb_max);
+
+    // Add the active collision object to the broadphase
+    int type = cow->getCollisionShape()->getShapeType();
+    cow->setBroadphaseHandle(broadphase->createProxy(aabb_min,
+                                                     aabb_max,
+                                                     type,
+                                                     cow.get(),
+                                                     cow->m_collisionFilterGroup,
+                                                     cow->m_collisionFilterMask,
+                                                     dispatcher.get()));
+  }
+}
+
 }  // namespace tesseract_collision_bullet
 }  // namespace tesseract_collision
 #endif  // TESSERACT_COLLISION_BULLET_UTILS_H

--- a/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/include/tesseract_collision/bullet/bullet_utils.h
@@ -1188,6 +1188,15 @@ inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
   broadphase->getOverlappingPairCache()->cleanProxyFromPairs(cow->getBroadphaseHandle(), dispatcher.get());
 }
 
+/**
+ * @brief Refresh the broadphase data structure
+ * @details When change certain properties of a collision object the broadphase is not aware so this function can be
+ * called to trigger an update. For example, when changing active links this changes internal flags which may require
+ * moving a collision object from the static BVH to the dynamic BVH so this function must be called.
+ * @param cow The collision object to update.
+ * @param broadphase The broadphase to update.
+ * @param dispatcher The dispatcher.
+ */
 inline void refreshBroadphaseProxy(const COW::Ptr& cow,
                                    const std::unique_ptr<btBroadphaseInterface>& broadphase,
                                    const std::unique_ptr<btCollisionDispatcher>& dispatcher)

--- a/tesseract_collision/include/tesseract_collision/core/common.h
+++ b/tesseract_collision/include/tesseract_collision/core/common.h
@@ -87,17 +87,17 @@ inline bool isContactAllowed(const std::string& name1,
 
   if (acm != nullptr && acm(name1, name2))
   {
-    if (verbose)
+//    if (verbose)
     {
-      CONSOLE_BRIDGE_logDebug(
+      CONSOLE_BRIDGE_logError(
           "Collision between '%s' and '%s' is allowed. No contacts are computed.", name1.c_str(), name2.c_str());
     }
     return true;
   }
 
-  if (verbose)
+//  if (verbose)
   {
-    CONSOLE_BRIDGE_logDebug("Actually checking collisions between %s and %s", name1.c_str(), name2.c_str());
+    CONSOLE_BRIDGE_logError("Actually checking collisions between %s and %s", name1.c_str(), name2.c_str());
   }
 
   return false;

--- a/tesseract_collision/include/tesseract_collision/core/common.h
+++ b/tesseract_collision/include/tesseract_collision/core/common.h
@@ -87,7 +87,7 @@ inline bool isContactAllowed(const std::string& name1,
 
   if (acm != nullptr && acm(name1, name2))
   {
-//    if (verbose)
+    if (verbose)
     {
       CONSOLE_BRIDGE_logError(
           "Collision between '%s' and '%s' is allowed. No contacts are computed.", name1.c_str(), name2.c_str());
@@ -95,7 +95,7 @@ inline bool isContactAllowed(const std::string& name1,
     return true;
   }
 
-//  if (verbose)
+  if (verbose)
   {
     CONSOLE_BRIDGE_logError("Actually checking collisions between %s and %s", name1.c_str(), name2.c_str());
   }

--- a/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
+++ b/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
@@ -231,7 +231,6 @@ void BulletDiscreteBVHManager::setActiveCollisionObjects(const std::vector<std::
   for (auto& co : link2cow_)
   {
     COW::Ptr& cow = co.second;
-
     updateCollisionObjectFilters(active_, cow, broadphase_, dispatcher_);
     refreshBroadphaseProxy(cow, broadphase_, dispatcher_);
   }

--- a/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
+++ b/tesseract_collision/src/bullet/bullet_discrete_bvh_manager.cpp
@@ -233,6 +233,7 @@ void BulletDiscreteBVHManager::setActiveCollisionObjects(const std::vector<std::
     COW::Ptr& cow = co.second;
 
     updateCollisionObjectFilters(active_, cow, broadphase_, dispatcher_);
+    refreshBroadphaseProxy(cow, broadphase_, dispatcher_);
   }
 }
 

--- a/tesseract_environment/test/CMakeLists.txt
+++ b/tesseract_environment/test/CMakeLists.txt
@@ -107,3 +107,30 @@ target_code_coverage(
 add_gtest_discover_tests(${PROJECT_NAME}_manipulator_manager_unit)
 add_dependencies(${PROJECT_NAME}_manipulator_manager_unit ${PROJECT_NAME}_kdl)
 add_dependencies(run_tests ${PROJECT_NAME}_manipulator_manager_unit)
+
+
+find_package(tesseract_visualization REQUIRED)
+add_executable(${PROJECT_NAME}_environment_collision tesseract_environment_collision.cpp)
+target_link_libraries(
+  ${PROJECT_NAME}_environment_collision
+  PRIVATE GTest::GTest
+          GTest::Main
+          ${PROJECT_NAME}_kdl
+          ${PROJECT_NAME}_ofkt
+          tesseract::tesseract_visualization
+          tesseract::tesseract_support)
+target_compile_options(${PROJECT_NAME}_environment_collision PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
+                                                                        ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_compile_definitions(${PROJECT_NAME}_environment_collision PRIVATE ${TESSERACT_COMPILE_DEFINITIONS})
+target_clang_tidy(${PROJECT_NAME}_environment_collision ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS}
+                  ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_environment_collision PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}_environment_collision
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+add_gtest_discover_tests(${PROJECT_NAME}_environment_collision)
+add_dependencies(${PROJECT_NAME}_environment_collision ${PROJECT_NAME}_kdl)
+add_dependencies(run_tests ${PROJECT_NAME}_environment_collision)
+

--- a/tesseract_environment/test/CMakeLists.txt
+++ b/tesseract_environment/test/CMakeLists.txt
@@ -117,7 +117,7 @@ target_link_libraries(
           ${PROJECT_NAME}_ofkt
           tesseract::tesseract_support)
 target_compile_options(${PROJECT_NAME}_environment_collision PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
-                                                                        ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+                                                                     ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_environment_collision PRIVATE ${TESSERACT_COMPILE_DEFINITIONS})
 target_clang_tidy(${PROJECT_NAME}_environment_collision ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS}
                   ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
@@ -130,4 +130,3 @@ target_code_coverage(
 add_gtest_discover_tests(${PROJECT_NAME}_environment_collision)
 add_dependencies(${PROJECT_NAME}_environment_collision ${PROJECT_NAME}_kdl)
 add_dependencies(run_tests ${PROJECT_NAME}_environment_collision)
-

--- a/tesseract_environment/test/CMakeLists.txt
+++ b/tesseract_environment/test/CMakeLists.txt
@@ -108,8 +108,6 @@ add_gtest_discover_tests(${PROJECT_NAME}_manipulator_manager_unit)
 add_dependencies(${PROJECT_NAME}_manipulator_manager_unit ${PROJECT_NAME}_kdl)
 add_dependencies(run_tests ${PROJECT_NAME}_manipulator_manager_unit)
 
-
-find_package(tesseract_visualization REQUIRED)
 add_executable(${PROJECT_NAME}_environment_collision tesseract_environment_collision.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_environment_collision
@@ -117,7 +115,6 @@ target_link_libraries(
           GTest::Main
           ${PROJECT_NAME}_kdl
           ${PROJECT_NAME}_ofkt
-          tesseract::tesseract_visualization
           tesseract::tesseract_support)
 target_compile_options(${PROJECT_NAME}_environment_collision PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
                                                                         ${TESSERACT_COMPILE_OPTIONS_PUBLIC})

--- a/tesseract_environment/test/tesseract_environment_collision.cpp
+++ b/tesseract_environment/test/tesseract_environment_collision.cpp
@@ -1,0 +1,176 @@
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <vector>
+#include <tesseract_urdf/urdf_parser.h>
+#include <tesseract_collision/bullet/bullet_discrete_bvh_manager.h>
+#include <tesseract_collision/fcl/fcl_discrete_managers.h>
+#include <tesseract_collision/bullet/bullet_cast_bvh_manager.h>
+#include <tesseract_scene_graph/resource_locator.h>
+#include <tesseract_geometry/impl/box.h>
+#include <tesseract_common/utils.h>
+#include <tesseract_visualization/visualization_loader.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_environment/core/types.h>
+#include <tesseract_environment/core/commands.h>
+#include <tesseract_environment/kdl/kdl_state_solver.h>
+#include <tesseract_environment/ofkt/ofkt_state_solver.h>
+#include <tesseract_environment/core/environment.h>
+
+using namespace tesseract_scene_graph;
+using namespace tesseract_collision;
+using namespace tesseract_environment;
+
+std::string locateResource(const std::string& url)
+{
+  std::string mod_url = url;
+  if (url.find("package://tesseract_support") == 0)
+  {
+    mod_url.erase(0, strlen("package://tesseract_support"));
+    size_t pos = mod_url.find('/');
+    if (pos == std::string::npos)
+    {
+      return std::string();
+    }
+
+    std::string package = mod_url.substr(0, pos);
+    mod_url.erase(0, pos);
+    std::string package_path = std::string(TESSERACT_SUPPORT_DIR);
+
+    if (package_path.empty())
+    {
+      return std::string();
+    }
+
+    mod_url = package_path + mod_url;
+  }
+
+  return mod_url;
+}
+
+SceneGraph::Ptr getSceneGraph()
+{
+  std::string path = std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.urdf";
+
+  tesseract_scene_graph::ResourceLocator::Ptr locator =
+      std::make_shared<tesseract_scene_graph::SimpleResourceLocator>(locateResource);
+  return tesseract_urdf::parseURDFFile(path, locator);
+}
+
+tesseract_scene_graph::SRDFModel::Ptr getSRDFModel(const SceneGraph::Ptr& scene_graph)
+{
+  std::string path = std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.srdf";
+
+  tesseract_scene_graph::SRDFModel::Ptr srdf = std::make_shared<tesseract_scene_graph::SRDFModel>();
+  srdf->initFile(*scene_graph, path);
+
+  return srdf;
+}
+
+template <typename S>
+void runEnvironmentCollisionTest()
+{
+
+
+
+
+
+  tesseract_scene_graph::SceneGraph::Ptr scene_graph = getSceneGraph();
+  EXPECT_TRUE(scene_graph != nullptr);
+
+  auto srdf = getSRDFModel(scene_graph);
+  EXPECT_TRUE(srdf != nullptr);
+
+  auto env = std::make_shared<Environment>(true);
+  bool success = env->init<S>(*scene_graph, srdf);
+  EXPECT_TRUE(success);
+
+
+  Link link_1("link_n1");
+  {
+    Visual::Ptr v = std::make_shared<Visual>();
+    v->origin.translation() = Eigen::Vector3d(1, 0, 0);
+    v->material = std::make_shared<Material>("test_material");
+    v->material->color = Eigen::Vector4d(1, 0, 0, 1);
+    v->geometry = std::make_shared<tesseract_geometry::Box>(1, 1, 1);
+    v->name = "link1_visual";
+    link_1.visual.push_back(v);
+
+    Collision::Ptr c = std::make_shared<Collision>();
+    c->origin.translation() =  v->origin.translation();
+    c->geometry = v->geometry;
+    c->name = "link1_collision";
+    link_1.collision.push_back(c);
+  }
+
+  Link link_2("link_n2");
+  {
+    Visual::Ptr v = std::make_shared<Visual>();
+    v->origin.translation() = Eigen::Vector3d(1.5, 0, 0);
+    v->material = std::make_shared<Material>("test_material");
+    v->material->color = Eigen::Vector4d(1, 1, 1, 1);
+    v->geometry = std::make_shared<tesseract_geometry::Box>(1, 1, 1);
+    v->name = "link2_visual";
+    link_2.visual.push_back(v);
+
+    Collision::Ptr c = std::make_shared<Collision>();
+    c->origin.translation() =  v->origin.translation();
+    c->geometry = v->geometry;
+    c->name = "link2_collision";
+    link_2.collision.push_back(c);
+  }
+
+  auto cmd1 = std::make_shared<AddLinkCommand>(link_1, true);
+  env->applyCommand(cmd1);
+
+  auto cmd2 = std::make_shared<AddLinkCommand>(link_2, true);
+  env->applyCommand(cmd2);
+
+
+  // Load visualizer
+  tesseract_visualization::VisualizationLoader mLoader;
+  auto plotter = mLoader.get();
+  if (plotter != nullptr && env != nullptr)
+  {
+    plotter->waitForConnection(3);
+    plotter->plotEnvironment(env);
+  }
+
+  // Setup collision margin data
+  CollisionCheckConfig mCollisionCheckConfig;
+  mCollisionCheckConfig.longest_valid_segment_length = 0.1;
+  mCollisionCheckConfig.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+  mCollisionCheckConfig.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
+  tesseract_collision::CollisionMarginData margin_data(0.0);
+  mCollisionCheckConfig.collision_margin_data = margin_data;
+
+
+  // Setup collision checker
+  DiscreteContactManager::Ptr manager = env->getDiscreteContactManager();
+  std::vector<std::string> active_links = { "link_n1" };
+  manager->setActiveCollisionObjects(active_links);
+  manager->setCollisionObjectsTransform("link_n1", Eigen::Isometry3d::Identity());
+  manager->setCollisionMarginData(mCollisionCheckConfig.collision_margin_data);
+
+  // Check for collisions
+  tesseract_collision::ContactResultMap collision;
+  manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+
+  EXPECT_FALSE(collision.empty());
+
+}
+
+TEST(TesseractEnvironmentCollisionUnit, runEnvironmentCollisionTest)  // NOLINT
+{
+//  runEnvironmentCollisionTest<KDLStateSolver>();
+  runEnvironmentCollisionTest<OFKTStateSolver>();
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_environment/test/tesseract_environment_collision.cpp
+++ b/tesseract_environment/test/tesseract_environment_collision.cpp
@@ -4,9 +4,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <algorithm>
 #include <vector>
 #include <tesseract_urdf/urdf_parser.h>
-#include <tesseract_collision/bullet/bullet_discrete_bvh_manager.h>
-#include <tesseract_collision/fcl/fcl_discrete_managers.h>
-#include <tesseract_collision/bullet/bullet_cast_bvh_manager.h>
 #include <tesseract_scene_graph/resource_locator.h>
 #include <tesseract_geometry/impl/box.h>
 #include <tesseract_common/utils.h>
@@ -133,12 +130,12 @@ void runEnvironmentCollisionTest()
   DiscreteContactManager::Ptr manager = env->getDiscreteContactManager();
   {  // Check for collisions
     tesseract_collision::ContactResultMap collision;
+    std::vector<std::string> active_links = { "link_n1" };
+    manager->setActiveCollisionObjects(active_links);
     manager->contactTest(collision, mCollisionCheckConfig.contact_request);
     EXPECT_FALSE(collision.empty());
   }
 
-  std::vector<std::string> active_links = { "link_n1" };
-  manager->setActiveCollisionObjects(active_links);
   manager->setCollisionObjectsTransform("link_n1", Eigen::Isometry3d::Identity());
   manager->setCollisionMarginData(mCollisionCheckConfig.collision_margin_data);
 
@@ -151,6 +148,7 @@ void runEnvironmentCollisionTest()
 
 TEST(TesseractEnvironmentCollisionUnit, runEnvironmentCollisionTest)  // NOLINT
 {
+  runEnvironmentCollisionTest<KDLStateSolver>();
   runEnvironmentCollisionTest<OFKTStateSolver>();
 }
 

--- a/tesseract_visualization/src/trajectory_interpolator.cpp
+++ b/tesseract_visualization/src/trajectory_interpolator.cpp
@@ -84,7 +84,7 @@ void TrajectoryInterpolator::findStateIndices(const double& duration, long& befo
 
   // Compute duration blend
   double before_time = running_duration - duration_from_previous_[index];
-  if (after == before)
+  if ((index == 0) || (after == before))
     blend = 1.0;
   else
     blend = (duration - before_time) / duration_from_previous_[index];

--- a/tesseract_visualization/src/trajectory_player.cpp
+++ b/tesseract_visualization/src/trajectory_player.cpp
@@ -73,8 +73,12 @@ tesseract_common::JointState TrajectoryPlayer::setCurrentDuration(double duratio
   if (!trajectory_ || trajectory_->empty())
     throw std::runtime_error("Trajectory is empty!");
 
+  finished_ = false;
   if (duration > trajectory_duration_)
+  {
     current_duration_ = trajectory_duration_;
+    finished_ = true;
+  }
   else if (duration < 0)
     current_duration_ = 0;
   else

--- a/tesseract_visualization/test/trajectory_player_unit.cpp
+++ b/tesseract_visualization/test/trajectory_player_unit.cpp
@@ -79,6 +79,16 @@ TEST(TesseracTrajectoryPlayerUnit, TrajectoryTest)  // NOLINT
     JointState s = player.setCurrentDuration(10);
     EXPECT_NEAR(s.time, 9, 1e-5);
     EXPECT_NEAR(s.position(0), 9, 1e-5);
+    EXPECT_TRUE(player.isFinished());
+  }
+
+  {
+    JointState s = player.setCurrentDuration(11);
+    EXPECT_NEAR(s.time, 9, 1e-5);
+    EXPECT_NEAR(s.position(0), 9, 1e-5);
+    EXPECT_TRUE(player.isFinished());
+    player.setCurrentDuration(0);
+    EXPECT_FALSE(player.isFinished());
   }
 
   {
@@ -91,6 +101,7 @@ TEST(TesseracTrajectoryPlayerUnit, TrajectoryTest)  // NOLINT
     JointState s = player.setCurrentDuration(-1);
     EXPECT_NEAR(s.time, 0, 1e-5);
     EXPECT_NEAR(s.position(0), 0, 1e-5);
+    EXPECT_FALSE(player.isFinished());
   }
 }
 


### PR DESCRIPTION
Bullet does some optimization check to prevent necessary updates to broadphase which does not get triggered when setting active links. This add a function to refresh the broadphase when active links change.

Also fixes an issue in the trajectory player where it does not update the finished bool if the duration is set the max.