### PR TITLE
Move tesseract_variables() before any use of custom macros

### DIFF
--- a/tesseract_collision/CMakeLists.txt
+++ b/tesseract_collision/CMakeLists.txt
@@ -63,6 +63,9 @@ if(NOT TARGET octomath)
   set_target_properties(octomath PROPERTIES INTERFACE_LINK_LIBRARIES "${OCTOMAP_LIBRARIES}")
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -75,9 +78,6 @@ set(COVERAGE_EXCLUDE
     /*/include/ccd/*
     /*/include/fcl/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 # Create interface for core
 add_library(${PROJECT_NAME}_core INTERFACE)

--- a/tesseract_common/CMakeLists.txt
+++ b/tesseract_common/CMakeLists.txt
@@ -30,6 +30,9 @@ else()
   endif()
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -37,9 +40,6 @@ set(COVERAGE_EXCLUDE
     ${CMAKE_CURRENT_LIST_DIR}/test/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 add_library(
   ${PROJECT_NAME}

--- a/tesseract_environment/CMakeLists.txt
+++ b/tesseract_environment/CMakeLists.txt
@@ -32,6 +32,9 @@ else()
   endif()
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -41,9 +44,6 @@ set(COVERAGE_EXCLUDE
     /*/bullet/LinearMath/*
     /*/bullet/BulletCollision/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 # Create interface for core
 add_library(${PROJECT_NAME}_core src/core/environment.cpp src/core/manipulator_manager.cpp)

--- a/tesseract_geometry/CMakeLists.txt
+++ b/tesseract_geometry/CMakeLists.txt
@@ -51,6 +51,9 @@ else()
   set(TESSERACT_ASSIMP_USE_PBRMATERIAL)
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -58,9 +61,6 @@ set(COVERAGE_EXCLUDE
     ${CMAKE_CURRENT_LIST_DIR}/test/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_link_libraries(

--- a/tesseract_kinematics/CMakeLists.txt
+++ b/tesseract_kinematics/CMakeLists.txt
@@ -30,6 +30,9 @@ else()
   endif()
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -38,9 +41,6 @@ set(COVERAGE_EXCLUDE
     /*/gtest/*
     /*/bullet/LinearMath/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 # Create interface for core
 add_library(${PROJECT_NAME}_core src/core/rop_inverse_kinematics.cpp src/core/rep_inverse_kinematics.cpp)

--- a/tesseract_scene_graph/CMakeLists.txt
+++ b/tesseract_scene_graph/CMakeLists.txt
@@ -29,6 +29,9 @@ else()
   endif()
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -36,9 +39,6 @@ set(COVERAGE_EXCLUDE
     ${CMAKE_CURRENT_LIST_DIR}/test/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 add_library(
   ${PROJECT_NAME}

--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -31,6 +31,9 @@ else()
   endif()
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -39,9 +42,6 @@ set(COVERAGE_EXCLUDE
     /*/gtest/*
     /*/bullet/LinearMath/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 add_library(${PROJECT_NAME} src/urdf_parser.cpp)
 target_link_libraries(

--- a/tesseract_visualization/CMakeLists.txt
+++ b/tesseract_visualization/CMakeLists.txt
@@ -44,6 +44,9 @@ if(ignition-common3_FOUND
   message(STATUS "Ignition Visualization Library will be built!")
 endif()
 
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
 initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 set(COVERAGE_EXCLUDE
     /usr/*
@@ -51,9 +54,6 @@ set(COVERAGE_EXCLUDE
     ${CMAKE_CURRENT_LIST_DIR}/test/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-
-# Load variable for clang tidy args, compiler options and cxx version
-tesseract_variables()
 
 # ######################################################################################################################
 # Define compile-time default variables


### PR DESCRIPTION
The `tesseract_variables()` macro must be called before use of tesseract variables so they are correctly configured.