### PR TITLE
Store timestamp when environment state is set

### DIFF
--- a/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -30,6 +30,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <vector>
 #include <string>
 #include <shared_mutex>
+#include <chrono>
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -380,6 +381,9 @@ public:
 
   /** @brief Get the current state of the environment */
   virtual EnvState::ConstPtr getCurrentState() const;
+
+  /** @brief Get the current state timestamp */
+  virtual std::chrono::high_resolution_clock::duration getCurrentStateTimestamp() const;
 
   /**
    * @brief Get a link in the environment
@@ -738,15 +742,16 @@ protected:
   int revision_{ 0 };         /**< This increments when the scene graph is modified */
   int init_revision_{ 0 };    /**< This is the revision number after initialization used when reset is called */
   Commands commands_;         /**< The history of commands applied to the environment after intialization */
-  tesseract_scene_graph::SceneGraph::Ptr scene_graph_;            /**< Tesseract Scene Graph */
-  tesseract_scene_graph::SceneGraph::ConstPtr scene_graph_const_; /**< Tesseract Scene Graph Const */
-  ManipulatorManager::Ptr manipulator_manager_;                   /**< Managers for the kinematics objects */
-  EnvState::Ptr current_state_;                                   /**< Current state of the environment */
-  StateSolver::Ptr state_solver_;                                 /**< Tesseract State Solver */
-  std::vector<std::string> link_names_;                           /**< A vector of link names */
-  std::vector<std::string> joint_names_;                          /**< A vector of joint names */
-  std::vector<std::string> active_link_names_;                    /**< A vector of active link names */
-  std::vector<std::string> active_joint_names_;                   /**< A vector of active joint names */
+  tesseract_scene_graph::SceneGraph::Ptr scene_graph_;                   /**< Tesseract Scene Graph */
+  tesseract_scene_graph::SceneGraph::ConstPtr scene_graph_const_;        /**< Tesseract Scene Graph Const */
+  ManipulatorManager::Ptr manipulator_manager_;                          /**< Managers for the kinematics objects */
+  EnvState::Ptr current_state_;                                          /**< Current state of the environment */
+  std::chrono::high_resolution_clock::duration current_state_timestamp_; /**< Current state timestamp */
+  StateSolver::Ptr state_solver_;                                        /**< Tesseract State Solver */
+  std::vector<std::string> link_names_;                                  /**< A vector of link names */
+  std::vector<std::string> joint_names_;                                 /**< A vector of joint names */
+  std::vector<std::string> active_link_names_;                           /**< A vector of active link names */
+  std::vector<std::string> active_joint_names_;                          /**< A vector of active joint names */
   tesseract_collision::IsContactAllowedFn is_contact_allowed_fn_; /**< The function used to determine if two objects are
                                                                      allowed in collision */
 

--- a/tesseract_environment/src/core/environment.cpp
+++ b/tesseract_environment/src/core/environment.cpp
@@ -332,6 +332,12 @@ EnvState::ConstPtr Environment::getCurrentState() const
   return current_state_;
 }
 
+std::chrono::high_resolution_clock::duration Environment::getCurrentStateTimestamp() const
+{
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  return current_state_timestamp_;
+}
+
 tesseract_scene_graph::Link::ConstPtr Environment::getLink(const std::string& name) const
 {
   std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -676,6 +682,7 @@ void Environment::getCollisionObject(tesseract_collision::CollisionShapesConst& 
 
 void Environment::currentStateChanged()
 {
+  current_state_timestamp_ = std::chrono::high_resolution_clock::now().time_since_epoch();
   current_state_ = std::make_shared<EnvState>(*(state_solver_->getCurrentState()));
   if (discrete_manager_ != nullptr)
     discrete_manager_->setCollisionObjectsTransform(current_state_->link_transforms);


### PR DESCRIPTION
I was trying to figure out how best to determine if the current state in the environment has changes because we are not tracking this in the environment history. Adding a timestamp looks like the simplest approach where the developer can store the timestamp and then check if it is different to know if the state has changed.