### PR TITLE
IK Solver Redundant Solutions Update

### DIFF
--- a/tesseract_kinematics/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/include/tesseract_kinematics/core/utils.h
@@ -394,6 +394,28 @@ ForwardKinematicsConstPtrMap createKinematicsMap(const tesseract_scene_graph::Sc
 }
 
 /**
+ * @brief Creates a vector indicating which joints in the input list of joint names are capable of producing redundant solutions
+ */
+inline std::vector<Eigen::Index> getRedundancyCapableJointIndices(const tesseract_scene_graph::SceneGraph::ConstPtr& scene_graph,
+                                                                  const std::vector<std::string>& joint_names)
+{
+  std::vector<Eigen::Index> idx;
+  for (std::size_t i = 0; i < joint_names.size(); ++i)
+  {
+    const auto& joint = scene_graph->getJoint(joint_names[i]);
+    switch (joint->type)
+    {
+      case tesseract_scene_graph::JointType::REVOLUTE:
+        idx.push_back(static_cast<Eigen::Index>(i));
+        break;
+      default:
+        break;
+    }
+  }
+  return idx;
+}
+
+/**
  * @brief This a recursive function for caculating all permutations of the redundant solutions.
  * @details This should not be used directly, use getRedundantSolutions function.
  */

--- a/tesseract_kinematics/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
+++ b/tesseract_kinematics/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
@@ -103,15 +103,6 @@ IKSolutions IKFastInvKin::calcInvKin(const Eigen::Isometry3d& pose, const Eigen:
       // Add solution
       if (tesseract_common::satisfiesPositionLimits(eigen_sol, limits_.joint_limits))
         solution_set.push_back(eigen_sol);
-
-      // Add redundant solutions
-      IKSolutions redundant_sols = getRedundantSolutions<double>(eigen_sol, limits_.joint_limits);
-      if (!redundant_sols.empty())
-      {
-        solution_set.insert(end(solution_set),
-                            std::make_move_iterator(redundant_sols.begin()),
-                            std::make_move_iterator(redundant_sols.end()));
-      }
     }
   }
 

--- a/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_lma.cpp
+++ b/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_lma.cpp
@@ -92,15 +92,6 @@ IKSolutions KDLInvKinChainLMA::calcInvKinHelper(const Eigen::Isometry3d& pose,
   if (tesseract_common::satisfiesPositionLimits(solution, kdl_data_.limits.joint_limits))
     solution_set.push_back(solution);
 
-  // Add redundant solutions
-  IKSolutions redundant_sols = getRedundantSolutions<double>(solution, kdl_data_.limits.joint_limits);
-  if (!redundant_sols.empty())
-  {
-    solution_set.insert(end(solution_set),
-                        std::make_move_iterator(redundant_sols.begin()),
-                        std::make_move_iterator(redundant_sols.end()));
-  }
-
   return solution_set;
 }
 

--- a/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_nr.cpp
+++ b/tesseract_kinematics/src/kdl/kdl_inv_kin_chain_nr.cpp
@@ -98,15 +98,6 @@ IKSolutions KDLInvKinChainNR::calcInvKinHelper(const Eigen::Isometry3d& pose,
   if (tesseract_common::satisfiesPositionLimits(solution, kdl_data_.limits.joint_limits))
     solution_set.push_back(solution);
 
-  // Add redundant solutions
-  IKSolutions redundant_sols = getRedundantSolutions<double>(solution, kdl_data_.limits.joint_limits);
-  if (!redundant_sols.empty())
-  {
-    solution_set.insert(end(solution_set),
-                        std::make_move_iterator(redundant_sols.begin()),
-                        std::make_move_iterator(redundant_sols.end()));
-  }
-
   return solution_set;
 }
 

--- a/tesseract_kinematics/src/opw/opw_inv_kin.cpp
+++ b/tesseract_kinematics/src/opw/opw_inv_kin.cpp
@@ -68,15 +68,6 @@ IKSolutions OPWInvKin::calcInvKin(const Eigen::Isometry3d& pose,
       // Add solution
       if (tesseract_common::satisfiesPositionLimits(eigen_sol, limits_.joint_limits))
         solution_set.push_back(eigen_sol);
-
-      // Add redundant solutions
-      IKSolutions redundant_sols = getRedundantSolutions<double>(eigen_sol, limits_.joint_limits);
-      if (!redundant_sols.empty())
-      {
-        solution_set.insert(end(solution_set),
-                            std::make_move_iterator(redundant_sols.begin()),
-                            std::make_move_iterator(redundant_sols.end()));
-      }
     }
   }
 

--- a/tesseract_kinematics/src/ur/ur_inv_kin.cpp
+++ b/tesseract_kinematics/src/ur/ur_inv_kin.cpp
@@ -251,15 +251,6 @@ IKSolutions URInvKin::calcInvKin(const Eigen::Isometry3d& pose, const Eigen::Ref
 
     // Add solution
     solution_set.push_back(eigen_sol);
-
-    // Add redundant solutions
-    IKSolutions redundant_sols = getRedundantSolutions<double>(eigen_sol, limits_.joint_limits);
-    if (!redundant_sols.empty())
-    {
-      solution_set.insert(end(solution_set),
-                          std::make_move_iterator(redundant_sols.begin()),
-                          std::make_move_iterator(redundant_sols.end()));
-    }
   }
 
   return solution_set;

--- a/tesseract_kinematics/test/kinematics_core_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_core_unit.cpp
@@ -74,13 +74,14 @@ void runRedundantSolutionsTest()
   double max_diff = 1e-6;
   Eigen::MatrixX2d limits(3, 2);
   limits << 0, 2.0 * M_PI, 0, 2.0 * M_PI, 0, 2.0 * M_PI;
+  std::vector<Eigen::Index> redundancy_capable_joints = { 0, 1, 2 };
 
   tesseract_kinematics::VectorX<FloatType> q(3);
   q << 0, 0, 0;
 
   {  // Test when initial solution is at the lower limit
     std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
-        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits);
+        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
     if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
       solutions.push_back(q);
 
@@ -100,7 +101,7 @@ void runRedundantSolutionsTest()
   {  // Test when initial solution is within the limits
     limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
     std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
-        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits);
+        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
     if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
       solutions.push_back(q);
 
@@ -122,7 +123,7 @@ void runRedundantSolutionsTest()
     q << static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(4.0 * M_PI);
 
     std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
-        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits);
+        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
     if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
       solutions.push_back(q);
 
@@ -138,6 +139,7 @@ void runRedundantSolutionsTest()
       }
     }
   }
+
 }
 
 TEST(TesseractKinematicsUnit, RedundantSolutionsUnit)  // NOLINT

--- a/tesseract_kinematics/test/kinematics_core_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_core_unit.cpp
@@ -71,75 +71,82 @@ TEST(TesseractKinematicsUnit, UtilsHarmonizeUnit)  // NOLINT
 template <typename FloatType>
 void runRedundantSolutionsTest()
 {
-  double max_diff = 1e-6;
-  Eigen::MatrixX2d limits(3, 2);
-  limits << 0, 2.0 * M_PI, 0, 2.0 * M_PI, 0, 2.0 * M_PI;
-  std::vector<Eigen::Index> redundancy_capable_joints = { 0, 1, 2 };
-
-  tesseract_kinematics::VectorX<FloatType> q(3);
-  q << 0, 0, 0;
-
-  {  // Test when initial solution is at the lower limit
-    std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
-        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
-    if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
-      solutions.push_back(q);
-
-    EXPECT_EQ(solutions.size(), 8);
-
-    // Check and make sure they are unique
-    for (std::size_t i = 0; i < solutions.size() - 1; ++i)
+  // Helper function for checking if all redundant solutions are unique
+  auto expect_unique_solutions = [](const std::vector<tesseract_kinematics::VectorX<FloatType>>& solutions) {
+    for (auto sol_1 = solutions.begin(); sol_1 != solutions.end() - 1; ++sol_1)
     {
-      for (std::size_t j = i + 1; j < solutions.size(); ++j)
+      for (auto sol_2 = sol_1 + 1; sol_2 != solutions.end(); ++sol_2)
       {
         EXPECT_FALSE(tesseract_common::almostEqualRelativeAndAbs(
-            solutions[i].template cast<double>(), solutions[j].template cast<double>(), 1e-6));
+            sol_1->template cast<double>(), sol_2->template cast<double>(), 1e-6));
       }
+    }
+  };
+
+  {
+    double max_diff = 1e-6;
+    Eigen::MatrixX2d limits(3, 2);
+    limits << 0, 2.0 * M_PI, 0, 2.0 * M_PI, 0, 2.0 * M_PI;
+    std::vector<Eigen::Index> redundancy_capable_joints = { 0, 1, 2 };
+
+    tesseract_kinematics::VectorX<FloatType> q(3);
+    q << 0, 0, 0;
+
+    {  // Test when initial solution is at the lower limit
+      std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
+          tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
+      if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+        solutions.push_back(q);
+
+      EXPECT_EQ(solutions.size(), 8);
+      expect_unique_solutions(solutions);
+    }
+
+    {  // Test when initial solution is within the limits
+      limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
+      std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
+          tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
+      if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+        solutions.push_back(q);
+
+      EXPECT_EQ(solutions.size(), 27);
+      expect_unique_solutions(solutions);
+    }
+
+    {  // Test when the initial solution outside the lower and upper limit
+      limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
+      q << static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(4.0 * M_PI);
+
+      std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
+          tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
+      if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+        solutions.push_back(q);
+
+      EXPECT_EQ(solutions.size(), 27);
+      expect_unique_solutions(solutions);
     }
   }
 
-  {  // Test when initial solution is within the limits
-    limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
+  {  // Test case when not all joints are redundancy capable
+    double max_diff = 1.0e-6;
+    Eigen::MatrixX2d limits(4, 2);
+    limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
+
+    tesseract_kinematics::VectorX<FloatType> q(4);
+    q << static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(0.0),
+        static_cast<FloatType>(4.0 * M_PI);
+
+    // Arbitrarily decide that joint 2 is not redundancy capable
+    std::vector<Eigen::Index> redundancy_capable_joints = { 0, 1, 3 };
+
     std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
         tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
     if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
       solutions.push_back(q);
 
     EXPECT_EQ(solutions.size(), 27);
-
-    // Check and make sure they are unique
-    for (std::size_t i = 0; i < solutions.size() - 1; ++i)
-    {
-      for (std::size_t j = i + 1; j < solutions.size(); ++j)
-      {
-        EXPECT_FALSE(tesseract_common::almostEqualRelativeAndAbs(
-            solutions[i].template cast<double>(), solutions[j].template cast<double>(), 1e-6));
-      }
-    }
+    expect_unique_solutions(solutions);
   }
-
-  {  // Test when the initial solution outside the lower and upper limit
-    limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
-    q << static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(4.0 * M_PI);
-
-    std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
-        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
-    if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
-      solutions.push_back(q);
-
-    EXPECT_EQ(solutions.size(), 27);
-
-    // Check and make sure they are unique
-    for (std::size_t i = 0; i < solutions.size() - 1; ++i)
-    {
-      for (std::size_t j = i + 1; j < solutions.size(); ++j)
-      {
-        EXPECT_FALSE(tesseract_common::almostEqualRelativeAndAbs(
-            solutions[i].template cast<double>(), solutions[j].template cast<double>(), 1e-6));
-      }
-    }
-  }
-
 }
 
 TEST(TesseractKinematicsUnit, RedundantSolutionsUnit)  // NOLINT

--- a/tesseract_kinematics/test/kinematics_core_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_core_unit.cpp
@@ -147,6 +147,25 @@ void runRedundantSolutionsTest()
     EXPECT_EQ(solutions.size(), 27);
     expect_unique_solutions(solutions);
   }
+
+  {  // Edge-case tests
+    Eigen::MatrixX2d limits(4, 2);
+    limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
+
+    tesseract_kinematics::VectorX<FloatType> q(4);
+    q << static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(-4.0 * M_PI), static_cast<FloatType>(0.0),
+        static_cast<FloatType>(4.0 * M_PI);
+
+    std::vector<Eigen::Index> redundancy_capable_joints = {};
+    std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
+        tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
+
+    EXPECT_EQ(solutions.size(), 0);
+
+    redundancy_capable_joints = { 10 };
+    EXPECT_THROW(tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints),
+                 std::runtime_error);
+  }
 }
 
 TEST(TesseractKinematicsUnit, RedundantSolutionsUnit)  // NOLINT


### PR DESCRIPTION
This PR:
- Removes the addition of redundant solutions to the output of the inverse kinematic solvers
  - Returning redundant IK solutions with nominal solutions can cause downstream applications to repeat operations because those applications cannot disambiguate the two types of solutions. For example, the Tesseract Descartes planner collision checks all generated IK solutions, resulting in a lot of unnecessary repeated work when the vast majority of IK solutions are just redundancies of a solution that has already been checked.
  - Applications requiring redundant solutions should use the provided utility function to produce them from a nominal solution
- Adds a function for generating a list of indices which indicate which joints in a input list are capable of generating redundant solutions. 
  - Linear joints, unlike revolute joints, are not capable of producing redundant solutions. 
- Updates the redundant solution calculation function to only generate redundant solutions for joints that are capable of producing them