### PR TITLE
Add support function for getting active and static links along with collision pairs

### DIFF
--- a/tesseract_environment/CMakeLists.txt
+++ b/tesseract_environment/CMakeLists.txt
@@ -47,7 +47,7 @@ set(COVERAGE_EXCLUDE
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 
 # Create interface for core
-add_library(${PROJECT_NAME}_core src/core/environment.cpp src/core/manipulator_manager.cpp)
+add_library(${PROJECT_NAME}_core src/core/environment.cpp src/core/manipulator_manager.cpp src/core/utils.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_core
   PUBLIC Eigen3::Eigen

--- a/tesseract_environment/include/tesseract_environment/core/environment.h
+++ b/tesseract_environment/include/tesseract_environment/core/environment.h
@@ -473,6 +473,26 @@ public:
   virtual std::vector<std::string> getActiveLinkNames() const;
 
   /**
+   * @brief Get a vector of active link names affected by the provided joints in the environment
+   * @param joint_names A list of joint names
+   * @return A vector of active link names
+   */
+  virtual std::vector<std::string> getActiveLinkNames(const std::vector<std::string>& joint_names) const;
+
+  /**
+   * @brief Get a vector of static link names in the environment
+   * @return A vector of static link names
+   */
+  virtual std::vector<std::string> getStaticLinkNames() const;
+
+  /**
+   * @brief Get a vector of static link names not affected by the provided joints in the environment
+   * @param joint_names A list of joint names
+   * @return A vector of static link names
+   */
+  virtual std::vector<std::string> getStaticLinkNames(const std::vector<std::string>& joint_names) const;
+
+  /**
    * @brief Get all of the links transforms
    *
    * Order should be the same as getLinkNames()

--- a/tesseract_environment/src/core/environment.cpp
+++ b/tesseract_environment/src/core/environment.cpp
@@ -431,6 +431,51 @@ std::vector<std::string> Environment::getActiveLinkNames() const
   return active_link_names_;
 }
 
+std::vector<std::string> Environment::getActiveLinkNames(const std::vector<std::string>& joint_names) const
+{
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  return scene_graph_const_->getJointChildrenNames(joint_names);
+}
+
+std::vector<std::string> Environment::getStaticLinkNames() const
+{
+  std::vector<std::string> active_link_names = active_link_names_;
+  std::vector<std::string> full_link_names = link_names_;
+  std::vector<std::string> static_link_names;
+  static_link_names.reserve(full_link_names.size());
+
+  std::sort(active_link_names.begin(), active_link_names.end());
+  std::sort(full_link_names.begin(), full_link_names.end());
+
+  std::set_difference(full_link_names.begin(),
+                      full_link_names.end(),
+                      active_link_names.begin(),
+                      active_link_names.end(),
+                      std::inserter(static_link_names, static_link_names.begin()));
+
+  return static_link_names;
+}
+
+std::vector<std::string> Environment::getStaticLinkNames(const std::vector<std::string>& joint_names) const
+{
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  std::vector<std::string> active_link_names = getActiveLinkNames(joint_names);
+  std::vector<std::string> full_link_names = link_names_;
+  std::vector<std::string> static_link_names;
+  static_link_names.reserve(full_link_names.size());
+
+  std::sort(active_link_names.begin(), active_link_names.end());
+  std::sort(full_link_names.begin(), full_link_names.end());
+
+  std::set_difference(full_link_names.begin(),
+                      full_link_names.end(),
+                      active_link_names.begin(),
+                      active_link_names.end(),
+                      std::inserter(static_link_names, static_link_names.begin()));
+
+  return static_link_names;
+}
+
 tesseract_common::VectorIsometry3d Environment::getLinkTransforms() const
 {
   std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -1018,7 +1063,7 @@ bool Environment::changeJointPositionLimits(const std::string& joint_name, doubl
   return applyCommand(std::make_shared<ChangeJointPositionLimitsCommand>(joint_name, lower, upper));
 }
 
-bool Environment::changeJointPositionLimits(const std::unordered_map<std::string, std::pair<double, double> >& limits)
+bool Environment::changeJointPositionLimits(const std::unordered_map<std::string, std::pair<double, double>>& limits)
 {
   return applyCommand(std::make_shared<ChangeJointPositionLimitsCommand>(limits));
 }

--- a/tesseract_environment/src/core/utils.cpp
+++ b/tesseract_environment/src/core/utils.cpp
@@ -1,0 +1,380 @@
+/**
+ * @file utils.cpp
+ * @brief Tesseract Environment Utility Functions.
+ *
+ * @author Levi Armstrong
+ * @date Dec 18, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_environment/core/utils.h>
+
+namespace tesseract_environment
+{
+/**
+ * @brief Get the active Link Names Recursively
+ *
+ *        This currently only works for graphs that are trees. Need to create a generic method using boost::visitor
+ *        TODO: Need to update using graph->getLinkChildren
+ *
+ * @param active_links
+ * @param scene_graph
+ * @param current_link
+ * @param active
+ */
+void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
+                                 const tesseract_scene_graph::SceneGraph::ConstPtr& scene_graph,
+                                 const std::string& current_link,
+                                 bool active)
+{
+  // recursively get all active links
+  assert(scene_graph->isTree());
+  if (active)
+  {
+    active_links.push_back(current_link);
+    for (const auto& child_link : scene_graph->getAdjacentLinkNames(current_link))
+      getActiveLinkNamesRecursive(active_links, scene_graph, child_link, active);
+  }
+  else
+  {
+    for (const auto& child_link : scene_graph->getAdjacentLinkNames(current_link))
+      if (scene_graph->getInboundJoints(child_link)[0]->type != tesseract_scene_graph::JointType::FIXED)
+        getActiveLinkNamesRecursive(active_links, scene_graph, child_link, true);
+      else
+        getActiveLinkNamesRecursive(active_links, scene_graph, child_link, active);
+  }
+}
+
+bool checkTrajectorySegment(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                            tesseract_collision::ContinuousContactManager& manager,
+                            const tesseract_environment::EnvState::Ptr& state0,
+                            const tesseract_environment::EnvState::Ptr& state1,
+                            const tesseract_collision::CollisionCheckConfig& config)
+{
+  for (const auto& link_name : manager.getActiveCollisionObjects())
+    manager.setCollisionObjectsTransform(
+        link_name, state0->link_transforms[link_name], state1->link_transforms[link_name]);
+
+  tesseract_collision::ContactResultMap collisions;
+  manager.contactTest(collisions, config.contact_request);
+
+  if (!collisions.empty())
+  {
+    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+    {
+      for (auto& collision : collisions)
+      {
+        std::stringstream ss;
+        ss << "Continuous collision detected between '" << collision.first.first << "' and '" << collision.first.second
+           << "' with distance " << collision.second.front().distance << std::endl;
+
+        CONSOLE_BRIDGE_logError(ss.str().c_str());
+      }
+    }
+
+    contacts.push_back(collisions);
+    return true;
+  }
+
+  return false;
+}
+
+bool checkTrajectoryState(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                          tesseract_collision::DiscreteContactManager& manager,
+                          const tesseract_environment::EnvState::Ptr& state,
+                          const tesseract_collision::CollisionCheckConfig& config)
+{
+  tesseract_collision::ContactResultMap collisions;
+
+  for (const auto& link_name : manager.getActiveCollisionObjects())
+    manager.setCollisionObjectsTransform(link_name, state->link_transforms[link_name]);
+
+  manager.contactTest(collisions, config.contact_request);
+
+  if (!collisions.empty())
+  {
+    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+    {
+      for (auto& collision : collisions)
+      {
+        std::stringstream ss;
+        ss << "Discrete collision detected between '" << collision.first.first << "' and '" << collision.first.second
+           << "' with distance " << collision.second.front().distance << std::endl;
+
+        CONSOLE_BRIDGE_logError(ss.str().c_str());
+      }
+    }
+
+    contacts.push_back(collisions);
+    return true;
+  }
+
+  return false;
+}
+
+bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                     tesseract_collision::ContinuousContactManager& manager,
+                     const tesseract_environment::StateSolver& state_solver,
+                     const std::vector<std::string>& joint_names,
+                     const tesseract_common::TrajArray& traj,
+                     const tesseract_collision::CollisionCheckConfig& config)
+{
+  if (config.type != tesseract_collision::CollisionEvaluatorType::CONTINUOUS &&
+      config.type != tesseract_collision::CollisionEvaluatorType::LVS_CONTINUOUS)
+    throw std::runtime_error("checkTrajectory was given an CollisionEvaluatorType that is inconsistent with the "
+                             "ContactManager type");
+
+  if (traj.rows() == 1)
+    throw std::runtime_error("checkTrajectory was given continuous contact manager with a trajectory that only has one "
+                             "state.");
+
+  bool found = false;
+  if (config.type == tesseract_collision::CollisionEvaluatorType::LVS_CONTINUOUS)
+  {
+    contacts.reserve(static_cast<size_t>(traj.rows() - 1));
+    for (int iStep = 0; iStep < traj.rows() - 1; ++iStep)
+    {
+      double dist = (traj.row(iStep + 1) - traj.row(iStep)).norm();
+      if (dist > config.longest_valid_segment_length)
+      {
+        long cnt = static_cast<long>(std::ceil(dist / config.longest_valid_segment_length)) + 1;
+        tesseract_common::TrajArray subtraj(cnt, traj.cols());
+        for (long iVar = 0; iVar < traj.cols(); ++iVar)
+          subtraj.col(iVar) = Eigen::VectorXd::LinSpaced(cnt, traj.row(iStep)(iVar), traj.row(iStep + 1)(iVar));
+
+        for (int iSubStep = 0; iSubStep < subtraj.rows() - 1; ++iSubStep)
+        {
+          tesseract_environment::EnvState::Ptr state0 = state_solver.getState(joint_names, subtraj.row(iSubStep));
+          tesseract_environment::EnvState::Ptr state1 = state_solver.getState(joint_names, subtraj.row(iSubStep + 1));
+          if (checkTrajectorySegment(contacts, manager, state0, state1, config))
+          {
+            found = true;
+            if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+            {
+              std::stringstream ss;
+              ss << "Continuous collision detected at step: " << iStep << " of " << (traj.rows() - 1)
+                 << " substep: " << iSubStep << std::endl;
+
+              ss << "     Names:";
+              for (const auto& name : joint_names)
+                ss << " " << name;
+
+              ss << std::endl
+                 << "    State0: " << subtraj.row(iSubStep) << std::endl
+                 << "    State1: " << subtraj.row(iSubStep + 1) << std::endl;
+
+              CONSOLE_BRIDGE_logError(ss.str().c_str());
+            }
+          }
+
+          if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+            break;
+        }
+
+        if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          break;
+      }
+      else
+      {
+        tesseract_environment::EnvState::Ptr state0 = state_solver.getState(joint_names, traj.row(iStep));
+        tesseract_environment::EnvState::Ptr state1 = state_solver.getState(joint_names, traj.row(iStep + 1));
+        if (checkTrajectorySegment(contacts, manager, state0, state1, config))
+        {
+          found = true;
+          if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+          {
+            std::stringstream ss;
+            ss << "Continuous collision detected at step: " << iStep << " of " << (traj.rows() - 1) << std::endl;
+
+            ss << "     Names:";
+            for (const auto& name : joint_names)
+              ss << " " << name;
+
+            ss << std::endl
+               << "    State0: " << traj.row(iStep) << std::endl
+               << "    State1: " << traj.row(iStep + 1) << std::endl;
+
+            CONSOLE_BRIDGE_logError(ss.str().c_str());
+          }
+        }
+
+        if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          break;
+      }
+    }
+  }
+  else
+  {
+    contacts.reserve(static_cast<size_t>(traj.rows() - 1));
+    for (int iStep = 0; iStep < traj.rows() - 1; ++iStep)
+    {
+      tesseract_environment::EnvState::Ptr state0 = state_solver.getState(joint_names, traj.row(iStep));
+      tesseract_environment::EnvState::Ptr state1 = state_solver.getState(joint_names, traj.row(iStep + 1));
+
+      if (checkTrajectorySegment(contacts, manager, state0, state1, config))
+      {
+        found = true;
+        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        {
+          std::stringstream ss;
+          ss << "Discrete collision detected at step: " << iStep << " of " << (traj.rows() - 1) << std::endl;
+
+          ss << "     Names:";
+          for (const auto& name : joint_names)
+            ss << " " << name;
+
+          ss << std::endl
+             << "    State0: " << traj.row(iStep) << std::endl
+             << "    State1: " << traj.row(iStep + 1) << std::endl;
+
+          CONSOLE_BRIDGE_logError(ss.str().c_str());
+        }
+      }
+
+      if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+        break;
+    }
+  }
+
+  return found;
+}
+
+bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                     tesseract_collision::DiscreteContactManager& manager,
+                     const tesseract_environment::StateSolver& state_solver,
+                     const std::vector<std::string>& joint_names,
+                     const tesseract_common::TrajArray& traj,
+                     const tesseract_collision::CollisionCheckConfig& config)
+{
+  if (config.type != tesseract_collision::CollisionEvaluatorType::DISCRETE &&
+      config.type != tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE)
+    throw std::runtime_error("checkTrajectory was given an CollisionEvaluatorType that is inconsistent with the "
+                             "ContactManager type");
+
+  if (traj.rows() == 1)
+  {
+    tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, traj.row(0));
+    return checkTrajectoryState(contacts, manager, state, config);
+  }
+
+  bool found = false;
+  if (config.type == tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE)
+  {
+    contacts.reserve(static_cast<size_t>(traj.rows()));
+    for (int iStep = 0; iStep < traj.rows(); ++iStep)
+    {
+      double dist = -1;
+      if (iStep < traj.rows() - 1)
+        dist = (traj.row(iStep + 1) - traj.row(iStep)).norm();
+
+      if (dist > 0 && dist > config.longest_valid_segment_length)
+      {
+        int cnt = static_cast<int>(std::ceil(dist / config.longest_valid_segment_length)) + 1;
+        tesseract_common::TrajArray subtraj(cnt, traj.cols());
+        for (long iVar = 0; iVar < traj.cols(); ++iVar)
+          subtraj.col(iVar) = Eigen::VectorXd::LinSpaced(cnt, traj.row(iStep)(iVar), traj.row(iStep + 1)(iVar));
+
+        for (int iSubStep = 0; iSubStep < subtraj.rows() - 1; ++iSubStep)
+        {
+          tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, subtraj.row(iSubStep));
+          if (checkTrajectoryState(contacts, manager, state, config))
+          {
+            found = true;
+            if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+            {
+              std::stringstream ss;
+              ss << "Discrete collision detected at step: " << iStep << " of " << (traj.rows() - 1)
+                 << " substate: " << iSubStep << std::endl;
+
+              ss << "     Names:";
+              for (const auto& name : joint_names)
+                ss << " " << name;
+
+              ss << std::endl << "    State: " << subtraj.row(iSubStep) << std::endl;
+
+              CONSOLE_BRIDGE_logError(ss.str().c_str());
+            }
+          }
+
+          if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+            break;
+        }
+
+        if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          break;
+      }
+      else
+      {
+        tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, traj.row(iStep));
+        if (checkTrajectoryState(contacts, manager, state, config))
+        {
+          found = true;
+          if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+          {
+            std::stringstream ss;
+            ss << "Discrete collision detected at step: " << iStep << " of " << (traj.rows() - 1) << std::endl;
+
+            ss << "     Names:";
+            for (const auto& name : joint_names)
+              ss << " " << name;
+
+            ss << std::endl << "    State: " << traj.row(iStep) << std::endl;
+
+            CONSOLE_BRIDGE_logError(ss.str().c_str());
+          }
+        }
+
+        if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          break;
+      }
+    }
+  }
+  else
+  {
+    contacts.reserve(static_cast<size_t>(traj.rows()));
+    for (int iStep = 0; iStep < traj.rows(); ++iStep)
+    {
+      tesseract_environment::EnvState::Ptr state = state_solver.getState(joint_names, traj.row(iStep));
+      if (checkTrajectoryState(contacts, manager, state, config))
+      {
+        found = true;
+        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        {
+          std::stringstream ss;
+          ss << "Discrete collision detected at step: " << iStep << " of " << (traj.rows() - 1) << std::endl;
+
+          ss << "     Names:";
+          for (const auto& name : joint_names)
+            ss << " " << name;
+
+          ss << std::endl << "    State0: " << traj.row(iStep) << std::endl;
+
+          CONSOLE_BRIDGE_logError(ss.str().c_str());
+        }
+      }
+
+      if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+        break;
+    }
+  }
+  return found;
+}
+
+}  // namespace tesseract_environment

--- a/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -2128,12 +2128,48 @@ void runEnvCloneTest()
     EXPECT_EQ(history[i]->getType(), clone_history[i]->getType());
   }
 
-  // Check active links
-  std::vector<std::string> active_link_names = env->getActiveLinkNames();
-  std::vector<std::string> clone_active_link_names = clone->getActiveLinkNames();
-  for (const auto& name : active_link_names)
-    EXPECT_TRUE(std::find(clone_active_link_names.begin(), clone_active_link_names.end(), name) !=
-                clone_active_link_names.end());
+  {
+    // Check active links
+    std::vector<std::string> active_link_names = env->getActiveLinkNames();
+    std::vector<std::string> clone_active_link_names = clone->getActiveLinkNames();
+    EXPECT_EQ(active_link_names.size(), clone_active_link_names.size());
+    for (const auto& name : active_link_names)
+      EXPECT_TRUE(std::find(clone_active_link_names.begin(), clone_active_link_names.end(), name) !=
+                  clone_active_link_names.end());
+
+    // Check static links
+    std::vector<std::string> static_link_names = env->getStaticLinkNames();
+    std::vector<std::string> clone_static_link_names = clone->getStaticLinkNames();
+    EXPECT_EQ(static_link_names.size(), clone_static_link_names.size());
+    for (const auto& name : static_link_names)
+      EXPECT_TRUE(std::find(clone_static_link_names.begin(), clone_static_link_names.end(), name) !=
+                  clone_static_link_names.end());
+  }
+  {
+    // Check active links with joint names
+    std::vector<std::string> active_link_names = env->getActiveLinkNames(env->getActiveJointNames());
+    EXPECT_TRUE(tesseract_common::isIdentical(active_link_names, env->getActiveLinkNames(), false));
+
+    std::vector<std::string> clone_active_link_names = clone->getActiveLinkNames(env->getActiveJointNames());
+    EXPECT_TRUE(tesseract_common::isIdentical(clone_active_link_names, clone->getActiveLinkNames(), false));
+
+    EXPECT_EQ(active_link_names.size(), clone_active_link_names.size());
+    for (const auto& name : active_link_names)
+      EXPECT_TRUE(std::find(clone_active_link_names.begin(), clone_active_link_names.end(), name) !=
+                  clone_active_link_names.end());
+
+    // Check static links with joint names
+    std::vector<std::string> static_link_names = env->getStaticLinkNames(env->getActiveJointNames());
+    EXPECT_TRUE(tesseract_common::isIdentical(static_link_names, env->getStaticLinkNames(), false));
+
+    std::vector<std::string> clone_static_link_names = clone->getStaticLinkNames(env->getActiveJointNames());
+    EXPECT_TRUE(tesseract_common::isIdentical(clone_static_link_names, clone->getStaticLinkNames(), false));
+
+    EXPECT_EQ(static_link_names.size(), clone_static_link_names.size());
+    for (const auto& name : static_link_names)
+      EXPECT_TRUE(std::find(clone_static_link_names.begin(), clone_static_link_names.end(), name) !=
+                  clone_static_link_names.end());
+  }
 
   // Check active joints
   std::vector<std::string> active_joint_names = env->getActiveJointNames();

--- a/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/graph.h
@@ -422,11 +422,19 @@ public:
   std::vector<std::string> getLinkChildrenNames(const std::string& name) const;
 
   /**
-   * @brief Get all children for a given link name
-   * @param name Name of Link
+   * @brief Get all children link names for a given joint name
+   * @param name Name of joint
    * @return A vector of child link names
    */
   std::vector<std::string> getJointChildrenNames(const std::string& name) const;
+
+  /**
+   * @brief Get all children link names for the given joint names
+   * @todo Need to create custom vistor so already process joint_names do not get processed again.
+   * @param names Name of joints
+   * @return A vector of child link names
+   */
+  std::vector<std::string> getJointChildrenNames(const std::vector<std::string>& names) const;
 
   /**
    * @brief Saves Graph as Graph Description Language (DOT)

--- a/tesseract_scene_graph/src/graph.cpp
+++ b/tesseract_scene_graph/src/graph.cpp
@@ -551,6 +551,18 @@ std::vector<std::string> SceneGraph::getJointChildrenNames(const std::string& na
   return getLinkChildrenHelper(v);  // NOLINT
 }
 
+std::vector<std::string> SceneGraph::getJointChildrenNames(const std::vector<std::string>& names) const
+{
+  std::set<std::string> link_names;
+  for (const auto& name : names)
+  {
+    std::vector<std::string> joint_children = getJointChildrenNames(name);
+    link_names.insert(joint_children.begin(), joint_children.end());
+  }
+
+  return std::vector<std::string>(link_names.begin(), link_names.end());
+}
+
 void SceneGraph::saveDOT(const std::string& path) const
 {
   std::ofstream dot_file(path);


### PR DESCRIPTION
This adds the following

- Update Environment to get active link names provided a list of joint. This is used by motion planning to determine what links are active for a given manipulator.
- Update Environment to static link names and static link names provided a list of joints
- A utility function which uses active and static link names to generate a list of possible contact pairs.