### PR TITLE
Feature/write urdf

### DIFF
--- a/.github/workflows/windows_noetic_build.yml
+++ b/.github/workflows/windows_noetic_build.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         choco sources add -n=roswin -s https://aka.ms/ros/public --priority 1
         choco install ros-%ROS_DISTRO%-desktop_full -y --no-progress
+        vcpkg install pcl:x64-windows-static
 
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
         call "C:\opt\ros\%ROS_DISTRO%\x64\setup.bat"

--- a/.github/workflows/windows_noetic_build.yml
+++ b/.github/workflows/windows_noetic_build.yml
@@ -25,7 +25,6 @@ jobs:
       run: |
         choco sources add -n=roswin -s https://aka.ms/ros/public --priority 1
         choco install ros-%ROS_DISTRO%-desktop_full -y --no-progress
-        vcpkg install pcl:x64-windows-static
 
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
         call "C:\opt\ros\%ROS_DISTRO%\x64\setup.bat"

--- a/tesseract_geometry/include/tesseract_geometry/geometries.h
+++ b/tesseract_geometry/include/tesseract_geometry/geometries.h
@@ -27,43 +27,46 @@
 #define TESSERACT_GEOMETRY_GEOMETRIES_H
 
 #include <tesseract_geometry/impl/box.h>
-#include <tesseract_geometry/impl/sphere.h>
-#include <tesseract_geometry/impl/cylinder.h>
 #include <tesseract_geometry/impl/capsule.h>
 #include <tesseract_geometry/impl/cone.h>
-#include <tesseract_geometry/impl/plane.h>
-#include <tesseract_geometry/impl/mesh.h>
 #include <tesseract_geometry/impl/convex_mesh.h>
+#include <tesseract_geometry/impl/cylinder.h>
+#include <tesseract_geometry/impl/mesh.h>
 #include <tesseract_geometry/impl/octree.h>
+#include <tesseract_geometry/impl/plane.h>
+#include <tesseract_geometry/impl/polygon_mesh.h>
 #include <tesseract_geometry/impl/sdf_mesh.h>
+#include <tesseract_geometry/impl/sphere.h>
 
 #ifdef SWIG
 
 %shared_factory(
     tesseract_geometry::Geometry,
     tesseract_geometry::Box,
-	tesseract_geometry::Capsule,
-	tesseract_geometry::Cone,
-	tesseract_geometry::ConvexMesh,
-	tesseract_geometry::Cylinder,
-	tesseract_geometry::Mesh,
-	tesseract_geometry::Octree,
-	tesseract_geometry::Plane,
-	tesseract_geometry::SDFMesh,
-	tesseract_geometry::Sphere
+    tesseract_geometry::Capsule,
+    tesseract_geometry::Cone,
+    tesseract_geometry::ConvexMesh,
+    tesseract_geometry::Cylinder,
+    tesseract_geometry::Mesh,
+    tesseract_geometry::Octree,
+    tesseract_geometry::Plane,
+    tesseract_geometry::PolygonMesh,
+    tesseract_geometry::SDFMesh,
+    tesseract_geometry::Sphere
 )
 
 %include <tesseract_geometry/impl/box.h>
-%include <tesseract_geometry/impl/sphere.h>
-%include <tesseract_geometry/impl/cylinder.h>
 %include <tesseract_geometry/impl/capsule.h>
 %include <tesseract_geometry/impl/cone.h>
-%include <tesseract_geometry/impl/plane.h>
-%include <tesseract_geometry/impl/mesh_material.h>
-%include <tesseract_geometry/impl/mesh.h>
 %include <tesseract_geometry/impl/convex_mesh.h>
+%include <tesseract_geometry/impl/cylinder.h>
+%include <tesseract_geometry/impl/mesh.h>
+%include <tesseract_geometry/impl/mesh_material.h>
 %include <tesseract_geometry/impl/octree.h>
+%include <tesseract_geometry/impl/plane.h>
+%include <tesseract_geometry/impl/polygon_mesh.h>
 %include <tesseract_geometry/impl/sdf_mesh.h>
+%include <tesseract_geometry/impl/sphere.h>
 
 #endif  // SWIG
 

--- a/tesseract_geometry/include/tesseract_geometry/geometry.h
+++ b/tesseract_geometry/include/tesseract_geometry/geometry.h
@@ -49,7 +49,7 @@ enum GeometryType
   MESH,
   CONVEX_MESH,
   SDF_MESH,
-  OCTREE
+  OCTREE,
 };
 static const std::vector<std::string> GeometryTypeStrings = {
   "SPHERE", "CYLINDER", "CAPSULE", "CONE", "BOX", "PLANE", "MESH", "CONVEX_MESH", "SDF_MESH", "OCTREE"

--- a/tesseract_geometry/include/tesseract_geometry/impl/convex_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/convex_mesh.h
@@ -45,7 +45,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_geometry
 {
-
 class ConvexMesh : public PolygonMesh
 {
 public:
@@ -77,17 +76,16 @@ public:
              std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
              MeshMaterial::Ptr mesh_material = nullptr,
              std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : PolygonMesh(vertices,
-                  faces,
-                  resource,
-                  scale,
-                  normals,
-                  vertex_colors,
-                  mesh_material,
-                  mesh_textures,
+    : PolygonMesh(std::move(vertices),
+                  std::move(faces),
+                  std::move(resource),
+                  std::move(scale),
+                  std::move(normals),
+                  std::move(vertex_colors),
+                  std::move(mesh_material),
+                  std::move(mesh_textures),
                   GeometryType::CONVEX_MESH)
   {
-    return;
   }
 
   /**
@@ -108,26 +106,25 @@ public:
    * @param mesh_textures A vector of MeshTexture to apply to the mesh (optional)
    */
   ConvexMesh(std::shared_ptr<const tesseract_common::VectorVector3d> vertices,
-              std::shared_ptr<const Eigen::VectorXi> faces,
-              int face_count,
-              tesseract_common::Resource::Ptr resource = nullptr,
-              Eigen::Vector3d scale = Eigen::Vector3d(1, 1, 1),
-              std::shared_ptr<const tesseract_common::VectorVector3d> normals = nullptr,
-              std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
-              MeshMaterial::Ptr mesh_material = nullptr,
-              std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : PolygonMesh(vertices,
-                  faces,
+             std::shared_ptr<const Eigen::VectorXi> faces,
+             int face_count,
+             tesseract_common::Resource::Ptr resource = nullptr,
+             Eigen::Vector3d scale = Eigen::Vector3d(1, 1, 1),
+             std::shared_ptr<const tesseract_common::VectorVector3d> normals = nullptr,
+             std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
+             MeshMaterial::Ptr mesh_material = nullptr,
+             std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
+    : PolygonMesh(std::move(vertices),
+                  std::move(faces),
                   face_count,
-                  resource,
-                  scale,
-                  normals,
-                  vertex_colors,
-                  mesh_material,
-                  mesh_textures,
+                  std::move(resource),
+                  std::move(scale),
+                  std::move(normals),
+                  std::move(vertex_colors),
+                  std::move(mesh_material),
+                  std::move(mesh_textures),
                   GeometryType::CONVEX_MESH)
   {
-    return;
   }
 
   ~ConvexMesh() override = default;
@@ -144,6 +141,6 @@ public:
 private:
 };
 
-} // namespace tesseract_geometry
+}  // namespace tesseract_geometry
 
 #endif

--- a/tesseract_geometry/include/tesseract_geometry/impl/convex_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/convex_mesh.h
@@ -33,9 +33,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_geometry/geometry.h>
-#include <tesseract_common/types.h>
-#include <tesseract_common/resource.h>
 #include <tesseract_geometry/impl/mesh_material.h>
+#include <tesseract_geometry/impl/polygon_mesh.h>
+#include <tesseract_common/resource.h>
+#include <tesseract_common/types.h>
 
 #ifdef SWIG
 %shared_ptr(tesseract_geometry::ConvexMesh)
@@ -44,7 +45,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_geometry
 {
-class ConvexMesh : public Geometry
+
+class ConvexMesh : public PolygonMesh
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -55,10 +57,11 @@ public:
   /**
    * @brief Convex Mesh geometry
    * @param vertices A vector of vertices associated with the mesh
-   * @param faces A vector of face indices where the first indice indicates the number of vertices associated
-   *              with the face followed by the vertice index in parameter vertices. For example a triangle
-   *              has three vertices so there should be four inputs where the first should be 3 indicating there are
-   *              three vertices that define this face followed by three indices.
+   * @param faces A vector of face indices, where the first number indicates the number of vertices
+   *              associated with the face, followed by the vertex index in parameter vertices. For
+   *              example, a triangle has three vertices, so there should be four inputs, where the
+   *              first should be 3, indicating there are three vertices that define this face,
+   *              followed by three indices.
    * @param resource A resource locator for locating resource
    * @param scale Scale the mesh
    * @param normals A vector of normals for the vertices (optional)
@@ -74,63 +77,57 @@ public:
              std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
              MeshMaterial::Ptr mesh_material = nullptr,
              std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : Geometry(GeometryType::CONVEX_MESH)
-    , vertices_(std::move(vertices))
-    , faces_(std::move(faces))
-    , resource_(std::move(resource))
-    , scale_(std::move(scale))
-    , normals_(std::move(normals))
-    , vertex_colors_(std::move(vertex_colors))
-    , mesh_material_(std::move(mesh_material))
-    , mesh_textures_(std::move(mesh_textures))
+    : PolygonMesh(vertices,
+                  faces,
+                  resource,
+                  scale,
+                  normals,
+                  vertex_colors,
+                  mesh_material,
+                  mesh_textures,
+                  GeometryType::CONVEX_MESH)
   {
-    vertice_count_ = static_cast<int>(vertices_->size());
-
-    face_count_ = 0;
-    for (int i = 0; i < faces_->size(); ++i)
-    {
-      ++face_count_;
-      int num_verts = (*faces_)(i);
-      i += num_verts;
-    }
+    return;
   }
 
   /**
    * @brief Convex Mesh geometry
    * @param vertices A vector of vertices associated with the mesh
-   * @param faces A vector of face indices where the first indice indicates the number of vertices associated
-   *              with the face followed by the vertice index in parameter vertices. For example a triangle
-   *              has three vertices so there should be four inputs where the first should be 3 indicating there are
-   *              three vertices that define this face followed by three indices.
-   * @param face_count Provide the number of faces. This is faster because it does not need to loop over triangles.
+   * @param faces A vector of face indices, where the first number indicates the number of vertices
+   *              associated with the face, followed by the vertex index in parameter vertices. For
+   *              example, a triangle has three vertices, so there should be four inputs, where the
+   *              first should be 3, indicating there are three vertices that define this face,
+   *              followed by three indices.
+   * @param face_count Provide the number of faces. This is faster because it does not need to loop
+   *                   over the faces.
    * @param resource A resource locator for locating resource
    * @param scale Scale the mesh
    * @param normals A vector of normals for the vertices (optional)
    * @param vertex_colors A vector of colors (RGBA) for the vertices (optional)
-   * @param mesh_material A MeshMaterial describing the color and material properties of the mesh (optional)
+   * @param mesh_material Describes the color and material properties of the mesh (optional)
    * @param mesh_textures A vector of MeshTexture to apply to the mesh (optional)
    */
   ConvexMesh(std::shared_ptr<const tesseract_common::VectorVector3d> vertices,
-             std::shared_ptr<const Eigen::VectorXi> faces,
-             int face_count,
-             tesseract_common::Resource::Ptr resource = nullptr,
-             Eigen::Vector3d scale = Eigen::Vector3d(1, 1, 1),
-             std::shared_ptr<const tesseract_common::VectorVector3d> normals = nullptr,
-             std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
-             MeshMaterial::Ptr mesh_material = nullptr,
-             std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : Geometry(GeometryType::CONVEX_MESH)
-    , vertices_(std::move(vertices))
-    , faces_(std::move(faces))
-    , face_count_(face_count)
-    , resource_(std::move(resource))
-    , scale_(std::move(scale))
-    , normals_(std::move(normals))
-    , vertex_colors_(std::move(vertex_colors))
-    , mesh_material_(std::move(mesh_material))
-    , mesh_textures_(std::move(mesh_textures))
+              std::shared_ptr<const Eigen::VectorXi> faces,
+              int face_count,
+              tesseract_common::Resource::Ptr resource = nullptr,
+              Eigen::Vector3d scale = Eigen::Vector3d(1, 1, 1),
+              std::shared_ptr<const tesseract_common::VectorVector3d> normals = nullptr,
+              std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
+              MeshMaterial::Ptr mesh_material = nullptr,
+              std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
+    : PolygonMesh(vertices,
+                  faces,
+                  face_count,
+                  resource,
+                  scale,
+                  normals,
+                  vertex_colors,
+                  mesh_material,
+                  mesh_textures,
+                  GeometryType::CONVEX_MESH)
   {
-    vertice_count_ = static_cast<int>(vertices_->size());
+    return;
   }
 
   ~ConvexMesh() override = default;
@@ -139,102 +136,14 @@ public:
   ConvexMesh(ConvexMesh&&) = delete;
   ConvexMesh& operator=(ConvexMesh&&) = delete;
 
-  /**
-   * @brief Get convex mesh vertices
-   * @return A vector of vertices
-   */
-  const std::shared_ptr<const tesseract_common::VectorVector3d>& getVertices() const { return vertices_; }
-
-  /**
-   * @brief Get convex mesh faces
-   * @return A vector of face indices
-   */
-  const std::shared_ptr<const Eigen::VectorXi>& getFaces() const { return faces_; }
-
-  /**
-   * @brief Get vertice count
-   * @return Number of vertices
-   */
-  int getVerticeCount() const { return vertice_count_; }
-
-  /**
-   * @brief Get face count
-   * @return Number of triangles
-   */
-  int getFaceCount() const { return face_count_; }
-
-  /**
-   * @brief Get the path to file used to generate the mesh
-   *
-   * Note: If empty, assume it was manually generated.
-   *
-   * @return Absolute path to the mesh file
-   */
-  const tesseract_common::Resource::Ptr getResource() const { return resource_; }
-
-  /**
-   * @brief Get the scale applied to file used to generate the mesh
-   * @return The scale x, y, z
-   */
-  const Eigen::Vector3d& getScale() const { return scale_; }
-
-  /**
-   * @brief Get the vertice normal vectors
-   *
-   * Optional, may be nullptr
-   *
-   * @return The vertice normal vector
-   */
-  std::shared_ptr<const tesseract_common::VectorVector3d> getNormals() const { return normals_; }
-
-  /**
-   * @brief Get the vertex colors
-   *
-   * Optional, may be nullptr
-   *
-   * @return Vertex colors
-   */
-  std::shared_ptr<const tesseract_common::VectorVector4d> getVertexColors() const { return vertex_colors_; }
-
-  /**
-   * @brief Get material data extracted from the mesh file
-   *
-   * Mesh files contain material information. The mesh parser will
-   * extract the material information and store it in a MeshMaterial structure.
-   *
-   * @return The MeshMaterial data extracted from mesh file
-   */
-  MeshMaterial::ConstPtr getMaterial() const { return mesh_material_; }
-
-  /**
-   * @brief Get textures extracted from the mesh file
-   *
-   * Mesh files contain (or reference) image files that form textures on the surface
-   * of the mesh. UV coordinates specify how the image is applied to the mesh. The
-   * MeshTexture structure contains a resource to the image, and the UV coordinates.
-   * Currently only jpg and png image formats are supported.
-   *
-   * @return Vector of mesh textures
-   */
-  std::shared_ptr<const std::vector<MeshTexture::Ptr>> getTextures() const { return mesh_textures_; }
-
   Geometry::Ptr clone() const override
   {
-    return std::make_shared<ConvexMesh>(vertices_, faces_, face_count_, resource_, scale_);
+    return std::make_shared<ConvexMesh>(getVertices(), getFaces(), getFaceCount(), getResource(), getScale());
   }
 
 private:
-  std::shared_ptr<const tesseract_common::VectorVector3d> vertices_;
-  std::shared_ptr<const Eigen::VectorXi> faces_;
-
-  int vertice_count_;
-  int face_count_;
-  tesseract_common::Resource::Ptr resource_;
-  Eigen::Vector3d scale_;
-  std::shared_ptr<const tesseract_common::VectorVector3d> normals_;
-  std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors_;
-  MeshMaterial::Ptr mesh_material_;
-  std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures_;
 };
-}  // namespace tesseract_geometry
+
+} // namespace tesseract_geometry
+
 #endif

--- a/tesseract_geometry/include/tesseract_geometry/impl/mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/mesh.h
@@ -33,9 +33,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_geometry/geometry.h>
 #include <tesseract_common/types.h>
+#include <tesseract_geometry/geometry.h>
 #include <tesseract_geometry/impl/mesh_material.h>
+#include <tesseract_geometry/impl/polygon_mesh.h>
 
 #ifdef SWIG
 %shared_ptr(tesseract_geometry::Mesh)
@@ -44,7 +45,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_geometry
 {
-class Mesh : public Geometry
+class Mesh : public PolygonMesh
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -74,33 +75,28 @@ public:
        std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
        MeshMaterial::Ptr mesh_material = nullptr,
        std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : Geometry(GeometryType::MESH)
-    , vertices_(std::move(vertices))
-    , triangles_(std::move(triangles))
-    , resource_(std::move(resource))
-    , scale_(std::move(scale))
-    , normals_(std::move(normals))
-    , vertex_colors_(std::move(vertex_colors))
-    , mesh_material_(std::move(mesh_material))
-    , mesh_textures_(std::move(mesh_textures))
+    : PolygonMesh(vertices,
+                  triangles,
+                  resource,
+                  scale,
+                  normals,
+                  vertex_colors,
+                  mesh_material,
+                  mesh_textures,
+                  GeometryType::MESH)
   {
-    vertice_count_ = static_cast<int>(vertices_->size());
-
-    triangle_count_ = 0;
-    for (int i = 0; i < triangles_->size(); ++i)
+    if ((getFaceCount() * 4) != getFaces()->size())
     {
-      ++triangle_count_;
-      int num_verts = (*triangles_)(i);
-      i += num_verts;
-      assert(num_verts == 3);
+      std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
     }
+    return;
   }
 
   /**
    * @brief Mesh geometry
    * @param vertices A vector of vertices associated with the mesh
    * @param triangles A vector of face indices where the first indice indicates the number of vertices associated
-   *                  with the face followed by the vertice index in parameter vertices. For example a triangle
+   *                  with the face followed by the vertex index in parameter vertices. For example a triangle
    *                  has three vertices so there should be four inputs where the first should be 3 indicating there are
    *                  three vertices that define this face followed by three indices.
    * @param triangle_count Provide the number of faces. This is faster because it does not need to loop over triangles.
@@ -120,19 +116,22 @@ public:
        std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
        MeshMaterial::Ptr mesh_material = nullptr,
        std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : Geometry(GeometryType::MESH)
-    , vertices_(std::move(vertices))
-    , triangles_(std::move(triangles))
-    , triangle_count_(triangle_count)
-    , resource_(std::move(resource))
-    , scale_(std::move(scale))
-    , normals_(std::move(normals))
-    , vertex_colors_(std::move(vertex_colors))
-    , mesh_material_(std::move(mesh_material))
-    , mesh_textures_(std::move(mesh_textures))
+    : PolygonMesh(vertices,
+                  triangles,
+                  triangle_count,
+                  resource,
+                  scale,
+                  normals,
+                  vertex_colors,
+                  mesh_material,
+                  mesh_textures,
+                  GeometryType::MESH)
   {
-    vertice_count_ = static_cast<int>(vertices_->size());
-    assert((triangle_count_ * 4) == triangles_->size());
+    if ((getFaceCount() * 4) != getFaces()->size())
+    {
+      std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
+    }
+    return;
   }
 
   ~Mesh() override = default;
@@ -142,108 +141,33 @@ public:
   Mesh& operator=(Mesh&&) = delete;
 
   /**
-   * @brief Get mesh vertices
-   * @return A vector of vertices
-   */
-  const std::shared_ptr<const tesseract_common::VectorVector3d>& getVertices() const { return vertices_; }
-
-  /**
    * @brief Get mesh Triangles
    * @return A vector of triangle indices
    */
-  const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const { return triangles_; }
-
-  /**
-   * @brief Get vertice count
-   * @return Number of vertices
-   */
-  int getVerticeCount() const { return vertice_count_; }
+  [[deprecated ("Please use getFaces() instead")]]
+  const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const { return getFaces(); }
 
   /**
    * @brief Get triangle count
    * @return Number of triangles
    */
-  int getTriangleCount() const { return triangle_count_; }
-
-  /**
-   * @brief Get the path to file used to generate the mesh
-   *
-   * Note: If empty, assume it was manually generated.
-   *
-   * @return Absolute path to the mesh file
-   */
-  const tesseract_common::Resource::Ptr getResource() const { return resource_; }
-
-  /**
-   * @brief Get the scale applied to file used to generate the mesh
-   * @return The scale x, y, z
-   */
-  const Eigen::Vector3d& getScale() const { return scale_; }
-
-  /**
-   * @brief Get the vertice normal vectors
-   *
-   * Optional, may be nullptr
-   *
-   * @return The vertice normal vector
-   */
-  const std::shared_ptr<const tesseract_common::VectorVector3d>& getNormals() const { return normals_; }
-
-  /**
-   * @brief Get the vertex colors
-   *
-   * Optional, may be nullptr
-   *
-   * @return Vertex colors
-   */
-  const std::shared_ptr<const tesseract_common::VectorVector4d>& getVertexColors() const { return vertex_colors_; }
-
-  /**
-   * @brief Get material data extracted from the mesh file
-   *
-   * Mesh files contain material information. The mesh parser will
-   * extract the material information and store it in a MeshMaterial structure.
-   *
-   * @return The MeshMaterial data extracted from mesh file
-   */
-  MeshMaterial::ConstPtr getMaterial() const { return mesh_material_; }
-
-  /**
-   * @brief Get textures extracted from the mesh file
-   *
-   * Mesh files contain (or reference) image files that form textures on the surface
-   * of the mesh. UV coordinates specify how the image is applied to the mesh. The
-   * MeshTexture structure contains a resource to the image, and the UV coordinates.
-   * Currently only jpg and png image formats are supported.
-   *
-   * @return Vector of mesh textures
-   */
-  const std::shared_ptr<const std::vector<MeshTexture::Ptr>>& getTextures() const { return mesh_textures_; }
+  [[deprecated ("Please use getFaceCount() instead")]]
+  int getTriangleCount() const { return getFaceCount(); }
 
   Geometry::Ptr clone() const override
   {
-    return std::make_shared<Mesh>(vertices_,
-                                  triangles_,
-                                  triangle_count_,
-                                  resource_,
-                                  scale_,
-                                  normals_,
-                                  vertex_colors_,
-                                  mesh_material_,
-                                  mesh_textures_);
+    return std::make_shared<Mesh>(getVertices(),
+                                  getFaces(),
+                                  getFaceCount(),
+                                  getResource(),
+                                  getScale(),
+                                  getNormals(),
+                                  getVertexColors(),
+                                  MeshMaterial::Ptr(new MeshMaterial(*getMaterial())),
+                                  getTextures());
   }
 
 private:
-  std::shared_ptr<const tesseract_common::VectorVector3d> vertices_;
-  std::shared_ptr<const Eigen::VectorXi> triangles_;
-  int vertice_count_;
-  int triangle_count_;
-  tesseract_common::Resource::Ptr resource_;
-  Eigen::Vector3d scale_;
-  std::shared_ptr<const tesseract_common::VectorVector3d> normals_;
-  std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors_;
-  MeshMaterial::Ptr mesh_material_;
-  std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures_;
 };
 }  // namespace tesseract_geometry
 #endif

--- a/tesseract_geometry/include/tesseract_geometry/impl/mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/mesh.h
@@ -75,21 +75,20 @@ public:
        std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
        MeshMaterial::Ptr mesh_material = nullptr,
        std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : PolygonMesh(vertices,
-                  triangles,
-                  resource,
-                  scale,
-                  normals,
-                  vertex_colors,
-                  mesh_material,
-                  mesh_textures,
+    : PolygonMesh(std::move(vertices),
+                  std::move(triangles),
+                  std::move(resource),
+                  std::move(scale),
+                  std::move(normals),
+                  std::move(vertex_colors),
+                  std::move(mesh_material),
+                  std::move(mesh_textures),
                   GeometryType::MESH)
   {
     if ((getFaceCount() * 4) != getFaces()->size())
     {
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
     }
-    return;
   }
 
   /**
@@ -116,22 +115,21 @@ public:
        std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
        MeshMaterial::Ptr mesh_material = nullptr,
        std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : PolygonMesh(vertices,
-                  triangles,
+    : PolygonMesh(std::move(vertices),
+                  std::move(triangles),
                   triangle_count,
-                  resource,
-                  scale,
-                  normals,
-                  vertex_colors,
-                  mesh_material,
-                  mesh_textures,
+                  std::move(resource),
+                  std::move(scale),
+                  std::move(normals),
+                  std::move(vertex_colors),
+                  std::move(mesh_material),
+                  std::move(mesh_textures),
                   GeometryType::MESH)
   {
     if ((getFaceCount() * 4) != getFaces()->size())
     {
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
     }
-    return;
   }
 
   ~Mesh() override = default;
@@ -144,27 +142,46 @@ public:
    * @brief Get mesh Triangles
    * @return A vector of triangle indices
    */
-  [[deprecated ("Please use getFaces() instead")]]
-  const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const { return getFaces(); }
+  [[deprecated("Please use getFaces() instead")]] const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const
+  {
+    return getFaces();
+  }
 
   /**
    * @brief Get triangle count
    * @return Number of triangles
    */
-  [[deprecated ("Please use getFaceCount() instead")]]
-  int getTriangleCount() const { return getFaceCount(); }
+  [[deprecated("Please use getFaceCount() instead")]] int getTriangleCount() const { return getFaceCount(); }
 
   Geometry::Ptr clone() const override
   {
-    return std::make_shared<Mesh>(getVertices(),
-                                  getFaces(),
-                                  getFaceCount(),
-                                  getResource(),
-                                  getScale(),
-                                  getNormals(),
-                                  getVertexColors(),
-                                  MeshMaterial::Ptr(new MeshMaterial(*getMaterial())),
-                                  getTextures());
+    // getMaterial returns a pointer-to-const, so dereference and make_shared, but also guard against nullptr
+    std::shared_ptr<Mesh> ptr;
+    if (getMaterial() != nullptr)
+    {
+      ptr = std::make_shared<Mesh>(getVertices(),
+                                   getFaces(),
+                                   getFaceCount(),
+                                   getResource(),
+                                   getScale(),
+                                   getNormals(),
+                                   getVertexColors(),
+                                   std::make_shared<MeshMaterial>(*getMaterial()),
+                                   getTextures());
+    }
+    else
+    {
+      ptr = std::make_shared<Mesh>(getVertices(),
+                                   getFaces(),
+                                   getFaceCount(),
+                                   getResource(),
+                                   getScale(),
+                                   getNormals(),
+                                   getVertexColors(),
+                                   nullptr,
+                                   getTextures());
+    }
+    return ptr;
   }
 
 private:

--- a/tesseract_geometry/include/tesseract_geometry/impl/octree.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/octree.h
@@ -73,7 +73,10 @@ public:
       ot->updateNode(point.x, point.y, point.z, true);
 
     if (prune)
+    {
       tesseract_geometry::Octree::prune(*ot);
+      pruned_ = prune;
+    }
 
     octree_ = ot;
   }
@@ -89,6 +92,8 @@ public:
   const std::shared_ptr<const octomap::OcTree>& getOctree() const { return octree_; }
 #endif  // SWIG
   SubType getSubType() const { return sub_type_; }
+
+  bool getPruned() const { return pruned_; }
 
   Geometry::Ptr clone() const override { return std::make_shared<Octree>(octree_, sub_type_); }
 
@@ -120,6 +125,7 @@ public:
 private:
   std::shared_ptr<const octomap::OcTree> octree_;
   SubType sub_type_;
+  bool pruned_;
 
   static bool isNodeCollapsible(octomap::OcTree& octree, octomap::OcTreeNode* node)
   {

--- a/tesseract_geometry/include/tesseract_geometry/impl/polygon_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/polygon_mesh.h
@@ -1,0 +1,255 @@
+/**
+ * @file polygon_mesh.h
+ * @brief Tesseract Polygon Mesh Geometry
+ *
+ * @author David Merz, Jr.
+ * @date September 9, 2021
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2017, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_GEOMETRY_POLYGON_MESH_H
+#define TESSERACT_GEOMETRY_POLYGON_MESH_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <Eigen/Geometry>
+#include <memory>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_geometry/geometry.h>
+#include <tesseract_common/types.h>
+#include <tesseract_common/resource.h>
+#include <tesseract_geometry/impl/mesh_material.h>
+
+#ifdef SWIG
+%shared_ptr(tesseract_geometry::PolygonMesh)
+%template(PolygonMeshVector) std::vector<std::shared_ptr<tesseract_geometry::PolygonMesh> >;
+#endif  // SWIG
+
+namespace tesseract_geometry
+{
+class PolygonMesh : public Geometry
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  using Ptr = std::shared_ptr<PolygonMesh>;
+  using ConstPtr = std::shared_ptr<const PolygonMesh>;
+
+  /**
+   * @brief Polygon Mesh geometry
+   * @param vertices A vector of vertices associated with the mesh
+   * @param faces A vector of face indices, where the first number indicates the number of vertices
+   *              associated with the face, followed by the vertex index in parameter vertices. For
+   *              example, a triangle has three vertices, so there should be four inputs, where the
+   *              first should be 3, indicating there are three vertices that define this face,
+   *              followed by three indices.
+   * @param resource A resource locator for locating resource
+   * @param scale Scale the mesh
+   * @param normals A vector of normals for the vertices (optional)
+   * @param vertex_colors A vector of colors (RGBA) for the vertices (optional)
+   * @param mesh_material A MeshMaterial describing the color and material properties of the mesh (optional)
+   * @param mesh_textures A vector of MeshTexture to apply to the mesh (optional)
+   */
+  PolygonMesh(std::shared_ptr<const tesseract_common::VectorVector3d> vertices,
+              std::shared_ptr<const Eigen::VectorXi> faces,
+              tesseract_common::Resource::Ptr resource = nullptr,
+              Eigen::Vector3d scale = Eigen::Vector3d(1, 1, 1),
+              std::shared_ptr<const tesseract_common::VectorVector3d> normals = nullptr,
+              std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
+              MeshMaterial::Ptr mesh_material = nullptr,
+              std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr,
+              GeometryType type = GeometryType::CONVEX_MESH)
+    : Geometry(type)
+    , vertices_(std::move(vertices))
+    , faces_(std::move(faces))
+    , resource_(std::move(resource))
+    , scale_(std::move(scale))
+    , normals_(std::move(normals))
+    , vertex_colors_(std::move(vertex_colors))
+    , mesh_material_(std::move(mesh_material))
+    , mesh_textures_(std::move(mesh_textures))
+  {
+    vertex_count_ = static_cast<int>(vertices_->size());
+
+    face_count_ = 0;
+    for (int i = 0; i < faces_->size(); ++i)
+    {
+      ++face_count_;
+      int num_verts = (*faces_)(i);
+      i += num_verts;
+    }
+  }
+
+  /**
+   * @brief Polygon Mesh geometry
+   * @param vertices A vector of vertices associated with the mesh
+   * @param faces A vector of face indices, where the first number indicates the number of vertices
+   *              associated with the face, followed by the vertex index in parameter vertices. For
+   *              example, a triangle has three vertices, so there should be four inputs, where the
+   *              first should be 3, indicating there are three vertices that define this face,
+   *              followed by three indices.
+   * @param face_count Provide the number of faces. This is faster because it does not need to loop
+   *                   over the faces.
+   * @param resource A resource locator for locating resource
+   * @param scale Scale the mesh
+   * @param normals A vector of normals for the vertices (optional)
+   * @param vertex_colors A vector of colors (RGBA) for the vertices (optional)
+   * @param mesh_material Describes the color and material properties of the mesh (optional)
+   * @param mesh_textures A vector of MeshTexture to apply to the mesh (optional)
+   */
+  PolygonMesh(std::shared_ptr<const tesseract_common::VectorVector3d> vertices,
+              std::shared_ptr<const Eigen::VectorXi> faces,
+              int face_count,
+              tesseract_common::Resource::Ptr resource = nullptr,
+              Eigen::Vector3d scale = Eigen::Vector3d(1, 1, 1),
+              std::shared_ptr<const tesseract_common::VectorVector3d> normals = nullptr,
+              std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
+              MeshMaterial::Ptr mesh_material = nullptr,
+              std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr,
+              GeometryType type = GeometryType::CONVEX_MESH)
+    : Geometry(type)
+    , vertices_(std::move(vertices))
+    , faces_(std::move(faces))
+    , face_count_(face_count)
+    , resource_(std::move(resource))
+    , scale_(std::move(scale))
+    , normals_(std::move(normals))
+    , vertex_colors_(std::move(vertex_colors))
+    , mesh_material_(std::move(mesh_material))
+    , mesh_textures_(std::move(mesh_textures))
+  {
+    vertex_count_ = static_cast<int>(vertices_->size());
+  }
+
+  ~PolygonMesh() override = default;
+  PolygonMesh(const PolygonMesh&) = delete;
+  PolygonMesh& operator=(const PolygonMesh&) = delete;
+  PolygonMesh(PolygonMesh&&) = delete;
+  PolygonMesh& operator=(PolygonMesh&&) = delete;
+
+  /**
+   * @brief Get Polygon mesh vertices
+   * @return A vector of vertices
+   */
+  const std::shared_ptr<const tesseract_common::VectorVector3d>& getVertices() const { return vertices_; }
+
+  /**
+   * @brief Get Polygon mesh faces
+   * @return A vector of face indices
+   */
+  const std::shared_ptr<const Eigen::VectorXi>& getFaces() const { return faces_; }
+
+  /**
+   * @brief Get vertex count
+   * @return Number of vertices
+   */
+  [[deprecated ("Deprecated due to typo.  Please use getVertexCount()")]]
+  int getVerticeCount() const { return getVertexCount(); }
+
+  /**
+   * @brief Get vertex count
+   * @return Number of vertices
+   */
+  int getVertexCount() const { return vertex_count_; }
+
+
+  /**
+   * @brief Get face count
+   * @return Number of faces
+   */
+  int getFaceCount() const { return face_count_; }
+
+  /**
+   * @brief Get the path to file used to generate the mesh
+   *
+   * Note: If empty, assume it was manually generated.
+   *
+   * @return Absolute path to the mesh file
+   */
+  const tesseract_common::Resource::Ptr getResource() const { return resource_; }
+
+  /**
+   * @brief Get the scale applied to file used to generate the mesh
+   * @return The scale x, y, z
+   */
+  const Eigen::Vector3d& getScale() const { return scale_; }
+
+  /**
+   * @brief Get the vertice normal vectors
+   *
+   * Optional, may be nullptr
+   *
+   * @return The vertice normal vector
+   */
+  std::shared_ptr<const tesseract_common::VectorVector3d> getNormals() const { return normals_; }
+
+  /**
+   * @brief Get the vertex colors
+   *
+   * Optional, may be nullptr
+   *
+   * @return Vertex colors
+   */
+  std::shared_ptr<const tesseract_common::VectorVector4d> getVertexColors() const { return vertex_colors_; }
+
+  /**
+   * @brief Get material data extracted from the mesh file
+   *
+   * Mesh files contain material information. The mesh parser will
+   * extract the material information and store it in a MeshMaterial structure.
+   *
+   * @return The MeshMaterial data extracted from mesh file
+   */
+  MeshMaterial::ConstPtr getMaterial() const { return mesh_material_; }
+
+  /**
+   * @brief Get textures extracted from the mesh file
+   *
+   * Mesh files contain (or reference) image files that form textures on the surface
+   * of the mesh. UV coordinates specify how the image is applied to the mesh. The
+   * MeshTexture structure contains a resource to the image, and the UV coordinates.
+   * Currently only jpg and png image formats are supported.
+   *
+   * @return Vector of mesh textures
+   */
+  std::shared_ptr<const std::vector<MeshTexture::Ptr>> getTextures() const { return mesh_textures_; }
+
+  Geometry::Ptr clone() const override
+  {
+    return std::make_shared<PolygonMesh>(vertices_, faces_, face_count_, resource_, scale_);
+  }
+
+private:
+  std::shared_ptr<const tesseract_common::VectorVector3d> vertices_;
+  std::shared_ptr<const Eigen::VectorXi> faces_;
+
+  int vertex_count_;
+  int face_count_;
+  tesseract_common::Resource::Ptr resource_;
+  Eigen::Vector3d scale_;
+  std::shared_ptr<const tesseract_common::VectorVector3d> normals_;
+  std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors_;
+  MeshMaterial::Ptr mesh_material_;
+  std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures_;
+};
+
+}  // namespace tesseract_geometry
+
+#endif // POLYGON_MESH_H

--- a/tesseract_geometry/include/tesseract_geometry/impl/polygon_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/polygon_mesh.h
@@ -160,15 +160,16 @@ public:
    * @brief Get vertex count
    * @return Number of vertices
    */
-  [[deprecated ("Deprecated due to typo.  Please use getVertexCount()")]]
-  int getVerticeCount() const { return getVertexCount(); }
+  [[deprecated("Deprecated due to typo.  Please use getVertexCount()")]] int getVerticeCount() const
+  {
+    return getVertexCount();
+  }
 
   /**
    * @brief Get vertex count
    * @return Number of vertices
    */
   int getVertexCount() const { return vertex_count_; }
-
 
   /**
    * @brief Get face count
@@ -252,4 +253,4 @@ private:
 
 }  // namespace tesseract_geometry
 
-#endif // POLYGON_MESH_H
+#endif  // POLYGON_MESH_H

--- a/tesseract_geometry/include/tesseract_geometry/impl/sdf_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/sdf_mesh.h
@@ -33,9 +33,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_geometry/geometry.h>
-#include <tesseract_common/types.h>
-#include <tesseract_common/resource.h>
 #include <tesseract_geometry/impl/mesh_material.h>
+#include <tesseract_geometry/impl/polygon_mesh.h>
+#include <tesseract_common/resource.h>
+#include <tesseract_common/types.h>
 
 #ifdef SWIG
 %shared_ptr(tesseract_geometry::SDFMesh)
@@ -44,7 +45,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_geometry
 {
-class SDFMesh : public Geometry
+class SDFMesh : public PolygonMesh
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -74,26 +75,21 @@ public:
           std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
           MeshMaterial::Ptr mesh_material = nullptr,
           std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : Geometry(GeometryType::SDF_MESH)
-    , vertices_(std::move(vertices))
-    , triangles_(std::move(triangles))
-    , resource_(std::move(resource))
-    , scale_(std::move(scale))
-    , normals_(std::move(normals))
-    , vertex_colors_(std::move(vertex_colors))
-    , mesh_material_(std::move(mesh_material))
-    , mesh_textures_(std::move(mesh_textures))
+    : PolygonMesh(vertices,
+                  triangles,
+                  resource,
+                  scale,
+                  normals,
+                  vertex_colors,
+                  mesh_material,
+                  mesh_textures,
+                  GeometryType::SDF_MESH)
   {
-    vertice_count_ = static_cast<int>(vertices_->size());
-
-    triangle_count_ = 0;
-    for (int i = 0; i < triangles_->size(); ++i)
+    if ((getFaceCount() * 4) != getFaces()->size())
     {
-      ++triangle_count_;
-      int num_verts = (*triangles_)(i);
-      i += num_verts;
-      assert(num_verts == 3);
+      std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
     }
+    return;
   }
 
   /**
@@ -120,19 +116,22 @@ public:
           std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
           MeshMaterial::Ptr mesh_material = nullptr,
           std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : Geometry(GeometryType::SDF_MESH)
-    , vertices_(std::move(vertices))
-    , triangles_(std::move(triangles))
-    , triangle_count_(triangle_count)
-    , resource_(std::move(resource))
-    , scale_(std::move(scale))
-    , normals_(std::move(normals))
-    , vertex_colors_(std::move(vertex_colors))
-    , mesh_material_(std::move(mesh_material))
-    , mesh_textures_(std::move(mesh_textures))
+    : PolygonMesh(vertices,
+                  triangles,
+                  triangle_count,
+                  resource,
+                  scale,
+                  normals,
+                  vertex_colors,
+                  mesh_material,
+                  mesh_textures,
+                  GeometryType::SDF_MESH)
   {
-    vertice_count_ = static_cast<int>(vertices_->size());
-    assert((triangle_count_ * 4) == triangles_->size());
+    if ((getFaceCount() * 4) != getFaces()->size())
+    {
+      std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
+    }
+    return;
   }
 
   ~SDFMesh() override = default;
@@ -142,101 +141,29 @@ public:
   SDFMesh& operator=(SDFMesh&&) = delete;
 
   /**
-   * @brief Get SDF mesh vertices
-   * @return A vector of vertices
-   */
-  const std::shared_ptr<const tesseract_common::VectorVector3d>& getVertices() const { return vertices_; }
-
-  /**
    * @brief Get SDF mesh Triangles
    * @return A vector of triangle indices
    */
-  const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const { return triangles_; }
-
-  /**
-   * @brief Get vertice count
-   * @return Number of vertices
-   */
-  int getVerticeCount() const { return vertice_count_; }
+  [[deprecated ("Please use getFaces() instead")]]
+  const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const { return getFaces(); }
 
   /**
    * @brief Get triangle count
    * @return Number of triangles
    */
-  int getTriangleCount() const { return triangle_count_; }
-
-  /**
-   * @brief Get the path to file used to generate the mesh
-   *
-   * Note: If empty, assume it was manually generated.
-   *
-   * @return Absolute path to the mesh file
-   */
-  const tesseract_common::Resource::Ptr getResource() const { return resource_; }
-
-  /**
-   * @brief Get the scale applied to file used to generate the mesh
-   * @return The scale x, y, z
-   */
-  const Eigen::Vector3d& getScale() const { return scale_; }
-
-  /**
-   * @brief Get the vertice normal vectors
-   *
-   * Optional, may be nullptr
-   *
-   * @return The vertice normal vector
-   */
-  std::shared_ptr<const tesseract_common::VectorVector3d> getNormals() const { return normals_; }
-
-  /**
-   * @brief Get the vertex colors
-   *
-   * Optional, may be nullptr
-   *
-   * @return Vertex colors
-   */
-  std::shared_ptr<const tesseract_common::VectorVector4d> getVertexColors() const { return vertex_colors_; }
-
-  /**
-   * @brief Get material data extracted from the mesh file
-   *
-   * Mesh files contain material information. The mesh parser will
-   * extract the material information and store it in a MeshMaterial structure.
-   *
-   * @return The MeshMaterial data extracted from mesh file
-   */
-  MeshMaterial::ConstPtr getMaterial() const { return mesh_material_; }
-
-  /**
-   * @brief Get textures extracted from the mesh file
-   *
-   * Mesh files contain (or reference) image files that form textures on the surface
-   * of the mesh. UV coordinates specify how the image is applied to the mesh. The
-   * MeshTexture structure contains a resource to the image, and the UV coordinates.
-   * Currently only jpg and png image formats are supported.
-   *
-   * @return Vector of mesh textures
-   */
-  std::shared_ptr<const std::vector<MeshTexture::Ptr>> getTextures() const { return mesh_textures_; }
+  [[deprecated ("Please use getFaceCount() instead")]]
+  int getTriangleCount() const { return getFaceCount(); }
 
   Geometry::Ptr clone() const override
   {
-    return std::make_shared<SDFMesh>(vertices_, triangles_, triangle_count_, resource_, scale_);
+    return std::make_shared<SDFMesh>(getVertices(),
+                                     getFaces(),
+                                     getFaceCount(),
+                                     getResource(),
+                                     getScale());
   }
 
 private:
-  std::shared_ptr<const tesseract_common::VectorVector3d> vertices_;
-  std::shared_ptr<const Eigen::VectorXi> triangles_;
-
-  int vertice_count_;
-  int triangle_count_;
-  tesseract_common::Resource::Ptr resource_;
-  Eigen::Vector3d scale_;
-  std::shared_ptr<const tesseract_common::VectorVector3d> normals_;
-  std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors_;
-  MeshMaterial::Ptr mesh_material_;
-  std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures_;
 };
 }  // namespace tesseract_geometry
 #endif

--- a/tesseract_geometry/include/tesseract_geometry/impl/sdf_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/sdf_mesh.h
@@ -75,21 +75,20 @@ public:
           std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
           MeshMaterial::Ptr mesh_material = nullptr,
           std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : PolygonMesh(vertices,
-                  triangles,
-                  resource,
-                  scale,
-                  normals,
-                  vertex_colors,
-                  mesh_material,
-                  mesh_textures,
+    : PolygonMesh(std::move(vertices),
+                  std::move(triangles),
+                  std::move(resource),
+                  std::move(scale),
+                  std::move(normals),
+                  std::move(vertex_colors),
+                  std::move(mesh_material),
+                  std::move(mesh_textures),
                   GeometryType::SDF_MESH)
   {
     if ((getFaceCount() * 4) != getFaces()->size())
     {
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
     }
-    return;
   }
 
   /**
@@ -116,22 +115,21 @@ public:
           std::shared_ptr<const tesseract_common::VectorVector4d> vertex_colors = nullptr,
           MeshMaterial::Ptr mesh_material = nullptr,
           std::shared_ptr<const std::vector<MeshTexture::Ptr>> mesh_textures = nullptr)
-    : PolygonMesh(vertices,
-                  triangles,
+    : PolygonMesh(std::move(vertices),
+                  std::move(triangles),
                   triangle_count,
-                  resource,
-                  scale,
-                  normals,
-                  vertex_colors,
-                  mesh_material,
-                  mesh_textures,
+                  std::move(resource),
+                  std::move(scale),
+                  std::move(normals),
+                  std::move(vertex_colors),
+                  std::move(mesh_material),
+                  std::move(mesh_textures),
                   GeometryType::SDF_MESH)
   {
     if ((getFaceCount() * 4) != getFaces()->size())
     {
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));
     }
-    return;
   }
 
   ~SDFMesh() override = default;
@@ -144,23 +142,20 @@ public:
    * @brief Get SDF mesh Triangles
    * @return A vector of triangle indices
    */
-  [[deprecated ("Please use getFaces() instead")]]
-  const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const { return getFaces(); }
+  [[deprecated("Please use getFaces() instead")]] const std::shared_ptr<const Eigen::VectorXi>& getTriangles() const
+  {
+    return getFaces();
+  }
 
   /**
    * @brief Get triangle count
    * @return Number of triangles
    */
-  [[deprecated ("Please use getFaceCount() instead")]]
-  int getTriangleCount() const { return getFaceCount(); }
+  [[deprecated("Please use getFaceCount() instead")]] int getTriangleCount() const { return getFaceCount(); }
 
   Geometry::Ptr clone() const override
   {
-    return std::make_shared<SDFMesh>(getVertices(),
-                                     getFaces(),
-                                     getFaceCount(),
-                                     getResource(),
-                                     getScale());
+    return std::make_shared<SDFMesh>(getVertices(), getFaces(), getFaceCount(), getResource(), getScale());
   }
 
 private:

--- a/tesseract_geometry/include/tesseract_geometry/utils.h
+++ b/tesseract_geometry/include/tesseract_geometry/utils.h
@@ -164,6 +164,19 @@ inline bool isIdentical(const Geometry& geom1, const Geometry& geom2)
 
       break;
     }
+  case GeometryType::POLYGON_MESH:
+  {
+    const PolygonMesh& s1 = static_cast<const PolygonMesh&>(geom1);
+    const PolygonMesh& s2 = static_cast<const PolygonMesh&>(geom2);
+
+    if (s1.getVerticeCount() != s2.getVerticeCount())
+      return false;
+
+    if (s1.getFaceCount() != s2.getFaceCount())
+      return false;
+
+    break;
+  }
     default:
     {
       CONSOLE_BRIDGE_logError("This geometric shape type (%d) is not supported", static_cast<int>(geom1.getType()));

--- a/tesseract_geometry/include/tesseract_geometry/utils.h
+++ b/tesseract_geometry/include/tesseract_geometry/utils.h
@@ -164,19 +164,19 @@ inline bool isIdentical(const Geometry& geom1, const Geometry& geom2)
 
       break;
     }
-  case GeometryType::POLYGON_MESH:
-  {
-    const PolygonMesh& s1 = static_cast<const PolygonMesh&>(geom1);
-    const PolygonMesh& s2 = static_cast<const PolygonMesh&>(geom2);
+    case GeometryType::POLYGON_MESH:
+    {
+      const PolygonMesh& s1 = static_cast<const PolygonMesh&>(geom1);
+      const PolygonMesh& s2 = static_cast<const PolygonMesh&>(geom2);
 
-    if (s1.getVerticeCount() != s2.getVerticeCount())
-      return false;
+      if (s1.getVerticeCount() != s2.getVerticeCount())
+        return false;
 
-    if (s1.getFaceCount() != s2.getFaceCount())
-      return false;
+      if (s1.getFaceCount() != s2.getFaceCount())
+        return false;
 
-    break;
-  }
+      break;
+    }
     default:
     {
       CONSOLE_BRIDGE_logError("This geometric shape type (%d) is not supported", static_cast<int>(geom1.getType()));

--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -18,9 +18,6 @@ find_package(tesseract_common REQUIRED)
 find_package(tesseract_scene_graph REQUIRED)
 find_package(tesseract_collision REQUIRED)
 
-include_directories(BEFORE ${PCL_INCLUDE_DIRS})
-link_directories(BEFORE ${PCL_LIBRARY_DIRS})
-
 if(NOT TARGET console_bridge::console_bridge)
   add_library(console_bridge::console_bridge INTERFACE IMPORTED)
   set_target_properties(console_bridge::console_bridge PROPERTIES INTERFACE_INCLUDE_DIRECTORIES

--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(
   src/link.cpp
   src/material.cpp
   src/mesh.cpp
+  src/mesh_writer.cpp
   src/mimic.cpp
   src/octomap.cpp
   src/octree.cpp
@@ -132,6 +133,7 @@ configure_package(NAMESPACE tesseract TARGETS ${PROJECT_NAME})
 
 # Mark cpp header files for installation
 install(FILES include/${PROJECT_NAME}/urdf_parser.h DESTINATION include/${PROJECT_NAME})
+install(FILES include/${PROJECT_NAME}/mesh_writer.h DESTINATION include/${PROJECT_NAME})
 
 # ADD Examples
 add_subdirectory(examples)

--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -18,6 +18,9 @@ find_package(tesseract_common REQUIRED)
 find_package(tesseract_scene_graph REQUIRED)
 find_package(tesseract_collision REQUIRED)
 
+include_directories(BEFORE ${PCL_INCLUDE_DIRS})
+link_directories(BEFORE ${PCL_LIBRARY_DIRS})
+
 if(NOT TARGET console_bridge::console_bridge)
   add_library(console_bridge::console_bridge INTERFACE IMPORTED)
   set_target_properties(console_bridge::console_bridge PROPERTIES INTERFACE_INCLUDE_DIRECTORIES

--- a/tesseract_urdf/include/tesseract_urdf/box.h
+++ b/tesseract_urdf/include/tesseract_urdf/box.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_geometry
 {
 class Box;

--- a/tesseract_urdf/include/tesseract_urdf/box.h
+++ b/tesseract_urdf/include/tesseract_urdf/box.h
@@ -49,6 +49,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Box> parseBox(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeBox(const std::shared_ptr<const tesseract_geometry::Box>& box, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_BOX_H

--- a/tesseract_urdf/include/tesseract_urdf/calibration.h
+++ b/tesseract_urdf/include/tesseract_urdf/calibration.h
@@ -50,6 +50,8 @@ namespace tesseract_urdf
 std::shared_ptr<tesseract_scene_graph::JointCalibration> parseCalibration(const tinyxml2::XMLElement* xml_element,
                                                                           int version);
 
+tinyxml2::XMLElement* writeCalibration(const std::shared_ptr<const tesseract_scene_graph::JointCalibration>& calibration, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_CALIBRATION_H

--- a/tesseract_urdf/include/tesseract_urdf/calibration.h
+++ b/tesseract_urdf/include/tesseract_urdf/calibration.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class JointCalibration;
@@ -50,7 +51,9 @@ namespace tesseract_urdf
 std::shared_ptr<tesseract_scene_graph::JointCalibration> parseCalibration(const tinyxml2::XMLElement* xml_element,
                                                                           int version);
 
-tinyxml2::XMLElement* writeCalibration(const std::shared_ptr<const tesseract_scene_graph::JointCalibration>& calibration, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement*
+writeCalibration(const std::shared_ptr<const tesseract_scene_graph::JointCalibration>& calibration,
+                 tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/capsule.h
+++ b/tesseract_urdf/include/tesseract_urdf/capsule.h
@@ -49,5 +49,7 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Capsule> parseCapsule(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeCapsule(const std::shared_ptr<const tesseract_geometry::Capsule>& capsule, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_CAPSULE_H

--- a/tesseract_urdf/include/tesseract_urdf/capsule.h
+++ b/tesseract_urdf/include/tesseract_urdf/capsule.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_geometry
 {
 class Capsule;
@@ -49,7 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Capsule> parseCapsule(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeCapsule(const std::shared_ptr<const tesseract_geometry::Capsule>& capsule, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeCapsule(const std::shared_ptr<const tesseract_geometry::Capsule>& capsule,
+                                   tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_CAPSULE_H

--- a/tesseract_urdf/include/tesseract_urdf/collision.h
+++ b/tesseract_urdf/include/tesseract_urdf/collision.h
@@ -56,6 +56,12 @@ parseCollision(const tinyxml2::XMLElement* xml_element,
                const std::shared_ptr<tesseract_scene_graph::ResourceLocator>& locator,
                int version);
 
+tinyxml2::XMLElement* writeCollision(const std::shared_ptr<const tesseract_scene_graph::Collision>& collision,
+                                     tinyxml2::XMLDocument& doc,
+                                     const std::string& directory,
+                                     const std::string& link_name,
+                                     const int id = -1);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_COLLISION_H

--- a/tesseract_urdf/include/tesseract_urdf/collision.h
+++ b/tesseract_urdf/include/tesseract_urdf/collision.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class Collision;
@@ -60,7 +61,7 @@ tinyxml2::XMLElement* writeCollision(const std::shared_ptr<const tesseract_scene
                                      tinyxml2::XMLDocument& doc,
                                      const std::string& directory,
                                      const std::string& link_name,
-                                     const int id = -1);
+                                     int id);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/cone.h
+++ b/tesseract_urdf/include/tesseract_urdf/cone.h
@@ -49,6 +49,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Cone> parseCone(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeCone(const std::shared_ptr<const tesseract_geometry::Cone>& cone, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_CONE_H

--- a/tesseract_urdf/include/tesseract_urdf/cone.h
+++ b/tesseract_urdf/include/tesseract_urdf/cone.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_geometry
 {
 class Cone;
@@ -49,7 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Cone> parseCone(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeCone(const std::shared_ptr<const tesseract_geometry::Cone>& cone, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeCone(const std::shared_ptr<const tesseract_geometry::Cone>& cone,
+                                tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/convex_mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/convex_mesh.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;

--- a/tesseract_urdf/include/tesseract_urdf/convex_mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/convex_mesh.h
@@ -61,6 +61,11 @@ parseConvexMesh(const tinyxml2::XMLElement* xml_element,
                 bool visual,
                 int version);
 
+tinyxml2::XMLElement* writeConvexMesh(const std::shared_ptr<const tesseract_geometry::ConvexMesh>& mesh,
+                                      tinyxml2::XMLDocument& doc,
+                                      const std::string& directory,
+                                      const std::string& filename);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_CONVEX_MESH_H

--- a/tesseract_urdf/include/tesseract_urdf/cylinder.h
+++ b/tesseract_urdf/include/tesseract_urdf/cylinder.h
@@ -49,6 +49,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Cylinder> parseCylinder(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeCylinder(const std::shared_ptr<const tesseract_geometry::Cylinder>& cylinder, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_CYLINDER_H

--- a/tesseract_urdf/include/tesseract_urdf/cylinder.h
+++ b/tesseract_urdf/include/tesseract_urdf/cylinder.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_geometry
 {
 class Cylinder;
@@ -49,7 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Cylinder> parseCylinder(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeCylinder(const std::shared_ptr<const tesseract_geometry::Cylinder>& cylinder, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeCylinder(const std::shared_ptr<const tesseract_geometry::Cylinder>& cylinder,
+                                    tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/dynamics.h
+++ b/tesseract_urdf/include/tesseract_urdf/dynamics.h
@@ -50,6 +50,8 @@ namespace tesseract_urdf
 std::shared_ptr<tesseract_scene_graph::JointDynamics> parseDynamics(const tinyxml2::XMLElement* xml_element,
                                                                     int version);
 
+tinyxml2::XMLElement* writeDynamics(const std::shared_ptr<const tesseract_scene_graph::JointDynamics>& dynamics, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_DYNAMICS_H

--- a/tesseract_urdf/include/tesseract_urdf/dynamics.h
+++ b/tesseract_urdf/include/tesseract_urdf/dynamics.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class JointDynamics;
@@ -50,7 +51,8 @@ namespace tesseract_urdf
 std::shared_ptr<tesseract_scene_graph::JointDynamics> parseDynamics(const tinyxml2::XMLElement* xml_element,
                                                                     int version);
 
-tinyxml2::XMLElement* writeDynamics(const std::shared_ptr<const tesseract_scene_graph::JointDynamics>& dynamics, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeDynamics(const std::shared_ptr<const tesseract_scene_graph::JointDynamics>& dynamics,
+                                    tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/geometry.h
+++ b/tesseract_urdf/include/tesseract_urdf/geometry.h
@@ -60,6 +60,11 @@ parseGeometry(const tinyxml2::XMLElement* xml_element,
               bool visual,
               int version);
 
+tinyxml2::XMLElement* writeGeometry(const std::shared_ptr<const tesseract_geometry::Geometry>& geometry,
+                                    tinyxml2::XMLDocument& doc,
+                                    const std::string& directory,
+                                    const std::string& filename);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_GEOMETRY_H

--- a/tesseract_urdf/include/tesseract_urdf/geometry.h
+++ b/tesseract_urdf/include/tesseract_urdf/geometry.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;

--- a/tesseract_urdf/include/tesseract_urdf/inertial.h
+++ b/tesseract_urdf/include/tesseract_urdf/inertial.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class Inertial;
@@ -50,7 +51,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::Inertial> parseInertial(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeInertial(const std::shared_ptr<const tesseract_scene_graph::Inertial>& inertial, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeInertial(const std::shared_ptr<const tesseract_scene_graph::Inertial>& inertial,
+                                    tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/inertial.h
+++ b/tesseract_urdf/include/tesseract_urdf/inertial.h
@@ -50,6 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::Inertial> parseInertial(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeInertial(const std::shared_ptr<const tesseract_scene_graph::Inertial>& inertial, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_INERTIAL_H

--- a/tesseract_urdf/include/tesseract_urdf/joint.h
+++ b/tesseract_urdf/include/tesseract_urdf/joint.h
@@ -49,5 +49,8 @@ namespace tesseract_urdf
  * @return A Tesseract Joint
  */
 std::shared_ptr<tesseract_scene_graph::Joint> parseJoint(const tinyxml2::XMLElement* xml_element, int version);
+
+tinyxml2::XMLElement* writeJoint(const std::shared_ptr<const tesseract_scene_graph::Joint>& joint, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_JOINT_H

--- a/tesseract_urdf/include/tesseract_urdf/joint.h
+++ b/tesseract_urdf/include/tesseract_urdf/joint.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class Joint;
@@ -50,7 +51,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::Joint> parseJoint(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeJoint(const std::shared_ptr<const tesseract_scene_graph::Joint>& joint, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeJoint(const std::shared_ptr<const tesseract_scene_graph::Joint>& joint,
+                                 tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_JOINT_H

--- a/tesseract_urdf/include/tesseract_urdf/limits.h
+++ b/tesseract_urdf/include/tesseract_urdf/limits.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class JointLimits;
@@ -50,7 +51,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::JointLimits> parseLimits(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeLimits(const std::shared_ptr<const tesseract_scene_graph::JointLimits>& limits, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeLimits(const std::shared_ptr<const tesseract_scene_graph::JointLimits>& limits,
+                                  tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/limits.h
+++ b/tesseract_urdf/include/tesseract_urdf/limits.h
@@ -50,6 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::JointLimits> parseLimits(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeLimits(const std::shared_ptr<const tesseract_scene_graph::JointLimits>& limits, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_LIMITS_H

--- a/tesseract_urdf/include/tesseract_urdf/link.h
+++ b/tesseract_urdf/include/tesseract_urdf/link.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class Link;

--- a/tesseract_urdf/include/tesseract_urdf/link.h
+++ b/tesseract_urdf/include/tesseract_urdf/link.h
@@ -59,5 +59,9 @@ parseLink(const tinyxml2::XMLElement* xml_element,
           std::unordered_map<std::string, std::shared_ptr<tesseract_scene_graph::Material>>& available_materials,
           int version);
 
+tinyxml2::XMLElement* writeLink(const std::shared_ptr<const tesseract_scene_graph::Link>& link,
+                                tinyxml2::XMLDocument& doc,
+                                const std::string& directory);
+
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_LINK_H

--- a/tesseract_urdf/include/tesseract_urdf/material.h
+++ b/tesseract_urdf/include/tesseract_urdf/material.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class Material;
@@ -57,7 +58,8 @@ parseMaterial(const tinyxml2::XMLElement* xml_element,
               bool allow_anonymous,
               int version);
 
-tinyxml2::XMLElement* writeMaterial(const std::shared_ptr<const tesseract_scene_graph::Material>& material, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeMaterial(const std::shared_ptr<const tesseract_scene_graph::Material>& material,
+                                    tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_MATERIAL_H

--- a/tesseract_urdf/include/tesseract_urdf/material.h
+++ b/tesseract_urdf/include/tesseract_urdf/material.h
@@ -57,5 +57,7 @@ parseMaterial(const tinyxml2::XMLElement* xml_element,
               bool allow_anonymous,
               int version);
 
+tinyxml2::XMLElement* writeMaterial(const std::shared_ptr<const tesseract_scene_graph::Material>& material, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_MATERIAL_H

--- a/tesseract_urdf/include/tesseract_urdf/mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh.h
@@ -47,6 +47,7 @@ class Mesh;
 
 namespace tesseract_urdf
 {
+
 /**
  * @brief Parse xml element mesh
  * @param xml_element The xml element
@@ -60,6 +61,11 @@ parseMesh(const tinyxml2::XMLElement* xml_element,
           const std::shared_ptr<tesseract_scene_graph::ResourceLocator>& locator,
           bool visual,
           int version);
+
+tinyxml2::XMLElement* writeMesh(const std::shared_ptr<const tesseract_geometry::Mesh>& mesh,
+                                tinyxml2::XMLDocument& doc,
+                                const std::string& directory,
+                                const std::string& filename);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;
@@ -47,7 +48,6 @@ class Mesh;
 
 namespace tesseract_urdf
 {
-
 /**
  * @brief Parse xml element mesh
  * @param xml_element The xml element

--- a/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
@@ -4,7 +4,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 
-#include <pcl/PolygonMesh.h>
 // #include <assimp/scene.h>
 
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -14,11 +13,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_urdf
 {
 /* Commented out due to nebulous errors during initial testing.
- * If errors are resolved, this is probably superior to the PCL method below.
+ * If errors are resolved, this is probably superior to the writeSimplePLY method used.
 aiScene createAssetFromMesh(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh);
 */
-
-pcl::PolygonMesh createPCLMesh(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh);
 
 void writeMeshToFile(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh, const std::string& filepath);
 

--- a/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
@@ -11,7 +11,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_urdf
 {
-
 template <class T>
 aiScene createAssetFromMesh(const std::shared_ptr<const T>& mesh)
 {
@@ -36,28 +35,27 @@ aiScene createAssetFromMesh(const std::shared_ptr<const T>& mesh)
   scene.mRootNode->mNumMeshes = 1;
 
   // Transcribe in the mesh vertices
-  scene.mMeshes[0]->mVertices = new aiVector3D[mesh->getVertexCount()];
+  scene.mMeshes[0]->mVertices = new aiVector3D[static_cast<unsigned long>(mesh->getVertexCount())];
   scene.mMeshes[0]->mNumVertices = static_cast<unsigned int>(mesh->getVertexCount());
 
-  for (std::size_t i = 0; i < mesh->getVertexCount(); ++i)
+  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getVertexCount()); ++i)
   {
-    scene.mMeshes[0]->mVertices[i] = aiVector3D(
-          static_cast<float>(mesh->getVertices()->at(i).x()),
-          static_cast<float>(mesh->getVertices()->at(i).y()),
-          static_cast<float>(mesh->getVertices()->at(i).z()));
+    scene.mMeshes[0]->mVertices[i] = aiVector3D(static_cast<float>(mesh->getVertices()->at(i).x()),
+                                                static_cast<float>(mesh->getVertices()->at(i).y()),
+                                                static_cast<float>(mesh->getVertices()->at(i).z()));
   }
 
   // Transcribe in the mesh triangles
-  scene.mMeshes[0]->mFaces = new aiFace[mesh->getFaceCount()];
+  scene.mMeshes[0]->mFaces = new aiFace[static_cast<unsigned long>(mesh->getFaceCount())];
   scene.mMeshes[0]->mNumFaces = static_cast<unsigned int>(mesh->getFaceCount());
 
   int indices = 0;
-  for (std::size_t i = 0; i < mesh->getFaceCount() && indices < mesh->getFaces()->size(); ++i)
+  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getFaceCount()) && indices < mesh->getFaces()->size(); ++i)
   {
     // Find and set the number of vertices for this face
     int num_vertices = (*mesh->getFaces())(indices);
-    scene.mMeshes[0]->mFaces[i].mIndices = new unsigned int[num_vertices];
-    scene.mMeshes[0]->mFaces[i].mNumIndices = num_vertices;
+    scene.mMeshes[0]->mFaces[i].mIndices = new unsigned int[static_cast<unsigned long>(num_vertices)];
+    scene.mMeshes[0]->mFaces[i].mNumIndices = static_cast<unsigned int>(num_vertices);
 
     // Copy over the index pointing to each vertex
     for (int j = 1; j <= num_vertices; ++j)
@@ -76,8 +74,7 @@ aiScene createAssetFromMesh(const std::shared_ptr<const T>& mesh)
 }
 
 template <class T>
-void writeMeshToFile(const std::shared_ptr<const T>& mesh,
-                     const std::string& filepath)
+void writeMeshToFile(const std::shared_ptr<const T>& mesh, const std::string& filepath)
 {
   aiScene scene = createAssetFromMesh(mesh);
   Assimp::Exporter exporter;
@@ -86,10 +83,9 @@ void writeMeshToFile(const std::shared_ptr<const T>& mesh,
 
   if (ret != AI_SUCCESS)
     std::throw_with_nested(std::runtime_error("Could not export file"));
-  return;
 }
 
-} // namespace tesseract_urdf
+}  // namespace tesseract_urdf
 
 #ifdef SWIG
 %pybuffer_binary(const uint8_t* bytes, size_t bytes_len);
@@ -101,4 +97,4 @@ void writeMeshToFile(const std::shared_ptr<const T>& mesh,
 %template(writeConvexMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::ConvexMesh>;
 #endif
 
-#endif // TESSERACT_SCENE_GRAPH_MESH_WRITER_H
+#endif  // TESSERACT_SCENE_GRAPH_MESH_WRITER_H

--- a/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
@@ -1,0 +1,104 @@
+#ifndef TESSERACT_SCENE_GRAPH_MESH_WRITER_H
+#define TESSERACT_SCENE_GRAPH_MESH_WRITER_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+
+#include <assimp/scene.h>
+#include <assimp/Exporter.hpp>
+
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_urdf
+{
+
+template <class T>
+aiScene createAssetFromMesh(const std::shared_ptr<const T>& mesh)
+{
+  // Create an assimp scene
+  aiScene scene;
+  scene.mRootNode = new aiNode();
+
+  // Make space for and create a default material
+  scene.mMaterials = new aiMaterial*[1];
+  scene.mMaterials[0] = new aiMaterial();
+  scene.mNumMaterials = 1;
+
+  // Make space for and create a mesh
+  scene.mMeshes = new aiMesh*[1];
+  scene.mMeshes[0] = new aiMesh();
+  scene.mMeshes[0]->mMaterialIndex = 0;
+  scene.mNumMeshes = 1;
+
+  // Register the mesh as part of the scene root node
+  scene.mRootNode->mMeshes = new unsigned int[1];
+  scene.mRootNode->mMeshes[0] = 0;
+  scene.mRootNode->mNumMeshes = 1;
+
+  // Transcribe in the mesh vertices
+  scene.mMeshes[0]->mVertices = new aiVector3D[mesh->getVertexCount()];
+  scene.mMeshes[0]->mNumVertices = static_cast<unsigned int>(mesh->getVertexCount());
+
+  for (std::size_t i = 0; i < mesh->getVertexCount(); ++i)
+  {
+    scene.mMeshes[0]->mVertices[i] = aiVector3D(
+          static_cast<float>(mesh->getVertices()->at(i).x()),
+          static_cast<float>(mesh->getVertices()->at(i).y()),
+          static_cast<float>(mesh->getVertices()->at(i).z()));
+  }
+
+  // Transcribe in the mesh triangles
+  scene.mMeshes[0]->mFaces = new aiFace[mesh->getFaceCount()];
+  scene.mMeshes[0]->mNumFaces = static_cast<unsigned int>(mesh->getFaceCount());
+
+  int indices = 0;
+  for (std::size_t i = 0; i < mesh->getFaceCount() && indices < mesh->getFaces()->size(); ++i)
+  {
+    // Find and set the number of vertices for this face
+    int num_vertices = (*mesh->getFaces())(indices);
+    scene.mMeshes[0]->mFaces[i].mIndices = new unsigned int[num_vertices];
+    scene.mMeshes[0]->mFaces[i].mNumIndices = num_vertices;
+
+    // Copy over the index pointing to each vertex
+    for (int j = 1; j <= num_vertices; ++j)
+      scene.mMeshes[0]->mFaces[i].mIndices[j] = static_cast<unsigned int>((*mesh->getFaces())(indices + j));
+
+    // Move along all the vertex indices just applied
+    indices += num_vertices;
+
+    // And move one more to get to the next face-size-indicator
+    ++indices;
+  }
+
+  // mTextureCoords? mNumUVComponents?
+
+  return scene;
+}
+
+template <class T>
+void writeMeshToFile(const std::shared_ptr<const T>& mesh,
+                     const std::string& filepath)
+{
+  aiScene scene = createAssetFromMesh(mesh);
+  Assimp::Exporter exporter;
+
+  aiReturn ret = exporter.Export(&scene, "pFormatId", filepath.c_str());
+
+  if (ret != AI_SUCCESS)
+    std::throw_with_nested(std::runtime_error("Could not export file"));
+  return;
+}
+
+} // namespace tesseract_urdf
+
+#ifdef SWIG
+%pybuffer_binary(const uint8_t* bytes, size_t bytes_len);
+%template(createAssetFromMesh) tesseract_urdf::createAssetFromMesh<tesseract_geometry::Mesh>;
+%template(createAssetFromSDFMesh) tesseract_urdf::createAssetFromMesh<tesseract_geometry::SDFMesh>;
+%template(createAssetFromConvexMesh) tesseract_urdf::createAssetFromMesh<tesseract_geometry::ConvexMesh>;
+%template(writeMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::Mesh>;
+%template(writeSDFMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::SDFMesh>;
+%template(writeConvexMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::ConvexMesh>;
+#endif
+
+#endif // TESSERACT_SCENE_GRAPH_MESH_WRITER_H

--- a/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh_writer.h
@@ -1,100 +1,27 @@
-#ifndef TESSERACT_SCENE_GRAPH_MESH_WRITER_H
-#define TESSERACT_SCENE_GRAPH_MESH_WRITER_H
+#ifndef TESSERACT_URDF_MESH_WRITER_H
+#define TESSERACT_URDF_MESH_WRITER_H
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 
-#include <assimp/scene.h>
-#include <assimp/Exporter.hpp>
+#include <pcl/PolygonMesh.h>
+// #include <assimp/scene.h>
 
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_geometry/impl/polygon_mesh.h>
+
 namespace tesseract_urdf
 {
-template <class T>
-aiScene createAssetFromMesh(const std::shared_ptr<const T>& mesh)
-{
-  // Create an assimp scene
-  aiScene scene;
-  scene.mRootNode = new aiNode();
+/* Commented out due to nebulous errors during initial testing.
+ * If errors are resolved, this is probably superior to the PCL method below.
+aiScene createAssetFromMesh(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh);
+*/
 
-  // Make space for and create a default material
-  scene.mMaterials = new aiMaterial*[1];
-  scene.mMaterials[0] = new aiMaterial();
-  scene.mNumMaterials = 1;
+pcl::PolygonMesh createPCLMesh(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh);
 
-  // Make space for and create a mesh
-  scene.mMeshes = new aiMesh*[1];
-  scene.mMeshes[0] = new aiMesh();
-  scene.mMeshes[0]->mMaterialIndex = 0;
-  scene.mNumMeshes = 1;
-
-  // Register the mesh as part of the scene root node
-  scene.mRootNode->mMeshes = new unsigned int[1];
-  scene.mRootNode->mMeshes[0] = 0;
-  scene.mRootNode->mNumMeshes = 1;
-
-  // Transcribe in the mesh vertices
-  scene.mMeshes[0]->mVertices = new aiVector3D[static_cast<unsigned long>(mesh->getVertexCount())];
-  scene.mMeshes[0]->mNumVertices = static_cast<unsigned int>(mesh->getVertexCount());
-
-  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getVertexCount()); ++i)
-  {
-    scene.mMeshes[0]->mVertices[i] = aiVector3D(static_cast<float>(mesh->getVertices()->at(i).x()),
-                                                static_cast<float>(mesh->getVertices()->at(i).y()),
-                                                static_cast<float>(mesh->getVertices()->at(i).z()));
-  }
-
-  // Transcribe in the mesh triangles
-  scene.mMeshes[0]->mFaces = new aiFace[static_cast<unsigned long>(mesh->getFaceCount())];
-  scene.mMeshes[0]->mNumFaces = static_cast<unsigned int>(mesh->getFaceCount());
-
-  int indices = 0;
-  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getFaceCount()) && indices < mesh->getFaces()->size(); ++i)
-  {
-    // Find and set the number of vertices for this face
-    int num_vertices = (*mesh->getFaces())(indices);
-    scene.mMeshes[0]->mFaces[i].mIndices = new unsigned int[static_cast<unsigned long>(num_vertices)];
-    scene.mMeshes[0]->mFaces[i].mNumIndices = static_cast<unsigned int>(num_vertices);
-
-    // Copy over the index pointing to each vertex
-    for (int j = 1; j <= num_vertices; ++j)
-      scene.mMeshes[0]->mFaces[i].mIndices[j] = static_cast<unsigned int>((*mesh->getFaces())(indices + j));
-
-    // Move along all the vertex indices just applied
-    indices += num_vertices;
-
-    // And move one more to get to the next face-size-indicator
-    ++indices;
-  }
-
-  // mTextureCoords? mNumUVComponents?
-
-  return scene;
-}
-
-template <class T>
-void writeMeshToFile(const std::shared_ptr<const T>& mesh, const std::string& filepath)
-{
-  aiScene scene = createAssetFromMesh(mesh);
-  Assimp::Exporter exporter;
-
-  aiReturn ret = exporter.Export(&scene, "pFormatId", filepath.c_str());
-
-  if (ret != AI_SUCCESS)
-    std::throw_with_nested(std::runtime_error("Could not export file"));
-}
+void writeMeshToFile(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh, const std::string& filepath);
 
 }  // namespace tesseract_urdf
 
-#ifdef SWIG
-%pybuffer_binary(const uint8_t* bytes, size_t bytes_len);
-%template(createAssetFromMesh) tesseract_urdf::createAssetFromMesh<tesseract_geometry::Mesh>;
-%template(createAssetFromSDFMesh) tesseract_urdf::createAssetFromMesh<tesseract_geometry::SDFMesh>;
-%template(createAssetFromConvexMesh) tesseract_urdf::createAssetFromMesh<tesseract_geometry::ConvexMesh>;
-%template(writeMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::Mesh>;
-%template(writeSDFMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::SDFMesh>;
-%template(writeConvexMeshToFile) tesseract_urdf::writeMeshToFile<tesseract_geometry::ConvexMesh>;
-#endif
-
-#endif  // TESSERACT_SCENE_GRAPH_MESH_WRITER_H
+#endif  // TESSERACT_URDF_MESH_WRITER_H

--- a/tesseract_urdf/include/tesseract_urdf/mimic.h
+++ b/tesseract_urdf/include/tesseract_urdf/mimic.h
@@ -50,6 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::JointMimic> parseMimic(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeMimic(const std::shared_ptr<const tesseract_scene_graph::JointMimic>& mimic, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_MIMIC_H

--- a/tesseract_urdf/include/tesseract_urdf/mimic.h
+++ b/tesseract_urdf/include/tesseract_urdf/mimic.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class JointMimic;
@@ -50,7 +51,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::JointMimic> parseMimic(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeMimic(const std::shared_ptr<const tesseract_scene_graph::JointMimic>& mimic, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeMimic(const std::shared_ptr<const tesseract_scene_graph::JointMimic>& mimic,
+                                 tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/octomap.h
+++ b/tesseract_urdf/include/tesseract_urdf/octomap.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;

--- a/tesseract_urdf/include/tesseract_urdf/octomap.h
+++ b/tesseract_urdf/include/tesseract_urdf/octomap.h
@@ -60,5 +60,10 @@ parseOctomap(const tinyxml2::XMLElement* xml_element,
              bool visual,
              int version);
 
+tinyxml2::XMLElement* writeOctomap(const std::shared_ptr<const tesseract_geometry::Octree>& octree,
+                                   tinyxml2::XMLDocument& doc,
+                                   const std::string& directory,
+                                   const std::string& filename);
+
 }  // namespace tesseract_urdf
 #endif  // TESSERACT_URDF_OCTOMAP_H

--- a/tesseract_urdf/include/tesseract_urdf/octree.h
+++ b/tesseract_urdf/include/tesseract_urdf/octree.h
@@ -59,6 +59,19 @@ parseOctree(const tinyxml2::XMLElement* xml_element,
             bool prune,
             int version);
 
+/**
+ * @brief writeOctree Write octree out to file, and generate appropriate xml
+ * @param octree The geometry element containing octree data
+ * @param doc The XML document to which to add the xml data
+ * @param directory Working directory, with trailing `/` (e.g. "/tmp/")
+ * @param filename Desired filename relative to the working directory ("octree.ot" or "collision/octree.ot")
+ * @return An XML element containing information on the saved file.
+ */
+tinyxml2::XMLElement* writeOctree(const std::shared_ptr<const tesseract_geometry::Octree>& octree,
+                                  tinyxml2::XMLDocument& doc,
+                                  const std::string& directory,
+                                  const std::string& filename);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_OCTREE_H

--- a/tesseract_urdf/include/tesseract_urdf/octree.h
+++ b/tesseract_urdf/include/tesseract_urdf/octree.h
@@ -36,7 +36,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;

--- a/tesseract_urdf/include/tesseract_urdf/origin.h
+++ b/tesseract_urdf/include/tesseract_urdf/origin.h
@@ -47,6 +47,8 @@ namespace tesseract_urdf
  */
 Eigen::Isometry3d parseOrigin(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeOrigin(const Eigen::Isometry3d& origin, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_ORIGIN_H

--- a/tesseract_urdf/include/tesseract_urdf/origin.h
+++ b/tesseract_urdf/include/tesseract_urdf/origin.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 
 namespace tesseract_urdf
 {

--- a/tesseract_urdf/include/tesseract_urdf/point_cloud.h
+++ b/tesseract_urdf/include/tesseract_urdf/point_cloud.h
@@ -36,7 +36,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;
@@ -59,8 +60,6 @@ parsePointCloud(const tinyxml2::XMLElement* xml_element,
                 tesseract_geometry::Octree::SubType shape_type,
                 bool prune,
                 int version);
-
-tinyxml2::XMLElement* writePointCloud(const std::shared_ptr<const tesseract_geometry::Octree>& point_cloud, tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/point_cloud.h
+++ b/tesseract_urdf/include/tesseract_urdf/point_cloud.h
@@ -59,6 +59,9 @@ parsePointCloud(const tinyxml2::XMLElement* xml_element,
                 tesseract_geometry::Octree::SubType shape_type,
                 bool prune,
                 int version);
+
+tinyxml2::XMLElement* writePointCloud(const std::shared_ptr<const tesseract_geometry::Octree>& point_cloud, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_POINT_CLOUD_H

--- a/tesseract_urdf/include/tesseract_urdf/safety_controller.h
+++ b/tesseract_urdf/include/tesseract_urdf/safety_controller.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class JointSafety;
@@ -50,7 +51,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::JointSafety> parseSafetyController(const tinyxml2::XMLElement* xml_element,
                                                                           int version);
-tinyxml2::XMLElement* writeSafetyController(const std::shared_ptr<const tesseract_scene_graph::JointSafety>& safety, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeSafetyController(const std::shared_ptr<const tesseract_scene_graph::JointSafety>& safety,
+                                            tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/safety_controller.h
+++ b/tesseract_urdf/include/tesseract_urdf/safety_controller.h
@@ -50,6 +50,7 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_scene_graph::JointSafety> parseSafetyController(const tinyxml2::XMLElement* xml_element,
                                                                           int version);
+tinyxml2::XMLElement* writeSafetyController(const std::shared_ptr<const tesseract_scene_graph::JointSafety>& safety, tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/sdf_mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/sdf_mesh.h
@@ -61,6 +61,11 @@ parseSDFMesh(const tinyxml2::XMLElement* xml_element,
              bool visual,
              int version);
 
+tinyxml2::XMLElement* writeSDFMesh(const std::shared_ptr<const tesseract_geometry::SDFMesh>& sdf_mesh,
+                                   tinyxml2::XMLDocument& doc,
+                                   const std::string& directory,
+                                   const std::string& filename);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_SDF_MESH_H

--- a/tesseract_urdf/include/tesseract_urdf/sdf_mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/sdf_mesh.h
@@ -35,7 +35,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class ResourceLocator;

--- a/tesseract_urdf/include/tesseract_urdf/sphere.h
+++ b/tesseract_urdf/include/tesseract_urdf/sphere.h
@@ -34,7 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_geometry
 {
 class Sphere;
@@ -49,7 +50,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Sphere> parseSphere(const tinyxml2::XMLElement* xml_element, int version);
 
-tinyxml2::XMLElement* writeSphere(const std::shared_ptr<const tesseract_geometry::Sphere>& sphere, tinyxml2::XMLDocument& doc);
+tinyxml2::XMLElement* writeSphere(const std::shared_ptr<const tesseract_geometry::Sphere>& sphere,
+                                  tinyxml2::XMLDocument& doc);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/sphere.h
+++ b/tesseract_urdf/include/tesseract_urdf/sphere.h
@@ -49,6 +49,8 @@ namespace tesseract_urdf
  */
 std::shared_ptr<tesseract_geometry::Sphere> parseSphere(const tinyxml2::XMLElement* xml_element, int version);
 
+tinyxml2::XMLElement* writeSphere(const std::shared_ptr<const tesseract_geometry::Sphere>& sphere, tinyxml2::XMLDocument& doc);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_SPHERE_H

--- a/tesseract_urdf/include/tesseract_urdf/urdf_parser.h
+++ b/tesseract_urdf/include/tesseract_urdf/urdf_parser.h
@@ -53,6 +53,9 @@ tesseract_scene_graph::SceneGraph::Ptr parseURDFString(const std::string& urdf_x
 tesseract_scene_graph::SceneGraph::Ptr parseURDFFile(const std::string& path,
                                                      const tesseract_scene_graph::ResourceLocator::Ptr& locator);
 
+void writeURDFFile(const tesseract_scene_graph::SceneGraph::ConstPtr& sg,
+                   const std::string& directory,
+                   const std::string& filename);
 }  // namespace tesseract_urdf
 
 #endif

--- a/tesseract_urdf/include/tesseract_urdf/visual.h
+++ b/tesseract_urdf/include/tesseract_urdf/visual.h
@@ -36,7 +36,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tinyxml2
 {
 class XMLElement;
-}
+class XMLDocument;
+}  // namespace tinyxml2
 namespace tesseract_scene_graph
 {
 class Visual;
@@ -69,7 +70,7 @@ tinyxml2::XMLElement* writeVisual(const std::shared_ptr<const tesseract_scene_gr
                                   tinyxml2::XMLDocument& doc,
                                   const std::string& directory,
                                   const std::string& link_name,
-                                  const int id = -1);
+                                  int id);
 
 }  // namespace tesseract_urdf
 

--- a/tesseract_urdf/include/tesseract_urdf/visual.h
+++ b/tesseract_urdf/include/tesseract_urdf/visual.h
@@ -59,6 +59,18 @@ parseVisual(const tinyxml2::XMLElement* xml_element,
             std::unordered_map<std::string, std::shared_ptr<tesseract_scene_graph::Material>>& available_materials,
             int version);
 
+/**
+ * @brief writeVisual - call once per visual geometry
+ * @param visuals
+ * @param doc
+ * @return
+ */
+tinyxml2::XMLElement* writeVisual(const std::shared_ptr<const tesseract_scene_graph::Visual>& visual,
+                                  tinyxml2::XMLDocument& doc,
+                                  const std::string& directory,
+                                  const std::string& link_name,
+                                  const int id = -1);
+
 }  // namespace tesseract_urdf
 
 #endif  // TESSERACT_URDF_VISUAL_H

--- a/tesseract_urdf/src/box.cpp
+++ b/tesseract_urdf/src/box.cpp
@@ -64,7 +64,8 @@ tesseract_geometry::Box::Ptr tesseract_urdf::parseBox(const tinyxml2::XMLElement
   return std::make_shared<tesseract_geometry::Box>(l, w, h);
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeBox(const std::shared_ptr<const tesseract_geometry::Box>& box, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeBox(const std::shared_ptr<const tesseract_geometry::Box>& box,
+                                               tinyxml2::XMLDocument& doc)
 {
   if (box == nullptr)
     std::throw_with_nested(std::runtime_error("Box is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/box.cpp
+++ b/tesseract_urdf/src/box.cpp
@@ -63,3 +63,14 @@ tesseract_geometry::Box::Ptr tesseract_urdf::parseBox(const tinyxml2::XMLElement
 
   return std::make_shared<tesseract_geometry::Box>(l, w, h);
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeBox(const std::shared_ptr<const tesseract_geometry::Box>& box, tinyxml2::XMLDocument& doc)
+{
+  if (box == nullptr)
+    std::throw_with_nested(std::runtime_error("Box is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("box");
+  xml_element->SetAttribute("l", box->getX());
+  xml_element->SetAttribute("w", box->getY());
+  xml_element->SetAttribute("h", box->getZ());
+  return xml_element;
+}

--- a/tesseract_urdf/src/calibration.cpp
+++ b/tesseract_urdf/src/calibration.cpp
@@ -58,3 +58,14 @@ tesseract_scene_graph::JointCalibration::Ptr tesseract_urdf::parseCalibration(co
 
   return calibration;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeCalibration(const std::shared_ptr<const tesseract_scene_graph::JointCalibration>& calibration, tinyxml2::XMLDocument& doc)
+{
+  if (calibration == nullptr)
+    std::throw_with_nested(std::runtime_error("Calibration is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("calibration");
+  xml_element->SetAttribute("rising", calibration->rising);
+  xml_element->SetAttribute("falling", calibration->falling);
+  return xml_element;
+}
+

--- a/tesseract_urdf/src/calibration.cpp
+++ b/tesseract_urdf/src/calibration.cpp
@@ -59,7 +59,9 @@ tesseract_scene_graph::JointCalibration::Ptr tesseract_urdf::parseCalibration(co
   return calibration;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeCalibration(const std::shared_ptr<const tesseract_scene_graph::JointCalibration>& calibration, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement*
+tesseract_urdf::writeCalibration(const std::shared_ptr<const tesseract_scene_graph::JointCalibration>& calibration,
+                                 tinyxml2::XMLDocument& doc)
 {
   if (calibration == nullptr)
     std::throw_with_nested(std::runtime_error("Calibration is nullptr and cannot be converted to XML"));
@@ -68,4 +70,3 @@ tinyxml2::XMLElement* tesseract_urdf::writeCalibration(const std::shared_ptr<con
   xml_element->SetAttribute("falling", calibration->falling);
   return xml_element;
 }
-

--- a/tesseract_urdf/src/capsule.cpp
+++ b/tesseract_urdf/src/capsule.cpp
@@ -44,3 +44,13 @@ tesseract_geometry::Capsule::Ptr tesseract_urdf::parseCapsule(const tinyxml2::XM
 
   return std::make_shared<tesseract_geometry::Capsule>(r, l);
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeCapsule(const std::shared_ptr<const tesseract_geometry::Capsule>& capsule, tinyxml2::XMLDocument& doc)
+{
+  if (capsule == nullptr)
+    std::throw_with_nested(std::runtime_error("Capsule is nullptr and cannot be written to XML file"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("capsule");
+  xml_element->SetAttribute("length", capsule->getLength());
+  xml_element->SetAttribute("radius", capsule->getRadius());
+  return xml_element;
+}

--- a/tesseract_urdf/src/capsule.cpp
+++ b/tesseract_urdf/src/capsule.cpp
@@ -45,7 +45,8 @@ tesseract_geometry::Capsule::Ptr tesseract_urdf::parseCapsule(const tinyxml2::XM
   return std::make_shared<tesseract_geometry::Capsule>(r, l);
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeCapsule(const std::shared_ptr<const tesseract_geometry::Capsule>& capsule, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeCapsule(const std::shared_ptr<const tesseract_geometry::Capsule>& capsule,
+                                                   tinyxml2::XMLDocument& doc)
 {
   if (capsule == nullptr)
     std::throw_with_nested(std::runtime_error("Capsule is nullptr and cannot be written to XML file"));

--- a/tesseract_urdf/src/collision.cpp
+++ b/tesseract_urdf/src/collision.cpp
@@ -107,11 +107,12 @@ tesseract_urdf::parseCollision(const tinyxml2::XMLElement* xml_element,
   return collisions;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeCollision(const std::shared_ptr<const tesseract_scene_graph::Collision>& collision,
-                                                     tinyxml2::XMLDocument& doc,
-                                                     const std::string& directory,
-                                                     const std::string& link_name,
-                                                     const int id)
+tinyxml2::XMLElement*
+tesseract_urdf::writeCollision(const std::shared_ptr<const tesseract_scene_graph::Collision>& collision,
+                               tinyxml2::XMLDocument& doc,
+                               const std::string& directory,
+                               const std::string& link_name,
+                               const int id = -1)
 {
   if (collision == nullptr)
     std::throw_with_nested(std::runtime_error("Collision is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/collision.cpp
+++ b/tesseract_urdf/src/collision.cpp
@@ -106,3 +106,43 @@ tesseract_urdf::parseCollision(const tinyxml2::XMLElement* xml_element,
 
   return collisions;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeCollision(const std::shared_ptr<const tesseract_scene_graph::Collision>& collision,
+                                                     tinyxml2::XMLDocument& doc,
+                                                     const std::string& directory,
+                                                     const std::string& link_name,
+                                                     const int id)
+{
+  if (collision == nullptr)
+    std::throw_with_nested(std::runtime_error("Collision is nullptr and cannot be converted to XML"));
+
+  tinyxml2::XMLElement* xml_element = doc.NewElement("collision");
+
+  if (!collision->name.empty())
+    xml_element->SetAttribute("name", collision->name.c_str());
+
+  try
+  {
+    tinyxml2::XMLElement* xml_origin = writeOrigin(collision->origin, doc);
+    xml_element->InsertEndChild(xml_origin);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Could not write origin for collision '" + collision->name + "'!"));
+  }
+
+  try
+  {
+    std::string filename = "collision/" + link_name + "_collision";
+    if (id >= 0)
+      filename += "_" + std::to_string(id);
+    tinyxml2::XMLElement* xml_geometry = writeGeometry(collision->geometry, doc, directory, filename);
+    xml_element->InsertEndChild(xml_geometry);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Could not write geometry for collision '" + collision->name + "'!"));
+  }
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/collision.cpp
+++ b/tesseract_urdf/src/collision.cpp
@@ -122,15 +122,8 @@ tesseract_urdf::writeCollision(const std::shared_ptr<const tesseract_scene_graph
   if (!collision->name.empty())
     xml_element->SetAttribute("name", collision->name.c_str());
 
-  try
-  {
-    tinyxml2::XMLElement* xml_origin = writeOrigin(collision->origin, doc);
-    xml_element->InsertEndChild(xml_origin);
-  }
-  catch (...)
-  {
-    std::throw_with_nested(std::runtime_error("Could not write origin for collision '" + collision->name + "'!"));
-  }
+  tinyxml2::XMLElement* xml_origin = writeOrigin(collision->origin, doc);
+  xml_element->InsertEndChild(xml_origin);
 
   try
   {

--- a/tesseract_urdf/src/cone.cpp
+++ b/tesseract_urdf/src/cone.cpp
@@ -45,7 +45,8 @@ tesseract_geometry::Cone::Ptr tesseract_urdf::parseCone(const tinyxml2::XMLEleme
   return std::make_shared<tesseract_geometry::Cone>(r, l);
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeCone(const std::shared_ptr<const tesseract_geometry::Cone>& cone, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeCone(const std::shared_ptr<const tesseract_geometry::Cone>& cone,
+                                                tinyxml2::XMLDocument& doc)
 {
   if (cone == nullptr)
     std::throw_with_nested(std::runtime_error("Cone is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/cone.cpp
+++ b/tesseract_urdf/src/cone.cpp
@@ -44,3 +44,13 @@ tesseract_geometry::Cone::Ptr tesseract_urdf::parseCone(const tinyxml2::XMLEleme
 
   return std::make_shared<tesseract_geometry::Cone>(r, l);
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeCone(const std::shared_ptr<const tesseract_geometry::Cone>& cone, tinyxml2::XMLDocument& doc)
+{
+  if (cone == nullptr)
+    std::throw_with_nested(std::runtime_error("Cone is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("cone");
+  xml_element->SetAttribute("length", cone->getLength());
+  xml_element->SetAttribute("radius", cone->getRadius());
+  return xml_element;
+}

--- a/tesseract_urdf/src/convex_mesh.cpp
+++ b/tesseract_urdf/src/convex_mesh.cpp
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_urdf/convex_mesh.h>
+#include <tesseract_urdf/mesh_writer.h>
 #include <tesseract_scene_graph/utils.h>
 #include <tesseract_geometry/mesh_parser.h>
 #include <tesseract_geometry/impl/mesh.h>
@@ -104,4 +105,36 @@ tesseract_urdf::parseConvexMesh(const tinyxml2::XMLElement* xml_element,
     std::throw_with_nested(std::runtime_error("ConvexMesh: Error importing meshes from filename: '" + filename + "'!"));
 
   return meshes;
+}
+
+tinyxml2::XMLElement* tesseract_urdf::writeConvexMesh(const std::shared_ptr<const tesseract_geometry::ConvexMesh>& mesh,
+                                                      tinyxml2::XMLDocument& doc,
+                                                      const std::string& directory,
+                                                      const std::string& filename)
+{
+  if (mesh == nullptr)
+    std::throw_with_nested(std::runtime_error("Mesh is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("convex_mesh");
+
+  try
+  {
+    writeMeshToFile(mesh, directory + filename);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Failed to write convex mesh to file: " + directory + filename));
+  }
+
+  xml_element->SetAttribute("filename", filename.c_str());
+
+  std::string scale_string =
+      std::to_string(mesh->getScale().x()) + " " +
+      std::to_string(mesh->getScale().y()) + " " +
+      std::to_string(mesh->getScale().z());
+
+  xml_element->SetAttribute("scale", scale_string.c_str());
+
+  xml_element->SetAttribute("convert", false);
+
+  return xml_element;
 }

--- a/tesseract_urdf/src/convex_mesh.cpp
+++ b/tesseract_urdf/src/convex_mesh.cpp
@@ -127,10 +127,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeConvexMesh(const std::shared_ptr<cons
 
   xml_element->SetAttribute("filename", filename.c_str());
 
-  std::string scale_string =
-      std::to_string(mesh->getScale().x()) + " " +
-      std::to_string(mesh->getScale().y()) + " " +
-      std::to_string(mesh->getScale().z());
+  std::string scale_string = std::to_string(mesh->getScale().x()) + " " + std::to_string(mesh->getScale().y()) + " " +
+                             std::to_string(mesh->getScale().z());
 
   xml_element->SetAttribute("scale", scale_string.c_str());
 

--- a/tesseract_urdf/src/cylinder.cpp
+++ b/tesseract_urdf/src/cylinder.cpp
@@ -46,7 +46,8 @@ tesseract_geometry::Cylinder::Ptr tesseract_urdf::parseCylinder(const tinyxml2::
   return std::make_shared<tesseract_geometry::Cylinder>(r, l);
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeCylinder(const std::shared_ptr<const tesseract_geometry::Cylinder>& cylinder, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeCylinder(const std::shared_ptr<const tesseract_geometry::Cylinder>& cylinder,
+                                                    tinyxml2::XMLDocument& doc)
 {
   if (cylinder == nullptr)
     std::throw_with_nested(std::runtime_error("Cylinder is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/cylinder.cpp
+++ b/tesseract_urdf/src/cylinder.cpp
@@ -45,3 +45,13 @@ tesseract_geometry::Cylinder::Ptr tesseract_urdf::parseCylinder(const tinyxml2::
 
   return std::make_shared<tesseract_geometry::Cylinder>(r, l);
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeCylinder(const std::shared_ptr<const tesseract_geometry::Cylinder>& cylinder, tinyxml2::XMLDocument& doc)
+{
+  if (cylinder == nullptr)
+    std::throw_with_nested(std::runtime_error("Cylinder is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("cylinder");
+  xml_element->SetAttribute("length", cylinder->getLength());
+  xml_element->SetAttribute("radius", cylinder->getRadius());
+  return xml_element;
+}

--- a/tesseract_urdf/src/dynamics.cpp
+++ b/tesseract_urdf/src/dynamics.cpp
@@ -59,3 +59,15 @@ tesseract_scene_graph::JointDynamics::Ptr tesseract_urdf::parseDynamics(const ti
 
   return dynamics;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeDynamics(const std::shared_ptr<const tesseract_scene_graph::JointDynamics>& dynamics, tinyxml2::XMLDocument& doc)
+{
+  if (dynamics == nullptr)
+    std::throw_with_nested(std::runtime_error("Dynamics is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("dynamics");
+
+  xml_element->SetAttribute("damping", dynamics->damping);
+  xml_element->SetAttribute("friction", dynamics->damping);
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/dynamics.cpp
+++ b/tesseract_urdf/src/dynamics.cpp
@@ -60,7 +60,9 @@ tesseract_scene_graph::JointDynamics::Ptr tesseract_urdf::parseDynamics(const ti
   return dynamics;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeDynamics(const std::shared_ptr<const tesseract_scene_graph::JointDynamics>& dynamics, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement*
+tesseract_urdf::writeDynamics(const std::shared_ptr<const tesseract_scene_graph::JointDynamics>& dynamics,
+                              tinyxml2::XMLDocument& doc)
 {
   if (dynamics == nullptr)
     std::throw_with_nested(std::runtime_error("Dynamics is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/geometry.cpp
+++ b/tesseract_urdf/src/geometry.cpp
@@ -225,7 +225,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_sphere = writeSphere(std::static_pointer_cast<const tesseract_geometry::Sphere>(geometry), doc);
+      tinyxml2::XMLElement* xml_sphere =
+          writeSphere(std::static_pointer_cast<const tesseract_geometry::Sphere>(geometry), doc);
       xml_element->InsertEndChild(xml_sphere);
     }
     catch (...)
@@ -237,7 +238,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_cylinder = writeCylinder(std::static_pointer_cast<const tesseract_geometry::Cylinder>(geometry), doc);
+      tinyxml2::XMLElement* xml_cylinder =
+          writeCylinder(std::static_pointer_cast<const tesseract_geometry::Cylinder>(geometry), doc);
       xml_element->InsertEndChild(xml_cylinder);
     }
     catch (...)
@@ -249,7 +251,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_capsule = writeCapsule(std::static_pointer_cast<const tesseract_geometry::Capsule>(geometry), doc);
+      tinyxml2::XMLElement* xml_capsule =
+          writeCapsule(std::static_pointer_cast<const tesseract_geometry::Capsule>(geometry), doc);
       xml_element->InsertEndChild(xml_capsule);
     }
     catch (...)
@@ -261,7 +264,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_cone = writeCone(std::static_pointer_cast<const tesseract_geometry::Cone>(geometry), doc);
+      tinyxml2::XMLElement* xml_cone =
+          writeCone(std::static_pointer_cast<const tesseract_geometry::Cone>(geometry), doc);
       xml_element->InsertEndChild(xml_cone);
     }
     catch (...)
@@ -289,7 +293,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_mesh = writeMesh(std::static_pointer_cast<const tesseract_geometry::Mesh>(geometry), doc, directory, filename + ".ply");
+      tinyxml2::XMLElement* xml_mesh = writeMesh(
+          std::static_pointer_cast<const tesseract_geometry::Mesh>(geometry), doc, directory, filename + ".ply");
       xml_element->InsertEndChild(xml_mesh);
     }
     catch (...)
@@ -301,7 +306,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_convex_mesh = writeConvexMesh(std::static_pointer_cast<const tesseract_geometry::ConvexMesh>(geometry), doc, directory, filename + ".ply");
+      tinyxml2::XMLElement* xml_convex_mesh = writeConvexMesh(
+          std::static_pointer_cast<const tesseract_geometry::ConvexMesh>(geometry), doc, directory, filename + ".ply");
       xml_element->InsertEndChild(xml_convex_mesh);
     }
     catch (...)
@@ -313,7 +319,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_sdf_mesh = writeSDFMesh(std::static_pointer_cast<const tesseract_geometry::SDFMesh>(geometry), doc, directory, filename + ".ply");
+      tinyxml2::XMLElement* xml_sdf_mesh = writeSDFMesh(
+          std::static_pointer_cast<const tesseract_geometry::SDFMesh>(geometry), doc, directory, filename + ".ply");
       xml_element->InsertEndChild(xml_sdf_mesh);
     }
     catch (...)
@@ -325,7 +332,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const 
   {
     try
     {
-      tinyxml2::XMLElement* xml_octree = writeOctomap(std::static_pointer_cast<const tesseract_geometry::Octree>(geometry), doc, directory, filename + ".bt");
+      tinyxml2::XMLElement* xml_octree = writeOctomap(
+          std::static_pointer_cast<const tesseract_geometry::Octree>(geometry), doc, directory, filename + ".bt");
       xml_element->InsertEndChild(xml_octree);
     }
     catch (...)

--- a/tesseract_urdf/src/geometry.cpp
+++ b/tesseract_urdf/src/geometry.cpp
@@ -209,3 +209,134 @@ tesseract_urdf::parseGeometry(const tinyxml2::XMLElement* xml_element,
 
   return geometries;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeGeometry(const std::shared_ptr<const tesseract_geometry::Geometry>& geometry,
+                                                    tinyxml2::XMLDocument& doc,
+                                                    const std::string& directory,
+                                                    const std::string& filename)
+{
+  if (geometry == nullptr)
+    std::throw_with_nested(std::runtime_error("Geometry is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("geometry");
+
+  tesseract_geometry::GeometryType type = geometry->getType();
+
+  if (type == tesseract_geometry::GeometryType::SPHERE)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_sphere = writeSphere(std::static_pointer_cast<const tesseract_geometry::Sphere>(geometry), doc);
+      xml_element->InsertEndChild(xml_sphere);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as sphere!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::CYLINDER)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_cylinder = writeCylinder(std::static_pointer_cast<const tesseract_geometry::Cylinder>(geometry), doc);
+      xml_element->InsertEndChild(xml_cylinder);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as cylinder!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::CAPSULE)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_capsule = writeCapsule(std::static_pointer_cast<const tesseract_geometry::Capsule>(geometry), doc);
+      xml_element->InsertEndChild(xml_capsule);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as capsule!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::CONE)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_cone = writeCone(std::static_pointer_cast<const tesseract_geometry::Cone>(geometry), doc);
+      xml_element->InsertEndChild(xml_cone);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as cone!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::BOX)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_box = writeBox(std::static_pointer_cast<const tesseract_geometry::Box>(geometry), doc);
+      xml_element->InsertEndChild(xml_box);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as box!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::PLANE)
+  {
+    std::throw_with_nested(std::runtime_error("Cannot write geometry of type PLANE to XML!  Consider using box."));
+  }
+  else if (type == tesseract_geometry::GeometryType::MESH)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_mesh = writeMesh(std::static_pointer_cast<const tesseract_geometry::Mesh>(geometry), doc, directory, filename + ".ply");
+      xml_element->InsertEndChild(xml_mesh);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as mesh!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::CONVEX_MESH)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_convex_mesh = writeConvexMesh(std::static_pointer_cast<const tesseract_geometry::ConvexMesh>(geometry), doc, directory, filename + ".ply");
+      xml_element->InsertEndChild(xml_convex_mesh);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as convex mesh!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::SDF_MESH)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_sdf_mesh = writeSDFMesh(std::static_pointer_cast<const tesseract_geometry::SDFMesh>(geometry), doc, directory, filename + ".ply");
+      xml_element->InsertEndChild(xml_sdf_mesh);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as SDF mesh!"));
+    }
+  }
+  else if (type == tesseract_geometry::GeometryType::OCTREE)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_octree = writeOctomap(std::static_pointer_cast<const tesseract_geometry::Octree>(geometry), doc, directory, filename + ".bt");
+      xml_element->InsertEndChild(xml_octree);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write geometry marked as octree!"));
+    }
+  }
+  else
+  {
+    std::throw_with_nested(std::runtime_error("Unknown geometry type, cannot write to XML!"));
+  }
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/inertial.cpp
+++ b/tesseract_urdf/src/inertial.cpp
@@ -81,3 +81,25 @@ tesseract_scene_graph::Inertial::Ptr tesseract_urdf::parseInertial(const tinyxml
 
   return inertial;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeInertial(const std::shared_ptr<const tesseract_scene_graph::Inertial>& inertial, tinyxml2::XMLDocument& doc)
+{
+  if (inertial == nullptr)
+    std::throw_with_nested(std::runtime_error("Inertial is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("inertial");
+
+  tinyxml2::XMLElement* xml_mass = doc.NewElement("mass");
+  xml_mass->SetAttribute("value", inertial->mass);
+
+  tinyxml2::XMLElement* xml_inertia = doc.NewElement("inertia");
+  xml_inertia->SetAttribute("ixx", inertial->ixx);
+  xml_inertia->SetAttribute("ixy", inertial->ixy);
+  xml_inertia->SetAttribute("ixz", inertial->ixz);
+  xml_inertia->SetAttribute("iyy", inertial->iyy);
+  xml_inertia->SetAttribute("iyz", inertial->iyz);
+  xml_inertia->SetAttribute("izz", inertial->izz);
+
+  xml_element->InsertEndChild(xml_mass);
+  xml_element->InsertEndChild(xml_inertia);
+  return xml_element;
+}

--- a/tesseract_urdf/src/inertial.cpp
+++ b/tesseract_urdf/src/inertial.cpp
@@ -90,6 +90,9 @@ tesseract_urdf::writeInertial(const std::shared_ptr<const tesseract_scene_graph:
     std::throw_with_nested(std::runtime_error("Inertial is nullptr and cannot be converted to XML"));
   tinyxml2::XMLElement* xml_element = doc.NewElement("inertial");
 
+  tinyxml2::XMLElement* xml_origin = writeOrigin(inertial->origin, doc);
+  xml_element->InsertEndChild(xml_origin);
+
   tinyxml2::XMLElement* xml_mass = doc.NewElement("mass");
   xml_mass->SetAttribute("value", inertial->mass);
 

--- a/tesseract_urdf/src/inertial.cpp
+++ b/tesseract_urdf/src/inertial.cpp
@@ -82,7 +82,9 @@ tesseract_scene_graph::Inertial::Ptr tesseract_urdf::parseInertial(const tinyxml
   return inertial;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeInertial(const std::shared_ptr<const tesseract_scene_graph::Inertial>& inertial, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement*
+tesseract_urdf::writeInertial(const std::shared_ptr<const tesseract_scene_graph::Inertial>& inertial,
+                              tinyxml2::XMLDocument& doc)
 {
   if (inertial == nullptr)
     std::throw_with_nested(std::runtime_error("Inertial is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/joint.cpp
+++ b/tesseract_urdf/src/joint.cpp
@@ -227,7 +227,8 @@ tesseract_scene_graph::Joint::Ptr tesseract_urdf::parseJoint(const tinyxml2::XML
   return j;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeJoint(const std::shared_ptr<const tesseract_scene_graph::Joint>& joint, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeJoint(const std::shared_ptr<const tesseract_scene_graph::Joint>& joint,
+                                                 tinyxml2::XMLDocument& doc)
 {
   if (joint == nullptr)
     std::throw_with_nested(std::runtime_error("Joint is nullptr and cannot be converted to XML"));
@@ -264,17 +265,15 @@ tinyxml2::XMLElement* tesseract_urdf::writeJoint(const std::shared_ptr<const tes
   else if (joint->type == tesseract_scene_graph::JointType::FIXED)
     xml_element->SetAttribute("type", "fixed");
   else
-    std::throw_with_nested(
-        std::runtime_error("Joint: Invalid joint type for joint '" + joint->getName() + "'!"));
+    std::throw_with_nested(std::runtime_error("Joint: Invalid joint type for joint '" + joint->getName() + "'!"));
 
   // Set joint axis
-  if (joint->type != tesseract_scene_graph::JointType::FLOATING && joint->type != tesseract_scene_graph::JointType::FIXED)
+  if (joint->type != tesseract_scene_graph::JointType::FLOATING &&
+      joint->type != tesseract_scene_graph::JointType::FIXED)
   {
     tinyxml2::XMLElement* xml_axis = doc.NewElement("axis");
     std::string axis_str =
-        std::to_string(joint->axis.x()) + " " +
-        std::to_string(joint->axis.y()) + " " +
-        std::to_string(joint->axis.z());
+        std::to_string(joint->axis.x()) + " " + std::to_string(joint->axis.y()) + " " + std::to_string(joint->axis.z());
     xml_axis->SetAttribute("xyz", axis_str.c_str());
     xml_element->InsertEndChild(xml_axis);
   }

--- a/tesseract_urdf/src/joint.cpp
+++ b/tesseract_urdf/src/joint.cpp
@@ -226,3 +226,97 @@ tesseract_scene_graph::Joint::Ptr tesseract_urdf::parseJoint(const tinyxml2::XML
 
   return j;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeJoint(const std::shared_ptr<const tesseract_scene_graph::Joint>& joint, tinyxml2::XMLDocument& doc)
+{
+  if (joint == nullptr)
+    std::throw_with_nested(std::runtime_error("Joint is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("joint");
+
+  // Set the joint name
+  xml_element->SetAttribute("name", joint->getName().c_str());
+
+  // Set joint origin
+  tinyxml2::XMLElement* xml_origin = writeOrigin(joint->parent_to_joint_origin_transform, doc);
+  xml_element->InsertEndChild(xml_origin);
+
+  // Set parent link
+  tinyxml2::XMLElement* xml_parent = doc.NewElement("parent");
+  xml_parent->SetAttribute("link", joint->parent_link_name.c_str());
+  xml_element->InsertEndChild(xml_parent);
+
+  // Set child link
+  tinyxml2::XMLElement* xml_child = doc.NewElement("child");
+  xml_child->SetAttribute("link", joint->child_link_name.c_str());
+  xml_element->InsertEndChild(xml_child);
+
+  // Set joint type
+  if (joint->type == tesseract_scene_graph::JointType::PLANAR)
+    xml_element->SetAttribute("type", "planar");
+  else if (joint->type == tesseract_scene_graph::JointType::FLOATING)
+    xml_element->SetAttribute("type", "floating");
+  else if (joint->type == tesseract_scene_graph::JointType::REVOLUTE)
+    xml_element->SetAttribute("type", "revolute");
+  else if (joint->type == tesseract_scene_graph::JointType::CONTINUOUS)
+    xml_element->SetAttribute("type", "continuous");
+  else if (joint->type == tesseract_scene_graph::JointType::PRISMATIC)
+    xml_element->SetAttribute("type", "prismatic");
+  else if (joint->type == tesseract_scene_graph::JointType::FIXED)
+    xml_element->SetAttribute("type", "fixed");
+  else
+    std::throw_with_nested(
+        std::runtime_error("Joint: Invalid joint type for joint '" + joint->getName() + "'!"));
+
+  // Set joint axis
+  if (joint->type != tesseract_scene_graph::JointType::FLOATING && joint->type != tesseract_scene_graph::JointType::FIXED)
+  {
+    tinyxml2::XMLElement* xml_axis = doc.NewElement("axis");
+    std::string axis_str =
+        std::to_string(joint->axis.x()) + " " +
+        std::to_string(joint->axis.y()) + " " +
+        std::to_string(joint->axis.z());
+    xml_axis->SetAttribute("xyz", axis_str.c_str());
+    xml_element->InsertEndChild(xml_axis);
+  }
+
+  // Set joint limits
+  if (joint->type == tesseract_scene_graph::JointType::REVOLUTE ||
+      joint->type == tesseract_scene_graph::JointType::PRISMATIC ||
+      joint->type == tesseract_scene_graph::JointType::CONTINUOUS)
+  {
+    if (joint->limits == nullptr)
+      std::throw_with_nested(std::runtime_error("Joint: Missing limits for joint '" + joint->getName() + "'!"));
+    tinyxml2::XMLElement* xml_limits = writeLimits(joint->limits, doc);
+    xml_element->InsertEndChild(xml_limits);
+  }
+
+  // Set joint safety if it exists
+  if (joint->safety != nullptr)
+  {
+    tinyxml2::XMLElement* xml_safety = writeSafetyController(joint->safety, doc);
+    xml_element->InsertEndChild(xml_safety);
+  }
+
+  // Set joint calibration if it exists
+  if (joint->calibration != nullptr)
+  {
+    tinyxml2::XMLElement* xml_calibration = writeCalibration(joint->calibration, doc);
+    xml_element->InsertEndChild(xml_calibration);
+  }
+
+  // Set mimic joint it it exists
+  if (joint->mimic != nullptr)
+  {
+    tinyxml2::XMLElement* xml_mimic = writeMimic(joint->mimic, doc);
+    xml_element->InsertEndChild(xml_mimic);
+  }
+
+  // Set dynamics if exists
+  if (joint->dynamics != nullptr)
+  {
+    tinyxml2::XMLElement* xml_dynamics = writeDynamics(joint->dynamics, doc);
+    xml_element->InsertEndChild(xml_dynamics);
+  }
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/limits.cpp
+++ b/tesseract_urdf/src/limits.cpp
@@ -61,7 +61,9 @@ tesseract_scene_graph::JointLimits::Ptr tesseract_urdf::parseLimits(const tinyxm
   return limits;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeLimits(const std::shared_ptr<const tesseract_scene_graph::JointLimits>& limits, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement*
+tesseract_urdf::writeLimits(const std::shared_ptr<const tesseract_scene_graph::JointLimits>& limits,
+                            tinyxml2::XMLDocument& doc)
 {
   if (limits == nullptr)
     std::throw_with_nested(std::runtime_error("Limits are nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/limits.cpp
+++ b/tesseract_urdf/src/limits.cpp
@@ -60,3 +60,18 @@ tesseract_scene_graph::JointLimits::Ptr tesseract_urdf::parseLimits(const tinyxm
 
   return limits;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeLimits(const std::shared_ptr<const tesseract_scene_graph::JointLimits>& limits, tinyxml2::XMLDocument& doc)
+{
+  if (limits == nullptr)
+    std::throw_with_nested(std::runtime_error("Limits are nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("limits");
+
+  xml_element->SetAttribute("lower", limits->lower);
+  xml_element->SetAttribute("upper", limits->upper);
+  xml_element->SetAttribute("effort", limits->effort);
+  xml_element->SetAttribute("velocity", limits->velocity);
+  xml_element->SetAttribute("acceleration", limits->acceleration);
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/link.cpp
+++ b/tesseract_urdf/src/link.cpp
@@ -152,7 +152,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeLink(const std::shared_ptr<const tess
     }
     catch (...)
     {
-      std::throw_with_nested(std::runtime_error("Could not write collision to XML for link `" + link->getName() + "`!"));
+      std::throw_with_nested(
+          std::runtime_error("Could not write collision to XML for link `" + link->getName() + "`!"));
     }
   }
 

--- a/tesseract_urdf/src/link.cpp
+++ b/tesseract_urdf/src/link.cpp
@@ -103,3 +103,58 @@ tesseract_urdf::parseLink(const tinyxml2::XMLElement* xml_element,
 
   return l;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeLink(const std::shared_ptr<const tesseract_scene_graph::Link>& link,
+                                                tinyxml2::XMLDocument& doc,
+                                                const std::string& directory)
+{
+  if (link == nullptr)
+    std::throw_with_nested(std::runtime_error("Link is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("link");
+
+  // Set name
+  xml_element->SetAttribute("name", link->getName().c_str());
+
+  // Set inertia if it exists
+  if (link->inertial != nullptr)
+  {
+    tinyxml2::XMLElement* xml_inertial = writeInertial(link->inertial, doc);
+    xml_element->InsertEndChild(xml_inertial);
+  }
+
+  // Set visual if it exists
+  int id = -1;
+  if (link->visual.size() > 1)
+    id = 0;
+  for (const tesseract_scene_graph::Visual::Ptr& vis : link->visual)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_visual = writeVisual(vis, doc, directory, link->getName(), id++);
+      xml_element->InsertEndChild(xml_visual);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write visual to XML for link `" + link->getName() + "`!"));
+    }
+  }
+
+  // Set collision if it exists
+  id = -1;
+  if (link->collision.size() > 1)
+    id = 0;
+  for (const tesseract_scene_graph::Collision::Ptr& col : link->collision)
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_collision = writeCollision(col, doc, directory, link->getName(), id++);
+      xml_element->InsertEndChild(xml_collision);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write collision to XML for link `" + link->getName() + "`!"));
+    }
+  }
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/material.cpp
+++ b/tesseract_urdf/src/material.cpp
@@ -119,7 +119,9 @@ tesseract_scene_graph::Material::Ptr tesseract_urdf::parseMaterial(
   return m;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeMaterial(const std::shared_ptr<const tesseract_scene_graph::Material>& material, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement*
+tesseract_urdf::writeMaterial(const std::shared_ptr<const tesseract_scene_graph::Material>& material,
+                              tinyxml2::XMLDocument& doc)
 {
   if (material == nullptr)
     std::throw_with_nested(std::runtime_error("Material is nullptr and cannot be converted to XML"));
@@ -132,11 +134,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeMaterial(const std::shared_ptr<const 
   xml_element->InsertEndChild(xml_texture);
 
   tinyxml2::XMLElement* xml_color = doc.NewElement("color");
-  std::string color_string =
-      std::to_string(material->color(0)) + " " +
-      std::to_string(material->color(1)) + " " +
-      std::to_string(material->color(2)) + " " +
-      std::to_string(material->color(3));
+  std::string color_string = std::to_string(material->color(0)) + " " + std::to_string(material->color(1)) + " " +
+                             std::to_string(material->color(2)) + " " + std::to_string(material->color(3));
   xml_color->SetAttribute("color", color_string.c_str());
   xml_element->InsertEndChild(xml_color);
 

--- a/tesseract_urdf/src/material.cpp
+++ b/tesseract_urdf/src/material.cpp
@@ -118,3 +118,27 @@ tesseract_scene_graph::Material::Ptr tesseract_urdf::parseMaterial(
 
   return m;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeMaterial(const std::shared_ptr<const tesseract_scene_graph::Material>& material, tinyxml2::XMLDocument& doc)
+{
+  if (material == nullptr)
+    std::throw_with_nested(std::runtime_error("Material is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("material");
+
+  xml_element->SetAttribute("name", material->getName().c_str());
+
+  tinyxml2::XMLElement* xml_texture = doc.NewElement("texture");
+  xml_texture->SetAttribute("filename", material->texture_filename.c_str());
+  xml_element->InsertEndChild(xml_texture);
+
+  tinyxml2::XMLElement* xml_color = doc.NewElement("color");
+  std::string color_string =
+      std::to_string(material->color(0)) + " " +
+      std::to_string(material->color(1)) + " " +
+      std::to_string(material->color(2)) + " " +
+      std::to_string(material->color(3));
+  xml_color->SetAttribute("color", color_string.c_str());
+  xml_element->InsertEndChild(xml_color);
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/mesh.cpp
+++ b/tesseract_urdf/src/mesh.cpp
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_urdf/mesh.h>
+#include <tesseract_urdf/mesh_writer.h>
 #include <tesseract_scene_graph/utils.h>
 #include <tesseract_scene_graph/resource_locator.h>
 #include <tesseract_geometry/mesh_parser.h>
@@ -90,4 +91,34 @@ tesseract_urdf::parseMesh(const tinyxml2::XMLElement* xml_element,
     std::throw_with_nested(std::runtime_error("Mesh: Error importing meshes from filename: '" + filename + "'!"));
 
   return meshes;
+}
+
+tinyxml2::XMLElement* tesseract_urdf::writeMesh(const std::shared_ptr<const tesseract_geometry::Mesh>& mesh,
+                                                tinyxml2::XMLDocument& doc,
+                                                const std::string& directory,
+                                                const std::string& filename)
+{
+  if (mesh == nullptr)
+    std::throw_with_nested(std::runtime_error("Mesh is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("mesh");
+
+  try
+  {
+    writeMeshToFile(mesh, directory + filename);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Failed to write convex mesh to file: " + directory + filename));
+  }
+  xml_element->SetAttribute("filename", filename.c_str());
+
+  std::string scale_string =
+      std::to_string(mesh->getScale().x()) + " " +
+      std::to_string(mesh->getScale().y()) + " " +
+      std::to_string(mesh->getScale().z());
+  xml_element->SetAttribute("scale", scale_string.c_str());
+
+  xml_element->SetAttribute("convert", false);
+
+  return xml_element;
 }

--- a/tesseract_urdf/src/mesh.cpp
+++ b/tesseract_urdf/src/mesh.cpp
@@ -112,10 +112,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeMesh(const std::shared_ptr<const tess
   }
   xml_element->SetAttribute("filename", filename.c_str());
 
-  std::string scale_string =
-      std::to_string(mesh->getScale().x()) + " " +
-      std::to_string(mesh->getScale().y()) + " " +
-      std::to_string(mesh->getScale().z());
+  std::string scale_string = std::to_string(mesh->getScale().x()) + " " + std::to_string(mesh->getScale().y()) + " " +
+                             std::to_string(mesh->getScale().z());
   xml_element->SetAttribute("scale", scale_string.c_str());
 
   xml_element->SetAttribute("convert", false);

--- a/tesseract_urdf/src/mesh_writer.cpp
+++ b/tesseract_urdf/src/mesh_writer.cpp
@@ -1,0 +1,137 @@
+#include <tesseract_urdf/mesh_writer.h>
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+
+#include <pcl/conversions.h>
+#include <pcl/io/vtk_lib_io.h>
+#include <pcl/point_cloud.h>
+
+// #include <assimp/Exporter.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+namespace tesseract_urdf
+{
+/*
+aiScene createAssetFromMesh(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh)
+{
+  // Create an assimp scene
+  aiScene scene;
+  scene.mRootNode = new aiNode();
+
+  // Make space for and create a default material
+  scene.mMaterials = new aiMaterial*[1];
+  scene.mMaterials[0] = new aiMaterial();
+  scene.mNumMaterials = 1;
+
+  // Make space for and create a mesh
+  scene.mMeshes = new aiMesh*[1];
+  scene.mMeshes[0] = new aiMesh();
+  scene.mMeshes[0]->mMaterialIndex = 0;
+  scene.mNumMeshes = 1;
+
+  // Register the mesh as part of the scene root node
+  scene.mRootNode->mMeshes = new unsigned int[1];
+  scene.mRootNode->mMeshes[0] = 0;
+  scene.mRootNode->mNumMeshes = 1;
+
+  // Transcribe in the mesh vertices
+  scene.mMeshes[0]->mVertices = new aiVector3D[static_cast<unsigned long>(mesh->getVertexCount())];
+  scene.mMeshes[0]->mNumVertices = static_cast<unsigned int>(mesh->getVertexCount());
+
+  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getVertexCount()); ++i)
+  {
+    scene.mMeshes[0]->mVertices[i] = aiVector3D(static_cast<float>(mesh->getVertices()->at(i).x()),
+                                                static_cast<float>(mesh->getVertices()->at(i).y()),
+                                                static_cast<float>(mesh->getVertices()->at(i).z()));
+  }
+
+  // Transcribe in the mesh triangles
+  scene.mMeshes[0]->mFaces = new aiFace[static_cast<unsigned long>(mesh->getFaceCount())];
+  scene.mMeshes[0]->mNumFaces = static_cast<unsigned int>(mesh->getFaceCount());
+
+  int indices = 0;
+  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getFaceCount()) && indices < mesh->getFaces()->size(); ++i)
+  {
+    // Find and set the number of vertices for this face
+    int num_vertices = (*mesh->getFaces())(indices);
+    scene.mMeshes[0]->mFaces[i].mIndices = new unsigned int[static_cast<unsigned long>(num_vertices)];
+    scene.mMeshes[0]->mFaces[i].mNumIndices = static_cast<unsigned int>(num_vertices);
+
+    // Copy over the index pointing to each vertex
+    for (int j = 1; j <= num_vertices; ++j)
+      scene.mMeshes[0]->mFaces[i].mIndices[j - 1] = static_cast<unsigned int>((*mesh->getFaces())(indices + j));
+
+    // Move along all the vertex indices just applied
+    indices += num_vertices;
+
+    // And move one more to get to the next face-size-indicator
+    ++indices;
+  }
+
+  // mTextureCoords? mNumUVComponents?
+
+  return scene;
+}
+*/
+
+pcl::PolygonMesh createPCLMesh(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh)
+{
+  // Create a PCL polygon mesh
+  pcl::PolygonMesh pcl_mesh;
+
+  // Transcribe in the mesh vertices
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  cloud.resize(static_cast<unsigned long>(mesh->getVertexCount()));
+  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getVertexCount()); ++i)
+  {
+    cloud[i] = pcl::PointXYZ(static_cast<float>(mesh->getVertices()->at(i).x()),
+                             static_cast<float>(mesh->getVertices()->at(i).y()),
+                             static_cast<float>(mesh->getVertices()->at(i).z()));
+  }
+  pcl::toPCLPointCloud2(cloud, pcl_mesh.cloud);
+
+  // Transcribe in the mesh polygons
+  pcl_mesh.polygons.resize(static_cast<std::size_t>(mesh->getFaceCount()));
+
+  std::size_t indices = 0;
+  for (std::size_t i = 0; i < static_cast<std::size_t>(mesh->getFaceCount()) &&
+                          indices < static_cast<std::size_t>(mesh->getFaces()->size());
+       ++i)
+  {
+    // Find and set the number of vertices for this face
+    int num_vertices = (*mesh->getFaces())(static_cast<Eigen::Index>(indices));
+    pcl_mesh.polygons[i].vertices.resize(static_cast<std::size_t>(num_vertices));
+
+    // Copy over the index pointing to each vertex
+    for (std::size_t j = 0; j < static_cast<std::size_t>(num_vertices); ++j)
+      pcl_mesh.polygons[i].vertices[j] =
+          static_cast<unsigned int>((*mesh->getFaces())(static_cast<Eigen::Index>(indices + 1 + j)));
+
+    // Move along all the vertex indices just applied
+    indices += static_cast<std::size_t>(num_vertices);
+
+    // And move one more to get to the next face-size-indicator
+    ++indices;
+  }
+
+  return pcl_mesh;
+}
+
+void writeMeshToFile(const std::shared_ptr<const tesseract_geometry::PolygonMesh>& mesh, const std::string& filepath)
+{
+  pcl::PolygonMesh pcl_mesh = createPCLMesh(mesh);
+  if (pcl::io::savePolygonFile(filepath, pcl_mesh) == 0)
+    std::throw_with_nested(std::runtime_error("Could not export file"));
+
+  /* Option to use the Assimp code if errors are resolved.
+  aiScene scene = createAssetFromMesh(mesh);
+  Assimp::Exporter exporter;
+
+  aiReturn ret = exporter.Export(&scene, "pFormatId", filepath.c_str());
+
+  if (ret != AI_SUCCESS)
+    std::throw_with_nested(std::runtime_error("Could not export file"));
+  */
+}
+}  // namespace tesseract_urdf

--- a/tesseract_urdf/src/mimic.cpp
+++ b/tesseract_urdf/src/mimic.cpp
@@ -60,7 +60,8 @@ tesseract_scene_graph::JointMimic::Ptr tesseract_urdf::parseMimic(const tinyxml2
   return m;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeMimic(const std::shared_ptr<const tesseract_scene_graph::JointMimic>& mimic, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeMimic(const std::shared_ptr<const tesseract_scene_graph::JointMimic>& mimic,
+                                                 tinyxml2::XMLDocument& doc)
 {
   if (mimic == nullptr)
     std::throw_with_nested(std::runtime_error("Mimic Joint is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/mimic.cpp
+++ b/tesseract_urdf/src/mimic.cpp
@@ -59,3 +59,16 @@ tesseract_scene_graph::JointMimic::Ptr tesseract_urdf::parseMimic(const tinyxml2
 
   return m;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeMimic(const std::shared_ptr<const tesseract_scene_graph::JointMimic>& mimic, tinyxml2::XMLDocument& doc)
+{
+  if (mimic == nullptr)
+    std::throw_with_nested(std::runtime_error("Mimic Joint is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("mimic");
+
+  xml_element->SetAttribute("joint", mimic->joint_name.c_str());
+  xml_element->SetAttribute("offset", mimic->offset);
+  xml_element->SetAttribute("multiplier", mimic->multiplier);
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/octomap.cpp
+++ b/tesseract_urdf/src/octomap.cpp
@@ -94,3 +94,41 @@ tesseract_geometry::Octree::Ptr tesseract_urdf::parseOctomap(const tinyxml2::XML
 
   std::throw_with_nested(std::runtime_error("Octomap: Missing element 'octree' or 'point_cloud', must define one!"));
 }
+
+
+tinyxml2::XMLElement* tesseract_urdf::writeOctomap(const std::shared_ptr<const tesseract_geometry::Octree>& octree,
+                                                   tinyxml2::XMLDocument& doc,
+                                                   const std::string& directory,
+                                                   const std::string& filename)
+{
+  if (octree == nullptr)
+    std::throw_with_nested(std::runtime_error("Octree is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("octree");
+
+  std::string type_string;
+  if (octree->getSubType() == tesseract_geometry::Octree::SubType::BOX)
+    type_string = "box";
+  else if (octree->getSubType() == tesseract_geometry::Octree::SubType::SPHERE_INSIDE)
+    type_string = "sphere_inside";
+  else if (octree->getSubType() == tesseract_geometry::Octree::SubType::SPHERE_OUTSIDE)
+    type_string = "sphere_outside";
+  else
+    std::throw_with_nested(std::runtime_error("Octree subtype is invalid and cannot be converted to XML"));
+  xml_element->SetAttribute("shape_type", type_string.c_str());
+
+  xml_element->SetAttribute("prune", octree->getPruned());
+
+  try
+  {
+    tinyxml2::XMLElement* xml_octree = writeOctree(octree, doc, directory, filename);
+    xml_element->InsertEndChild(xml_octree);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Octomap: Could not write octree to file"));
+  }
+
+  // @dmerz - optionally write to .pcd file?
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/octomap.cpp
+++ b/tesseract_urdf/src/octomap.cpp
@@ -95,7 +95,6 @@ tesseract_geometry::Octree::Ptr tesseract_urdf::parseOctomap(const tinyxml2::XML
   std::throw_with_nested(std::runtime_error("Octomap: Missing element 'octree' or 'point_cloud', must define one!"));
 }
 
-
 tinyxml2::XMLElement* tesseract_urdf::writeOctomap(const std::shared_ptr<const tesseract_geometry::Octree>& octree,
                                                    tinyxml2::XMLDocument& doc,
                                                    const std::string& directory,

--- a/tesseract_urdf/src/octree.cpp
+++ b/tesseract_urdf/src/octree.cpp
@@ -64,3 +64,24 @@ tesseract_geometry::Octree::Ptr tesseract_urdf::parseOctree(const tinyxml2::XMLE
 
   return geom;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeOctree(const tesseract_geometry::Octree::ConstPtr& octree,
+                                                  tinyxml2::XMLDocument& doc,
+                                                  const std::string& directory,
+                                                  const std::string& filename)
+{
+  tinyxml2::XMLElement* xml_element = doc.NewElement("octree");
+
+  std::string filepath = directory + filename;
+
+  // This copy is unfortunate, but avoiding the copy requires flowing mutability up to a lot of
+  // functions and their arguments. Don't know why writeBinary is non-const anyway, but we'll live.
+  std::shared_ptr<octomap::OcTree> underlying_tree = std::make_shared<octomap::OcTree>(*(octree->getOctree()));
+
+  if (!underlying_tree->writeBinary(filepath))
+    std::throw_with_nested(std::runtime_error("Could not write octree to file `" + filepath + "`!"));
+
+  xml_element->SetAttribute("filename", filename.c_str());
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/octree.cpp
+++ b/tesseract_urdf/src/octree.cpp
@@ -70,6 +70,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeOctree(const tesseract_geometry::Octr
                                                   const std::string& directory,
                                                   const std::string& filename)
 {
+  if (octree == nullptr)
+    std::throw_with_nested(std::runtime_error("Octree is nullptr and cannot be converted to XML"));
   tinyxml2::XMLElement* xml_element = doc.NewElement("octree");
 
   std::string filepath = directory + filename;

--- a/tesseract_urdf/src/origin.cpp
+++ b/tesseract_urdf/src/origin.cpp
@@ -128,19 +128,14 @@ tinyxml2::XMLElement* tesseract_urdf::writeOrigin(const Eigen::Isometry3d& origi
   tinyxml2::XMLElement* xml_element = doc.NewElement("origin");
 
   // Format and write the translation
-  std::string xyz_string =
-      std::to_string(origin.translation().x()) + " " +
-      std::to_string(origin.translation().y()) + " " +
-      std::to_string(origin.translation().z());
+  std::string xyz_string = std::to_string(origin.translation().x()) + " " + std::to_string(origin.translation().y()) +
+                           " " + std::to_string(origin.translation().z());
   xml_element->SetAttribute("xyz", xyz_string.c_str());
 
   // Extract, format, and write the rotation
-  Eigen::Quaterniond q (origin.linear());
+  Eigen::Quaterniond q(origin.linear());
   std::string wxyz_string =
-      std::to_string(q.w()) + " " +
-      std::to_string(q.x()) + " " +
-      std::to_string(q.y()) + " " +
-      std::to_string(q.z());
+      std::to_string(q.w()) + " " + std::to_string(q.x()) + " " + std::to_string(q.y()) + " " + std::to_string(q.z());
   xml_element->SetAttribute("wxyz", wxyz_string.c_str());
 
   return xml_element;

--- a/tesseract_urdf/src/origin.cpp
+++ b/tesseract_urdf/src/origin.cpp
@@ -122,3 +122,26 @@ Eigen::Isometry3d tesseract_urdf::parseOrigin(const tinyxml2::XMLElement* xml_el
   }
   return origin;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeOrigin(const Eigen::Isometry3d& origin, tinyxml2::XMLDocument& doc)
+{
+  tinyxml2::XMLElement* xml_element = doc.NewElement("origin");
+
+  // Format and write the translation
+  std::string xyz_string =
+      std::to_string(origin.translation().x()) + " " +
+      std::to_string(origin.translation().y()) + " " +
+      std::to_string(origin.translation().z());
+  xml_element->SetAttribute("xyz", xyz_string.c_str());
+
+  // Extract, format, and write the rotation
+  Eigen::Quaterniond q (origin.linear());
+  std::string wxyz_string =
+      std::to_string(q.w()) + " " +
+      std::to_string(q.x()) + " " +
+      std::to_string(q.y()) + " " +
+      std::to_string(q.z());
+  xml_element->SetAttribute("wxyz", wxyz_string.c_str());
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/point_cloud.cpp
+++ b/tesseract_urdf/src/point_cloud.cpp
@@ -76,3 +76,18 @@ tesseract_urdf::parsePointCloud(const tinyxml2::XMLElement* xml_element,
 
   return geom;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writePointCloud(const std::shared_ptr<const tesseract_geometry::Octree>& point_cloud, tinyxml2::XMLDocument& doc)
+{
+  if (point_cloud == nullptr)
+    std::throw_with_nested(std::runtime_error("Point_cloud is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("point_cloud");
+
+  // Convert to point cloud
+
+  // TODO: Save to file
+  std::string working_dir = "/tmp";                         // should include /visual or /collision
+  std::string filename = working_dir + "/point_cloud.pcd";  // Should have timestamp appended
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/point_cloud.cpp
+++ b/tesseract_urdf/src/point_cloud.cpp
@@ -76,18 +76,3 @@ tesseract_urdf::parsePointCloud(const tinyxml2::XMLElement* xml_element,
 
   return geom;
 }
-
-tinyxml2::XMLElement* tesseract_urdf::writePointCloud(const std::shared_ptr<const tesseract_geometry::Octree>& point_cloud, tinyxml2::XMLDocument& doc)
-{
-  if (point_cloud == nullptr)
-    std::throw_with_nested(std::runtime_error("Point_cloud is nullptr and cannot be converted to XML"));
-  tinyxml2::XMLElement* xml_element = doc.NewElement("point_cloud");
-
-  // Convert to point cloud
-
-  // TODO: Save to file
-  std::string working_dir = "/tmp";                         // should include /visual or /collision
-  std::string filename = working_dir + "/point_cloud.pcd";  // Should have timestamp appended
-
-  return xml_element;
-}

--- a/tesseract_urdf/src/safety_controller.cpp
+++ b/tesseract_urdf/src/safety_controller.cpp
@@ -70,7 +70,9 @@ tesseract_scene_graph::JointSafety::Ptr tesseract_urdf::parseSafetyController(co
   return s;
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeSafetyController(const std::shared_ptr<const tesseract_scene_graph::JointSafety>& safety, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement*
+tesseract_urdf::writeSafetyController(const std::shared_ptr<const tesseract_scene_graph::JointSafety>& safety,
+                                      tinyxml2::XMLDocument& doc)
 {
   if (safety == nullptr)
     std::throw_with_nested(std::runtime_error("Safety Controller is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/safety_controller.cpp
+++ b/tesseract_urdf/src/safety_controller.cpp
@@ -69,3 +69,19 @@ tesseract_scene_graph::JointSafety::Ptr tesseract_urdf::parseSafetyController(co
 
   return s;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeSafetyController(const std::shared_ptr<const tesseract_scene_graph::JointSafety>& safety, tinyxml2::XMLDocument& doc)
+{
+  if (safety == nullptr)
+    std::throw_with_nested(std::runtime_error("Safety Controller is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("safety");
+
+  xml_element->SetAttribute("k_velocity", safety->k_velocity);
+
+  // Could potentially check for and not write out zero.
+  xml_element->SetAttribute("soft_upper_limit", safety->soft_upper_limit);
+  xml_element->SetAttribute("soft_lower_limit", safety->soft_lower_limit);
+  xml_element->SetAttribute("k_position", safety->k_position);
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/sdf_mesh.cpp
+++ b/tesseract_urdf/src/sdf_mesh.cpp
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tinyxml2.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_urdf/mesh_writer.h>
 #include <tesseract_urdf/sdf_mesh.h>
 #include <tesseract_scene_graph/utils.h>
 #include <tesseract_scene_graph/resource_locator.h>
@@ -90,4 +91,35 @@ tesseract_urdf::parseSDFMesh(const tinyxml2::XMLElement* xml_element,
     std::throw_with_nested(std::runtime_error("SDFMesh: Error importing meshes from filename: '" + filename + "'!"));
 
   return meshes;
+}
+
+tinyxml2::XMLElement* tesseract_urdf::writeSDFMesh(const std::shared_ptr<const tesseract_geometry::SDFMesh>& sdf_mesh,
+                                                   tinyxml2::XMLDocument& doc,
+                                                   const std::string& directory,
+                                                   const std::string& filename)
+{
+
+  if (sdf_mesh == nullptr)
+    std::throw_with_nested(std::runtime_error("SDF Mesh is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("sdf_mesh");
+
+  try
+  {
+    writeMeshToFile(sdf_mesh, directory + filename);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Failed to write convex mesh to file: " + directory + filename));
+  }
+  xml_element->SetAttribute("filename", filename.c_str());
+
+  std::string scale_string =
+      std::to_string(sdf_mesh->getScale().x()) + " " +
+      std::to_string(sdf_mesh->getScale().y()) + " " +
+      std::to_string(sdf_mesh->getScale().z());
+  xml_element->SetAttribute("scale", scale_string.c_str());
+
+  xml_element->SetAttribute("convert", false);
+
+  return xml_element;
 }

--- a/tesseract_urdf/src/sdf_mesh.cpp
+++ b/tesseract_urdf/src/sdf_mesh.cpp
@@ -98,7 +98,6 @@ tinyxml2::XMLElement* tesseract_urdf::writeSDFMesh(const std::shared_ptr<const t
                                                    const std::string& directory,
                                                    const std::string& filename)
 {
-
   if (sdf_mesh == nullptr)
     std::throw_with_nested(std::runtime_error("SDF Mesh is nullptr and cannot be converted to XML"));
   tinyxml2::XMLElement* xml_element = doc.NewElement("sdf_mesh");
@@ -113,10 +112,8 @@ tinyxml2::XMLElement* tesseract_urdf::writeSDFMesh(const std::shared_ptr<const t
   }
   xml_element->SetAttribute("filename", filename.c_str());
 
-  std::string scale_string =
-      std::to_string(sdf_mesh->getScale().x()) + " " +
-      std::to_string(sdf_mesh->getScale().y()) + " " +
-      std::to_string(sdf_mesh->getScale().z());
+  std::string scale_string = std::to_string(sdf_mesh->getScale().x()) + " " + std::to_string(sdf_mesh->getScale().y()) +
+                             " " + std::to_string(sdf_mesh->getScale().z());
   xml_element->SetAttribute("scale", scale_string.c_str());
 
   xml_element->SetAttribute("convert", false);

--- a/tesseract_urdf/src/sphere.cpp
+++ b/tesseract_urdf/src/sphere.cpp
@@ -41,3 +41,14 @@ tesseract_geometry::Sphere::Ptr tesseract_urdf::parseSphere(const tinyxml2::XMLE
 
   return std::make_shared<tesseract_geometry::Sphere>(radius);
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeSphere(const std::shared_ptr<const tesseract_geometry::Sphere>& sphere, tinyxml2::XMLDocument& doc)
+{
+  if (sphere == nullptr)
+    std::throw_with_nested(std::runtime_error("Sphere is nullptr and cannot be converted to XML"));
+  tinyxml2::XMLElement* xml_element = doc.NewElement("sphere");
+
+  xml_element->SetAttribute("radius", sphere->getRadius());
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/sphere.cpp
+++ b/tesseract_urdf/src/sphere.cpp
@@ -42,7 +42,8 @@ tesseract_geometry::Sphere::Ptr tesseract_urdf::parseSphere(const tinyxml2::XMLE
   return std::make_shared<tesseract_geometry::Sphere>(radius);
 }
 
-tinyxml2::XMLElement* tesseract_urdf::writeSphere(const std::shared_ptr<const tesseract_geometry::Sphere>& sphere, tinyxml2::XMLDocument& doc)
+tinyxml2::XMLElement* tesseract_urdf::writeSphere(const std::shared_ptr<const tesseract_geometry::Sphere>& sphere,
+                                                  tinyxml2::XMLDocument& doc)
 {
   if (sphere == nullptr)
     std::throw_with_nested(std::runtime_error("Sphere is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/urdf_parser.cpp
+++ b/tesseract_urdf/src/urdf_parser.cpp
@@ -194,6 +194,10 @@ void writeURDFFile(const tesseract_scene_graph::SceneGraph::ConstPtr& sg,
   // Create XML Document
   tinyxml2::XMLDocument doc;
 
+  // Add XML Declaration
+  tinyxml2::XMLDeclaration* xml_declaration = doc.NewDeclaration(R"(xml version="1.0" )");
+  doc.InsertFirstChild(xml_declaration);
+
   // Assign Robot Name
   tinyxml2::XMLElement* xml_robot = doc.NewElement("robot");
   xml_robot->SetAttribute("name", sg->getName().c_str());

--- a/tesseract_urdf/src/urdf_parser.cpp
+++ b/tesseract_urdf/src/urdf_parser.cpp
@@ -28,6 +28,8 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <fstream>
 #include <stdexcept>
+
+#include <boost/filesystem.hpp>
 #include <tesseract_common/utils.h>
 #include <tinyxml2.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -172,6 +174,65 @@ tesseract_scene_graph::SceneGraph::Ptr parseURDFFile(const std::string& path,
   }
 
   return sg;
+}
+
+void writeURDFFile(const tesseract_scene_graph::SceneGraph::ConstPtr& sg,
+                   const std::string& directory,
+                   const std::string& filename)
+{
+  // If the directory does not exist, make it
+  boost::filesystem::create_directory(boost::filesystem::path(directory));
+
+  // If the collision and visual subdirectories do not exist, make them
+  boost::filesystem::create_directory(boost::filesystem::path(directory + "collision"));
+  boost::filesystem::create_directory(boost::filesystem::path(directory + "visual"));
+
+  // Create XML Document
+  tinyxml2::XMLDocument doc;
+
+  // Assign Robot Name
+  tinyxml2::XMLElement* xml_robot = doc.NewElement("robot");
+  xml_robot->SetAttribute("name", sg->getName().c_str());
+  // version?
+  doc.InsertEndChild(xml_robot);
+
+  // Materials were not saved anywhere at load
+
+  // Write Links
+  for (const tesseract_scene_graph::Link::ConstPtr& l : sg->getLinks())
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_link = writeLink(l, doc, directory);
+      doc.InsertEndChild(xml_link);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write out urdf link"));
+    }
+  }
+
+  // Write out urdf joints to xml
+  for (const tesseract_scene_graph::Joint::ConstPtr& j : sg->getJoints())
+  {
+    try
+    {
+      tinyxml2::XMLElement* xml_joint = writeJoint(j, doc);
+      doc.InsertEndChild(xml_joint);
+    }
+    catch (...)
+    {
+      std::throw_with_nested(std::runtime_error("Could not write out urdf joint"));
+    }
+  }
+
+  // Check for acyclic?
+
+  // Write the document to a file
+  std::string full_filepath = directory + filename;
+  doc.SaveFile(full_filepath.c_str());
+
+  return;
 }
 
 }  // namespace tesseract_urdf

--- a/tesseract_urdf/src/urdf_parser.cpp
+++ b/tesseract_urdf/src/urdf_parser.cpp
@@ -180,6 +180,10 @@ void writeURDFFile(const tesseract_scene_graph::SceneGraph::ConstPtr& sg,
                    const std::string& directory,
                    const std::string& filename)
 {
+  // Check for null input
+  if (sg == nullptr)
+    std::throw_with_nested(std::runtime_error("Scene Graph is nullptr and cannot be converted to URDF"));
+
   // If the directory does not exist, make it
   boost::filesystem::create_directory(boost::filesystem::path(directory));
 
@@ -204,7 +208,7 @@ void writeURDFFile(const tesseract_scene_graph::SceneGraph::ConstPtr& sg,
     try
     {
       tinyxml2::XMLElement* xml_link = writeLink(l, doc, directory);
-      doc.InsertEndChild(xml_link);
+      xml_robot->InsertEndChild(xml_link);
     }
     catch (...)
     {
@@ -218,7 +222,7 @@ void writeURDFFile(const tesseract_scene_graph::SceneGraph::ConstPtr& sg,
     try
     {
       tinyxml2::XMLElement* xml_joint = writeJoint(j, doc);
-      doc.InsertEndChild(xml_joint);
+      xml_robot->InsertEndChild(xml_joint);
     }
     catch (...)
     {

--- a/tesseract_urdf/src/visual.cpp
+++ b/tesseract_urdf/src/visual.cpp
@@ -131,7 +131,7 @@ tinyxml2::XMLElement* tesseract_urdf::writeVisual(const std::shared_ptr<const te
                                                   tinyxml2::XMLDocument& doc,
                                                   const std::string& directory,
                                                   const std::string& link_name,
-                                                  const int id)
+                                                  const int id = -1)
 {
   if (visual == nullptr)
     std::throw_with_nested(std::runtime_error("Visual is nullptr and cannot be converted to XML"));

--- a/tesseract_urdf/src/visual.cpp
+++ b/tesseract_urdf/src/visual.cpp
@@ -126,3 +126,53 @@ tesseract_urdf::parseVisual(const tinyxml2::XMLElement* xml_element,
 
   return visuals;
 }
+
+tinyxml2::XMLElement* tesseract_urdf::writeVisual(const std::shared_ptr<const tesseract_scene_graph::Visual>& visual,
+                                                  tinyxml2::XMLDocument& doc,
+                                                  const std::string& directory,
+                                                  const std::string& link_name,
+                                                  const int id)
+{
+  if (visual == nullptr)
+    std::throw_with_nested(std::runtime_error("Visual is nullptr and cannot be converted to XML"));
+
+  tinyxml2::XMLElement* xml_element = doc.NewElement("visual");
+
+  if (!visual->name.empty())
+    xml_element->SetAttribute("name", visual->name.c_str());
+
+  try
+  {
+    tinyxml2::XMLElement* xml_origin = writeOrigin(visual->origin, doc);
+    xml_element->InsertEndChild(xml_origin);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Could not write origin for visual '" + visual->name + "'!"));
+  }
+
+  try
+  {
+    tinyxml2::XMLElement* xml_material = writeMaterial(visual->material, doc);
+    xml_element->InsertEndChild(xml_material);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Could not write material for visual '" + visual->name + "'!"));
+  }
+
+  try
+  {
+    std::string filename = "visual/" + link_name + "_visual";
+    if (id >= 0)
+      filename += "_" + std::to_string(id);
+    tinyxml2::XMLElement* xml_geometry = writeGeometry(visual->geometry, doc, directory, filename);
+    xml_element->InsertEndChild(xml_geometry);
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("Could not write geometry for visual '" + visual->name + "'!"));
+  }
+
+  return xml_element;
+}

--- a/tesseract_urdf/src/visual.cpp
+++ b/tesseract_urdf/src/visual.cpp
@@ -141,24 +141,13 @@ tinyxml2::XMLElement* tesseract_urdf::writeVisual(const std::shared_ptr<const te
   if (!visual->name.empty())
     xml_element->SetAttribute("name", visual->name.c_str());
 
-  try
-  {
-    tinyxml2::XMLElement* xml_origin = writeOrigin(visual->origin, doc);
-    xml_element->InsertEndChild(xml_origin);
-  }
-  catch (...)
-  {
-    std::throw_with_nested(std::runtime_error("Could not write origin for visual '" + visual->name + "'!"));
-  }
+  tinyxml2::XMLElement* xml_origin = writeOrigin(visual->origin, doc);
+  xml_element->InsertEndChild(xml_origin);
 
-  try
+  if (visual->material != nullptr)
   {
     tinyxml2::XMLElement* xml_material = writeMaterial(visual->material, doc);
     xml_element->InsertEndChild(xml_material);
-  }
-  catch (...)
-  {
-    std::throw_with_nested(std::runtime_error("Could not write material for visual '" + visual->name + "'!"));
   }
 
   try

--- a/tesseract_urdf/test/tesseract_urdf_box_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_box_unit.cpp
@@ -64,3 +64,20 @@ TEST(TesseractURDFUnit, parse_box)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_geometry::Box::Ptr>(geom, &tesseract_urdf::parseBox, str, "box", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_box)  // NOLINT
+{
+  {
+    tesseract_geometry::Box::Ptr geom = std::make_shared<tesseract_geometry::Box>(1.0, 2.0, 3.0);
+    std::string text = "";
+    EXPECT_EQ(0, writeTest<tesseract_geometry::Box::Ptr>(geom, &tesseract_urdf::writeBox, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::Box::Ptr geom = nullptr;
+    std::string text = "";
+    EXPECT_EQ(1, writeTest<tesseract_geometry::Box::Ptr>(geom, &tesseract_urdf::writeBox, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_calibration_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_calibration_unit.cpp
@@ -57,3 +57,22 @@ TEST(TesseractURDFUnit, parse_calibration)  // NOLINT
         elem, &tesseract_urdf::parseCalibration, str, "calibration", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_calibration)  // NOLINT
+{
+  {
+    tesseract_scene_graph::JointCalibration::Ptr cal = std::make_shared<tesseract_scene_graph::JointCalibration>();
+    cal->rising = 5.0;
+    cal->falling = 3.0;
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::JointCalibration::Ptr>(cal, &tesseract_urdf::writeCalibration, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::JointCalibration::Ptr cal = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::JointCalibration::Ptr>(cal, &tesseract_urdf::writeCalibration, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_capsule_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_capsule_unit.cpp
@@ -77,3 +77,20 @@ TEST(TesseractURDFUnit, parse_capsule)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_geometry::Capsule::Ptr>(geom, &tesseract_urdf::parseCapsule, str, "capsule", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_capsule)  // NOLINT
+{
+  {
+    tesseract_geometry::Capsule::Ptr capsule = std::make_shared<tesseract_geometry::Capsule>(0.5, 1.0);
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_geometry::Capsule::Ptr>(capsule, &tesseract_urdf::writeCapsule, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::Capsule::Ptr capsule = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_geometry::Capsule::Ptr>(capsule, &tesseract_urdf::writeCapsule, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_collision_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_collision_unit.cpp
@@ -5,6 +5,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_urdf/collision.h>
+#include <tesseract_geometry/impl/box.h>
 #include "tesseract_urdf_common_unit.h"
 
 TEST(TesseractURDFUnit, parse_collision)  // NOLINT
@@ -89,5 +90,41 @@ TEST(TesseractURDFUnit, parse_collision)  // NOLINT
     EXPECT_FALSE(runTest<std::vector<tesseract_scene_graph::Collision::Ptr>>(
         elem, &tesseract_urdf::parseCollision, str, "collision", resource_locator, 2));
     EXPECT_TRUE(elem.empty());
+  }
+}
+
+TEST(TesseractURDFUnit, write_collision)  // NOLINT
+{
+  {  // trigger check for an assigned name and check for specified ID
+    tesseract_scene_graph::Collision::Ptr collision = std::make_shared<tesseract_scene_graph::Collision>();
+    collision->name = "test";
+    collision->origin = Eigen::Isometry3d::Identity();
+    collision->geometry = std::make_shared<tesseract_geometry::Box>(1.0, 1.0, 1.0);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_scene_graph::Collision::Ptr>(
+                  collision, &tesseract_urdf::writeCollision, text, std::string("/tmp/"), std::string("test"), 0));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger check for nullptr input
+    tesseract_scene_graph::Collision::Ptr collision = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_scene_graph::Collision::Ptr>(
+                  collision, &tesseract_urdf::writeCollision, text, std::string("/tmp/"), std::string("test"), -1));
+    EXPECT_EQ(text, "");
+  }
+
+  {  // trigger check for bad geometry
+    tesseract_scene_graph::Collision::Ptr collision = std::make_shared<tesseract_scene_graph::Collision>();
+    collision->name = "test";
+    collision->origin = Eigen::Isometry3d::Identity();
+    collision->geometry = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_scene_graph::Collision::Ptr>(
+                  collision, &tesseract_urdf::writeCollision, text, std::string("/tmp/"), std::string("test"), -1));
+    EXPECT_EQ(text, "");
   }
 }

--- a/tesseract_urdf/test/tesseract_urdf_common_unit.h
+++ b/tesseract_urdf/test/tesseract_urdf_common_unit.h
@@ -188,4 +188,182 @@ bool runTest(ElementType& type,
   return true;
 }
 
+/**
+ * @brief writeTest - test write functions
+ * @param type - object of type being tested
+ * @param func - function to write object to URDF-XML
+ * @param text - xml text generated
+ * @return 0 if success, 1 if exception thrown, 2 if nullptr generated
+ */
+template <typename TessType>
+int writeTest(TessType& type,
+              std::function<tinyxml2::XMLElement*(const TessType&, tinyxml2::XMLDocument&)> func,
+              std::string& text)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLPrinter printer;
+  std::stringstream ss;
+  int status = 0;
+  try
+  {
+    tinyxml2::XMLElement* element = func(type, doc);
+    if (element != nullptr)
+    {
+      element->Accept(&printer);
+      ss << printer.CStr();
+      text = ss.str();
+      status = 0;
+    }
+    else
+    {
+      text = "";
+      status = 2;
+    }
+  }
+  catch (...)
+  {
+    text = "";
+    status = 1;
+  }
+  return status;
+}
+
+/**
+ * @brief writeTest - test write functions for links
+ * @param type - object of type being tested
+ * @param func - function to write object to URDF-XML
+ * @param text - xml text generated
+ * @param directory - directory to save files
+ * @return 0 if success, 1 if exception thrown, 2 if nullptr generated
+ */
+template <typename TessType>
+int writeTest(TessType& type,
+              std::function<tinyxml2::XMLElement*(const TessType&, tinyxml2::XMLDocument&, const std::string&)> func,
+              std::string& text,
+              const std::string& directory)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLPrinter printer;
+  std::stringstream ss;
+  int status = 0;
+  try
+  {
+    tinyxml2::XMLElement* element = func(type, doc, directory);
+    if (element != nullptr)
+    {
+      element->Accept(&printer);
+      ss << printer.CStr();
+      text = ss.str();
+      status = 0;
+    }
+    else
+    {
+      text = "";
+      status = 2;
+    }
+  }
+  catch (...)
+  {
+    text = "";
+    status = 1;
+  }
+  return status;
+}
+
+/**
+ * @brief writeTest - test write functions for meshes
+ * @param type - object of type being tested
+ * @param func - function to write object to URDF-XML
+ * @param text - xml text generated
+ * @param directory - directory to save files
+ * @param filename - name of link to which geometry is attached
+ * @return 0 if success, 1 if exception thrown, 2 if nullptr generated
+ */
+template <typename TessType>
+int writeTest(
+    TessType& type,
+    std::function<
+        tinyxml2::XMLElement*(const TessType&, tinyxml2::XMLDocument&, const std::string&, const std::string&)> func,
+    std::string& text,
+    const std::string& directory,
+    const std::string& filename)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLPrinter printer;
+  std::stringstream ss;
+  int status = 0;
+  try
+  {
+    tinyxml2::XMLElement* element = func(type, doc, directory, filename);
+    if (element != nullptr)
+    {
+      element->Accept(&printer);
+      ss << printer.CStr();
+      text = ss.str();
+      status = 0;
+    }
+    else
+    {
+      text = "";
+      status = 2;
+    }
+  }
+  catch (...)
+  {
+    text = "";
+    status = 1;
+  }
+  return status;
+}
+
+/**
+ * @brief writeTest - test write functions for collision and visual geometries
+ * @param type - object of type being tested
+ * @param func - function to write object to URDF-XML
+ * @param text - xml text generated
+ * @param directory - directory to save files
+ * @param link_name - name of link to which geometry is attached
+ * @param id - index of this geometry in list
+ * @return 0 if success, 1 if exception thrown, 2 if nullptr generated
+ */
+template <typename TessType>
+int writeTest(TessType& type,
+              std::function<tinyxml2::XMLElement*(const TessType&,
+                                                  tinyxml2::XMLDocument&,
+                                                  const std::string&,
+                                                  const std::string&,
+                                                  const int)> func,
+              std::string& text,
+              const std::string& directory,
+              const std::string& link_name,
+              const int id)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLPrinter printer;
+  std::stringstream ss;
+  int status = 0;
+  try
+  {
+    tinyxml2::XMLElement* element = func(type, doc, directory, link_name, id);
+    if (element != nullptr)
+    {
+      element->Accept(&printer);
+      ss << printer.CStr();
+      text = ss.str();
+      status = 0;
+    }
+    else
+    {
+      text = "";
+      status = 2;
+    }
+  }
+  catch (...)
+  {
+    text = "";
+    status = 1;
+  }
+  return status;
+}
+
 #endif  // TESSERACT_URDF_COMMON_UNIT_H

--- a/tesseract_urdf/test/tesseract_urdf_cone_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_cone_unit.cpp
@@ -77,3 +77,20 @@ TEST(TesseractURDFUnit, parse_cone)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_geometry::Cone::Ptr>(geom, &tesseract_urdf::parseCone, str, "cone", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_cone)  // NOLINT
+{
+  {
+    tesseract_geometry::Cone::Ptr cone = std::make_shared<tesseract_geometry::Cone>(0.5, 1.0);
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_geometry::Cone::Ptr>(cone, &tesseract_urdf::writeCone, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::Cone::Ptr cone = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_geometry::Cone::Ptr>(cone, &tesseract_urdf::writeCone, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_convex_mesh_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_convex_mesh_unit.cpp
@@ -171,13 +171,28 @@ TEST(TesseractURDFUnit, write_convex_mesh)  // NOLINT
                                                   Eigen::Vector3d(0, 1, 0) };
     Eigen::VectorXi indices(4);
     indices << 3, 0, 1, 2;
-    tesseract_geometry::ConvexMesh::Ptr sdf_mesh = std::make_shared<tesseract_geometry::ConvexMesh>(
+    tesseract_geometry::ConvexMesh::Ptr convex_mesh = std::make_shared<tesseract_geometry::ConvexMesh>(
         std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
     std::string text = "";
     EXPECT_EQ(0,
               writeTest<tesseract_geometry::ConvexMesh::Ptr>(
-                  sdf_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("convex0.ply")));
+                  convex_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("convex0.ply")));
     EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::ConvexMesh::Ptr convex_mesh = std::make_shared<tesseract_geometry::ConvexMesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+    std::string text = "";
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::ConvexMesh::Ptr>(
+                  convex_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("")));
+    EXPECT_EQ(text, "");
   }
 
   {

--- a/tesseract_urdf/test/tesseract_urdf_convex_mesh_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_convex_mesh_unit.cpp
@@ -162,3 +162,31 @@ TEST(TesseractURDFUnit, parse_convex_mesh)  // NOLINT
     EXPECT_TRUE(geom.empty());
   }
 }
+
+TEST(TesseractURDFUnit, write_convex_mesh)  // NOLINT
+{
+  {
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::ConvexMesh::Ptr sdf_mesh = std::make_shared<tesseract_geometry::ConvexMesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+    std::string text = "";
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::ConvexMesh::Ptr>(
+                  sdf_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("convex0.ply")));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::ConvexMesh::Ptr convex_mesh = nullptr;
+    std::string text;
+    EXPECT_EQ(
+        1,
+        writeTest<tesseract_geometry::ConvexMesh::Ptr>(
+            convex_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("convex1.ply")));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_convex_mesh_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_convex_mesh_unit.cpp
@@ -174,9 +174,10 @@ TEST(TesseractURDFUnit, write_convex_mesh)  // NOLINT
     tesseract_geometry::ConvexMesh::Ptr convex_mesh = std::make_shared<tesseract_geometry::ConvexMesh>(
         std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
     std::string text = "";
-    EXPECT_EQ(0,
-              writeTest<tesseract_geometry::ConvexMesh::Ptr>(
-                  convex_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("convex0.ply")));
+    EXPECT_EQ(
+        0,
+        writeTest<tesseract_geometry::ConvexMesh::Ptr>(
+            convex_mesh, &tesseract_urdf::writeConvexMesh, text, std::string("/tmp/"), std::string("convex0.ply")));
     EXPECT_NE(text, "");
   }
 

--- a/tesseract_urdf/test/tesseract_urdf_cylinder_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_cylinder_unit.cpp
@@ -77,3 +77,20 @@ TEST(TesseractURDFUnit, parse_cylinder)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_geometry::Cylinder::Ptr>(geom, &tesseract_urdf::parseCylinder, str, "cylinder", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_cylinder)  // NOLINT
+{
+  {
+    tesseract_geometry::Cylinder::Ptr cylinder = std::make_shared<tesseract_geometry::Cylinder>(0.5, 1.0);
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_geometry::Cylinder::Ptr>(cylinder, &tesseract_urdf::writeCylinder, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::Cylinder::Ptr cylinder = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_geometry::Cylinder::Ptr>(cylinder, &tesseract_urdf::writeCylinder, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_dynamics_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_dynamics_unit.cpp
@@ -57,3 +57,22 @@ TEST(TesseractURDFUnit, parse_dynamics)  // NOLINT
         runTest<tesseract_scene_graph::JointDynamics::Ptr>(elem, &tesseract_urdf::parseDynamics, str, "dynamics", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_dynamics)  // NOLINT
+{
+  {
+    tesseract_scene_graph::JointDynamics::Ptr dynamics = std::make_shared<tesseract_scene_graph::JointDynamics>();
+    dynamics->damping = 1.5;
+    dynamics->friction = 2.5;
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::JointDynamics::Ptr>(dynamics, &tesseract_urdf::writeDynamics, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::JointDynamics::Ptr dynamics = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::JointDynamics::Ptr>(dynamics, &tesseract_urdf::writeDynamics, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_geometry_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_geometry_unit.cpp
@@ -4,6 +4,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_geometry/geometries.h>
 #include <tesseract_urdf/geometry.h>
 #include "tesseract_urdf_common_unit.h"
 
@@ -221,5 +222,133 @@ TEST(TesseractURDFUnit, parse_geometry)  // NOLINT
     EXPECT_FALSE(runTest<std::vector<tesseract_geometry::Geometry::Ptr>>(
         elem, &tesseract_urdf::parseGeometry, str, "geometry", resource_locator, 2, true));
     EXPECT_TRUE(elem.empty());
+  }
+}
+
+TEST(TesseractURDFUnit, write_geometry)  // NOLINT
+{
+  // The catch clause for many of the subtypes is not triggered by these tests.  Triggering them would require sending
+  // a nullptr to the write function - for now.  These could be expanded in the future to have more failure modes, and
+  // already having the catch blocks in place seems wise.
+
+  {  // trigger check for nullptr input
+    tesseract_geometry::Geometry::Ptr geometry = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_EQ(text, "");
+  }
+
+  {  // sphere
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Sphere>(1.0);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // cylinder
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Cylinder>(1.0, 1.414);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // capsule
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Capsule>(1.0, 1.57);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // cone
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Cone>(1.0, 2.3);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // box
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Box>(1.0, 2.0, 3.0);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // plane
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Plane>(1.0, 1.1, 1.2, 1.3);
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("")));
+    EXPECT_EQ(text, "");
+  }
+
+  {  // mesh
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Mesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("geom0")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // convex_mesh
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::ConvexMesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("geom1")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // sdf_mesh
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::SDFMesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("geom2")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // octree
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::BOX);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("geom3")));
+    EXPECT_NE(text, "");
   }
 }

--- a/tesseract_urdf/test/tesseract_urdf_geometry_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_geometry_unit.cpp
@@ -351,4 +351,14 @@ TEST(TesseractURDFUnit, write_geometry)  // NOLINT
                   geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/"), std::string("geom3")));
     EXPECT_NE(text, "");
   }
+
+  {  // octree failed-to-write
+    tesseract_geometry::Geometry::Ptr geometry = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::BOX);
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Geometry::Ptr>(
+                  geometry, &tesseract_urdf::writeGeometry, text, std::string("/tmp/nonexistant/"), std::string("")));
+    EXPECT_EQ(text, "");
+  }
 }

--- a/tesseract_urdf/test/tesseract_urdf_inertial_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_inertial_unit.cpp
@@ -223,3 +223,27 @@ TEST(TesseractURDFUnit, parse_inertial)  // NOLINT
         runTest<tesseract_scene_graph::Inertial::Ptr>(elem, &tesseract_urdf::parseInertial, str, "inertial", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_inertial)  // NOLINT
+{
+  {
+    tesseract_scene_graph::Inertial::Ptr inertial = std::make_shared<tesseract_scene_graph::Inertial>();
+    inertial->origin = Eigen::Isometry3d::Identity();
+    inertial->ixx = 1.0;
+    inertial->ixy = 2.0;
+    inertial->iyy = 3.0;
+    inertial->iyz = 4.0;
+    inertial->izz = 5.0;
+    inertial->ixz = 6.0;
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Inertial::Ptr>(inertial, &tesseract_urdf::writeInertial, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::Inertial::Ptr inertial = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::Inertial::Ptr>(inertial, &tesseract_urdf::writeInertial, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_joint_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_joint_unit.cpp
@@ -446,3 +446,82 @@ TEST(TesseractURDFUnit, parse_joint)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_scene_graph::Joint::Ptr>(elem, &tesseract_urdf::parseJoint, str, "joint", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_joint)  // NOLINT
+{
+  {  // trigger nullptr input
+    tesseract_scene_graph::Joint::Ptr joint = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_EQ(text, "");
+  }
+
+  {  // trigger type planar, set joint axis
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::PLANAR;
+    joint->axis = Eigen::Vector3d::UnitX();
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger type floating
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::FLOATING;
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger type revolute; set joint axis, joint limits, joint safety, joint cal, mimic joint, dynamics
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::REVOLUTE;
+    joint->axis = Eigen::Vector3d::UnitY();
+    joint->limits = std::make_shared<tesseract_scene_graph::JointLimits>();
+    joint->safety = std::make_shared<tesseract_scene_graph::JointSafety>();
+    joint->calibration = std::make_shared<tesseract_scene_graph::JointCalibration>();
+    joint->mimic = std::make_shared<tesseract_scene_graph::JointMimic>();
+    joint->dynamics = std::make_shared<tesseract_scene_graph::JointDynamics>();
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger type continuous
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::CONTINUOUS;
+    joint->axis = Eigen::Vector3d::UnitZ();
+    joint->limits = std::make_shared<tesseract_scene_graph::JointLimits>();
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger type prismatic
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::PRISMATIC;
+    joint->limits = std::make_shared<tesseract_scene_graph::JointLimits>();
+    joint->axis = Eigen::Vector3d::Ones();
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger type fixed
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::FIXED;
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger no joint limits
+    tesseract_scene_graph::Joint::Ptr joint = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint->type = tesseract_scene_graph::JointType::PRISMATIC;
+    joint->limits = nullptr;
+    joint->axis = Eigen::Vector3d::Ones();
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::Joint::Ptr>(joint, &tesseract_urdf::writeJoint, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_limits_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_limits_unit.cpp
@@ -114,3 +114,20 @@ TEST(TesseractURDFUnit, parse_limits)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_scene_graph::JointLimits::Ptr>(elem, &tesseract_urdf::parseLimits, str, "limit", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_limits)  // NOLINT
+{
+  {
+    tesseract_scene_graph::JointLimits::Ptr limits = std::make_shared<tesseract_scene_graph::JointLimits>();
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::JointLimits::Ptr>(limits, &tesseract_urdf::writeLimits, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::JointLimits::Ptr limits = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::JointLimits::Ptr>(limits, &tesseract_urdf::writeLimits, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_material_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_material_unit.cpp
@@ -202,3 +202,20 @@ TEST(TesseractURDFUnit, parse_material)  // NOLINT
         elem, &tesseract_urdf::parseMaterial, str, "material", empty_available_materials, 2, true));
   }
 }
+
+TEST(TesseractURDFUnit, write_material)  // NOLINT
+{
+  {
+    tesseract_scene_graph::Material::Ptr material = std::make_shared<tesseract_scene_graph::Material>("unobtainium");
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::Material::Ptr>(material, &tesseract_urdf::writeMaterial, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::Material::Ptr material = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::Material::Ptr>(material, &tesseract_urdf::writeMaterial, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_mesh_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_mesh_unit.cpp
@@ -113,6 +113,21 @@ TEST(TesseractURDFUnit, write_mesh)  // NOLINT
     EXPECT_NE(text, "");
   }
 
+  {  // fail to write
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::Mesh::Ptr mesh = std::make_shared<tesseract_geometry::Mesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+    std::string text = "";
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Mesh::Ptr>(
+                  mesh, &tesseract_urdf::writeMesh, text, std::string("/tmp/"), std::string("")));
+    EXPECT_EQ(text, "");
+  }
+
   {
     tesseract_geometry::Mesh::Ptr mesh = nullptr;
     std::string text;

--- a/tesseract_urdf/test/tesseract_urdf_mesh_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_mesh_unit.cpp
@@ -95,3 +95,30 @@ TEST(TesseractURDFUnit, parse_mesh)  // NOLINT
     EXPECT_TRUE(geom.empty());
   }
 }
+
+TEST(TesseractURDFUnit, write_mesh)  // NOLINT
+{
+  {
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::Mesh::Ptr mesh = std::make_shared<tesseract_geometry::Mesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+    std::string text = "";
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Mesh::Ptr>(
+                  mesh, &tesseract_urdf::writeMesh, text, std::string("/tmp/"), std::string("mesh0.ply")));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::Mesh::Ptr mesh = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Mesh::Ptr>(
+                  mesh, &tesseract_urdf::writeMesh, text, std::string("/tmp/"), std::string("mesh1.ply")));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_mimic_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_mimic_unit.cpp
@@ -63,3 +63,20 @@ TEST(TesseractURDFUnit, parse_mimic)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_scene_graph::JointMimic::Ptr>(elem, &tesseract_urdf::parseMimic, str, "mimic", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_mimic)  // NOLINT
+{
+  {
+    tesseract_scene_graph::JointMimic::Ptr mimic = std::make_shared<tesseract_scene_graph::JointMimic>();
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_scene_graph::JointMimic::Ptr>(mimic, &tesseract_urdf::writeMimic, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::JointMimic::Ptr mimic = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_scene_graph::JointMimic::Ptr>(mimic, &tesseract_urdf::writeMimic, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_octree_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_octree_unit.cpp
@@ -166,3 +166,25 @@ TEST(TesseractURDFUnit, parse_octree)  // NOLINT
         geom, &tesseract_urdf::parseOctomap, str, "octomap", resource_locator, 2, true));
   }
 }
+
+TEST(TesseractURDFUnit, write_octree)  // NOLINT
+{
+  {
+    tesseract_geometry::Octree::Ptr geom = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::BOX);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctree, text, std::string("/tmp/"), std::string("oct0.bt")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger nullptr input
+    tesseract_geometry::Octree::Ptr geom = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctree, text, std::string("/tmp/"), std::string("oct2.bt")));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_octree_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_octree_unit.cpp
@@ -179,12 +179,74 @@ TEST(TesseractURDFUnit, write_octree)  // NOLINT
     EXPECT_NE(text, "");
   }
 
+  {  // Trigger failed-to-write
+    tesseract_geometry::Octree::Ptr geom = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::BOX);
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctree, text, std::string("/tmp/"), std::string("")));
+    EXPECT_EQ(text, "");
+  }
+
   {  // trigger nullptr input
     tesseract_geometry::Octree::Ptr geom = nullptr;
     std::string text;
     EXPECT_EQ(1,
               writeTest<tesseract_geometry::Octree::Ptr>(
                   geom, &tesseract_urdf::writeOctree, text, std::string("/tmp/"), std::string("oct2.bt")));
+    EXPECT_EQ(text, "");
+  }
+}
+
+TEST(TesseractURDFUnit, write_octomap)  // NOLINT
+{
+  {  // box
+    tesseract_geometry::Octree::Ptr geom = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::BOX);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctomap, text, std::string("/tmp/"), std::string("octo0.bt")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // sphere inside
+    tesseract_geometry::Octree::Ptr geom = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::SPHERE_INSIDE);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctomap, text, std::string("/tmp/"), std::string("octo1.bt")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // sphere outside
+    tesseract_geometry::Octree::Ptr geom = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::SPHERE_OUTSIDE);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctomap, text, std::string("/tmp/"), std::string("octo2.bt")));
+    EXPECT_NE(text, "");
+  }
+
+  {  // Trigger failed-to-write
+    tesseract_geometry::Octree::Ptr geom = std::make_shared<tesseract_geometry::Octree>(
+        std::make_shared<octomap::OcTree>(1.0), tesseract_geometry::Octree::SubType::BOX);
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctomap, text, std::string("/tmp/"), std::string("")));
+    EXPECT_EQ(text, "");
+  }
+
+  {  // trigger nullptr input
+    tesseract_geometry::Octree::Ptr geom = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::Octree::Ptr>(
+                  geom, &tesseract_urdf::writeOctomap, text, std::string("/tmp/"), std::string("oct2.bt")));
     EXPECT_EQ(text, "");
   }
 }

--- a/tesseract_urdf/test/tesseract_urdf_origin_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_origin_unit.cpp
@@ -125,3 +125,13 @@ TEST(TesseractURDFUnit, parse_origin)  // NOLINT
     EXPECT_FALSE(runTest<Eigen::Isometry3d>(origin, &tesseract_urdf::parseOrigin, str, "origin", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_origin)  // NOLINT
+{
+  {
+    Eigen::Isometry3d origin = Eigen::Isometry3d::Identity();
+    std::string text;
+    EXPECT_EQ(0, writeTest<Eigen::Isometry3d>(origin, &tesseract_urdf::writeOrigin, text));
+    EXPECT_NE(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_safety_controller_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_safety_controller_unit.cpp
@@ -79,3 +79,22 @@ TEST(TesseractURDFUnit, parse_safety_controller)  // NOLINT
         elem, &tesseract_urdf::parseSafetyController, str, "safety_controller", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_safety_controller)  // NOLINT
+{
+  {
+    tesseract_scene_graph::JointSafety::Ptr safety = std::make_shared<tesseract_scene_graph::JointSafety>();
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_scene_graph::JointSafety::Ptr>(safety, &tesseract_urdf::writeSafetyController, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_scene_graph::JointSafety::Ptr safety = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_scene_graph::JointSafety::Ptr>(safety, &tesseract_urdf::writeSafetyController, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_sdf_mesh_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_sdf_mesh_unit.cpp
@@ -101,3 +101,30 @@ TEST(TesseractURDFUnit, parse_sdf_mesh)  // NOLINT
         geom, &tesseract_urdf::parseSDFMesh, str, "sdf_mesh", resource_locator, 2, true));
   }
 }
+
+TEST(TesseractURDFUnit, write_sdf_mesh)  // NOLINT
+{
+  {
+    tesseract_common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                  Eigen::Vector3d(1, 0, 0),
+                                                  Eigen::Vector3d(0, 1, 0) };
+    Eigen::VectorXi indices(4);
+    indices << 3, 0, 1, 2;
+    tesseract_geometry::SDFMesh::Ptr sdf_mesh = std::make_shared<tesseract_geometry::SDFMesh>(
+        std::make_shared<tesseract_common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+    std::string text = "";
+    EXPECT_EQ(0,
+              writeTest<tesseract_geometry::SDFMesh::Ptr>(
+                  sdf_mesh, &tesseract_urdf::writeSDFMesh, text, std::string("/tmp/"), std::string("sdf0.ply")));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::SDFMesh::Ptr sdf_mesh = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_geometry::SDFMesh::Ptr>(
+                  sdf_mesh, &tesseract_urdf::writeSDFMesh, text, std::string("/tmp/"), std::string("sdf2.ply")));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_sphere_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_sphere_unit.cpp
@@ -51,3 +51,20 @@ TEST(TesseractURDFUnit, parse_sphere)  // NOLINT
     EXPECT_FALSE(runTest<tesseract_geometry::Sphere::Ptr>(geom, &tesseract_urdf::parseSphere, str, "sphere", 2));
   }
 }
+
+TEST(TesseractURDFUnit, write_sphere)  // NOLINT
+{
+  {
+    tesseract_geometry::Sphere::Ptr geom = std::make_shared<tesseract_geometry::Sphere>(1.0);
+    std::string text;
+    EXPECT_EQ(0, writeTest<tesseract_geometry::Sphere::Ptr>(geom, &tesseract_urdf::writeSphere, text));
+    EXPECT_NE(text, "");
+  }
+
+  {
+    tesseract_geometry::Sphere::Ptr geom = nullptr;
+    std::string text;
+    EXPECT_EQ(1, writeTest<tesseract_geometry::Sphere::Ptr>(geom, &tesseract_urdf::writeSphere, text));
+    EXPECT_EQ(text, "");
+  }
+}

--- a/tesseract_urdf/test/tesseract_urdf_urdf_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_urdf_unit.cpp
@@ -440,3 +440,115 @@ TEST(TesseractURDFUnit, LoadURDFUnit)  // NOLINT
   EXPECT_TRUE(std::find(path.second.begin(), path.second.end(), "joint_a3") != path.second.end());
   EXPECT_TRUE(std::find(path.second.begin(), path.second.end(), "joint_a4") != path.second.end());
 }
+
+TEST(TesseractURDFUnit, write_urdf)  // NOLINT
+{
+  {  // trigger nullptr input
+    tesseract_scene_graph::SceneGraph::Ptr sg = nullptr;
+    bool success = true;
+    try
+    {
+      tesseract_urdf::writeURDFFile(sg, "/tmp/", "urdf0.urdf");
+    }
+    catch (...)
+    {
+      success = false;
+    }
+
+    EXPECT_FALSE(success);
+  }
+
+  {  // Successful run
+    tesseract_scene_graph::SceneGraph::Ptr sg = std::make_shared<tesseract_scene_graph::SceneGraph>();
+
+    // Add 2 links
+    tesseract_scene_graph::Link::Ptr link_0 = std::make_shared<tesseract_scene_graph::Link>("link_0");
+    tesseract_scene_graph::Link::Ptr link_1 = std::make_shared<tesseract_scene_graph::Link>("link_1");
+    sg->addLink(*link_0);
+    sg->addLink(*link_1);
+
+    // Add joint
+    tesseract_scene_graph::Joint::Ptr joint_0 = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint_0->type = tesseract_scene_graph::JointType::FIXED;
+    joint_0->parent_link_name = link_0->getName();
+    joint_0->child_link_name = link_1->getName();
+    sg->addJoint(*joint_0);
+
+    bool success = true;
+    try
+    {
+      tesseract_urdf::writeURDFFile(sg, "/tmp/", "urdf1.urdf");
+    }
+    catch (...)
+    {
+      success = false;
+    }
+
+    EXPECT_TRUE(success);
+  }
+
+  {  // Trigger Bad Joint
+    tesseract_scene_graph::SceneGraph::Ptr sg = std::make_shared<tesseract_scene_graph::SceneGraph>();
+
+    // Add 2 links
+    tesseract_scene_graph::Link::Ptr link_0 = std::make_shared<tesseract_scene_graph::Link>("link_0");
+    tesseract_scene_graph::Link::Ptr link_1 = std::make_shared<tesseract_scene_graph::Link>("link_1");
+    sg->addLink(*link_0);
+    sg->addLink(*link_1);
+
+    // Add joint
+    tesseract_scene_graph::Joint::Ptr joint_0 = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint_0->type = tesseract_scene_graph::JointType::REVOLUTE;
+    joint_0->limits = nullptr;  // REVOLUTE joints require limits, this will cause write failure
+    joint_0->parent_link_name = link_0->getName();
+    joint_0->child_link_name = link_1->getName();
+    sg->addJoint(*joint_0);
+
+    bool success = true;
+    try
+    {
+      tesseract_urdf::writeURDFFile(sg, "/tmp/", "urdf2.urdf");
+    }
+    catch (...)
+    {
+      success = false;
+    }
+
+    EXPECT_FALSE(success);
+  }
+
+  /* Triggering a bad link is actually very difficult.  The addLink function uses Link::clone(), which
+   * dereferences all the collision & visual pointers, causing a segfault if the link was ill-formed.
+   * This should probably get changed to throwing an exception if it is nullptr.
+  { // Trigger Bad Link
+    tesseract_scene_graph::SceneGraph::Ptr sg = std::make_shared<tesseract_scene_graph::SceneGraph>();
+
+    // Add 2 links
+    tesseract_scene_graph::Link::Ptr link_0 = std::make_shared<tesseract_scene_graph::Link>("link_0");
+    link_0->visual.resize(1);
+    link_0->visual[0] = nullptr;  // Bad visual geometry to cause write failure in link
+    tesseract_scene_graph::Link::Ptr link_1 = std::make_shared<tesseract_scene_graph::Link>("link_1");
+    sg->addLink(*link_0);
+    sg->addLink(*link_1);
+
+    // Add joint
+    tesseract_scene_graph::Joint::Ptr joint_0 = std::make_shared<tesseract_scene_graph::Joint>("joint_0");
+    joint_0->type = tesseract_scene_graph::JointType::FIXED;
+    joint_0->parent_link_name = link_0->getName();
+    joint_0->child_link_name = link_1->getName();
+    sg->addJoint(*joint_0);
+
+    bool success = true;
+    try
+    {
+      tesseract_urdf::writeURDFFile(sg, "/tmp/", "urdf3.urdf");
+    }
+    catch (...)
+    {
+      success = false;
+    }
+
+    EXPECT_FALSE(success);
+  }
+  */
+}

--- a/tesseract_urdf/test/tesseract_urdf_visual_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_visual_unit.cpp
@@ -4,6 +4,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_geometry/impl/box.h>
+#include <tesseract_urdf/box.h>
 #include <tesseract_urdf/visual.h>
 #include "tesseract_urdf_common_unit.h"
 
@@ -88,5 +90,41 @@ TEST(TesseractURDFUnit, parse_visual)  // NOLINT
     std::vector<tesseract_scene_graph::Visual::Ptr> elem;
     EXPECT_FALSE(runTest<std::vector<tesseract_scene_graph::Visual::Ptr>>(
         elem, &tesseract_urdf::parseVisual, str, "visual", resource_locator, empty_available_materials, 2));
+  }
+}
+
+TEST(TesseractURDFUnit, write_visual)  // NOLINT
+{
+  {  // trigger check for an assigned name and check for specified ID
+    tesseract_scene_graph::Visual::Ptr visual = std::make_shared<tesseract_scene_graph::Visual>();
+    visual->name = "test";
+    visual->origin = Eigen::Isometry3d::Identity();
+    visual->geometry = std::make_shared<tesseract_geometry::Box>(1.0, 1.0, 1.0);
+    std::string text;
+    EXPECT_EQ(0,
+              writeTest<tesseract_scene_graph::Visual::Ptr>(
+                  visual, &tesseract_urdf::writeVisual, text, std::string("/tmp/"), std::string("test"), 0));
+    EXPECT_NE(text, "");
+  }
+
+  {  // trigger check for nullptr input
+    tesseract_scene_graph::Visual::Ptr visual = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_scene_graph::Visual::Ptr>(
+                  visual, &tesseract_urdf::writeVisual, text, std::string("/tmp/"), std::string("test"), -1));
+    EXPECT_EQ(text, "");
+  }
+
+  {  // trigger check for bad geometry
+    tesseract_scene_graph::Visual::Ptr visual = std::make_shared<tesseract_scene_graph::Visual>();
+    visual->name = "test";
+    visual->origin = Eigen::Isometry3d::Identity();
+    visual->geometry = nullptr;
+    std::string text;
+    EXPECT_EQ(1,
+              writeTest<tesseract_scene_graph::Visual::Ptr>(
+                  visual, &tesseract_urdf::writeVisual, text, std::string("/tmp/"), std::string("test"), -1));
+    EXPECT_EQ(text, "");
   }
 }

--- a/tesseract_urdf/test/tesseract_urdf_visual_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_visual_unit.cpp
@@ -100,6 +100,7 @@ TEST(TesseractURDFUnit, write_visual)  // NOLINT
     visual->name = "test";
     visual->origin = Eigen::Isometry3d::Identity();
     visual->geometry = std::make_shared<tesseract_geometry::Box>(1.0, 1.0, 1.0);
+    visual->material = std::make_shared<tesseract_scene_graph::Material>("black");
     std::string text;
     EXPECT_EQ(0,
               writeTest<tesseract_scene_graph::Visual::Ptr>(


### PR DESCRIPTION
Write functions written and implemented to correspond to all tesseract_urdf::parseX calls, with the exception of writePointCloud.  Point clouds are always used to construct octomaps on load, so the original cloud is not around to write back out.  Feedback and suggestions on how to test would be welcome.  Some changes in tesseract_geometry were required to get meshes and octomaps writing out correctly.

@Levi-Armstrong let me know what more you would like done here.