### PR TITLE
Allow Docker workflow to be run manually

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
   release:
     types:
       - released
+  workflow_dispatch:
 
 jobs:
   ci:


### PR DESCRIPTION
Changes per commit message.

Before deciding how to update the Docker file wrt ROS GPG keys (per discussion in #1160), let's allow ourselves to manually rebuild the image (at specific points in history) in order to fix the currently non-functional downstream images