### PR TITLE
Catch error when substep == num_substeps and add test

### DIFF
--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -526,11 +526,11 @@ void ContactTrajectoryStepResults::addContact(int step_number,
     step = step_number;
   }
 
-  if (substep_number < 0 || substep_number > total_substeps)
+  if (substep_number < 0 || substep_number >= total_substeps)
   {
     if (substep_number < 0)
       throw std::runtime_error("ContactTrajectoryStepResults::addContact: substep_number is negative");
-    if (substep_number > total_substeps)
+    if (substep_number >= total_substeps)
       throw std::out_of_range("ContactTrajectoryStepResults::addContact: substep_number out of range");
   }
 


### PR DESCRIPTION
~~Need to rebase before ready to merge~~

Rebased. 

This could get triggered if there was a collision at an end state in certain scenarios, see https://github.com/tesseract-robotics/tesseract_planning/pull/703 for related details.