### PR TITLE
Add uuid to link class

### DIFF
--- a/tesseract_scene_graph/include/tesseract_scene_graph/cereal_serialization.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/cereal_serialization.h
@@ -74,6 +74,7 @@ void serialize(Archive& ar, Link& obj)
   ar(cereal::make_nvp("collision", obj.collision));
   ar(cereal::make_nvp("visible", obj.visible));
   ar(cereal::make_nvp("collision_enabled", obj.collision_enabled));
+  ar(cereal::make_nvp("uuid", obj.uuid_));
   ar(cereal::make_nvp("name", obj.name_));
 }
 

--- a/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -39,6 +39,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <boost/uuid/uuid.hpp>
 #include <string>
 #include <vector>
 #include <memory>
@@ -183,7 +184,7 @@ public:
   using Ptr = std::shared_ptr<Link>;
   using ConstPtr = std::shared_ptr<const Link>;
 
-  Link(std::string name);
+  explicit Link(std::string name);
   Link() = default;
   ~Link() = default;
   // Links are non-copyable as their name must be unique
@@ -194,6 +195,8 @@ public:
   Link& operator=(Link&& other) = default;
 
   const std::string& getName() const;
+
+  const boost::uuids::uuid& getUuid() const;
 
   /// inertial element
   Inertial::Ptr inertial;
@@ -216,16 +219,26 @@ public:
   bool operator!=(const Link& rhs) const;
 
   /**
-   * @brief Clone the link keeping the name.
+   * @brief Clone the link keeping the name and uuid.
    * @return Cloned link
    */
   Link clone() const;
 
-  /** Perform a copy of link, changing its name **/
+  /** Perform a copy of link, changing its name and uuid **/
   Link clone(const std::string& name) const;
+
+protected:
+  /** Constructor with specified name and uuid */
+  Link(std::string name, boost::uuids::uuid uuid);
+
+  /** Clone with specified name and uuid */
+  Link clone(const std::string& name, boost::uuids::uuid uuid) const;
 
 private:
   std::string name_;
+
+  /** @brief The uuid of the link */
+  boost::uuids::uuid uuid_{};
 
   template <class Archive>
   friend void ::tesseract_scene_graph::serialize(Archive& ar, Link& obj);

--- a/tesseract_scene_graph/test/tesseract_scene_graph_link_unit.cpp
+++ b/tesseract_scene_graph/test/tesseract_scene_graph_link_unit.cpp
@@ -1,8 +1,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
-#include <iostream>
-#include <fstream>
 #include <tesseract_geometry/geometries.h>
 #include <tesseract_common/utils.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -136,7 +134,10 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkUnit)  // NOLINT
   l.collision.push_back(c);
 
   Link l_clone = l.clone();
+  // Name should be the same
   EXPECT_EQ(l_clone.getName(), "test_link");
+  // Uuid should be the same
+  EXPECT_EQ(l_clone.getUuid(), l.getUuid());
   EXPECT_TRUE(l_clone.inertial != l.inertial);
   EXPECT_TRUE(l_clone.inertial != nullptr);
   EXPECT_TRUE(l_clone.inertial->origin.isApprox(l.inertial->origin));
@@ -163,8 +164,22 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkUnit)  // NOLINT
   EXPECT_TRUE(l_clone.collision.front()->geometry == l.collision.front()->geometry);
   EXPECT_TRUE(l_clone.collision.front()->name == l.collision.front()->name);
 
+  Link l_renamed_clone = l.clone("test_link");
+  // We used the same name
+  EXPECT_EQ(l_clone.getName(), "test_link");
+  // But the uuid should be different
+  EXPECT_NE(l_renamed_clone.getUuid(), l.getUuid());
+
+  Link l_renamed_clone2 = l.clone("renamed_link");
+  // We changed the name
+  EXPECT_EQ(l_renamed_clone2.getName(), "renamed_link");
+  // And the uuid should be different
+  EXPECT_NE(l_renamed_clone2.getUuid(), l.getUuid());
+
+  auto uuid_before_clear = l.getUuid();
   l.clear();
   EXPECT_EQ(l.getName(), "test_link");
+  EXPECT_EQ(l.getUuid(), uuid_before_clear);
   EXPECT_TRUE(l.visual.empty());
   EXPECT_TRUE(l.collision.empty());
   EXPECT_TRUE(l.inertial == nullptr);


### PR DESCRIPTION
Last Tesseract dev meeting we talked about using uuids to reference links in all of Tesseract, instead of strings. Reason is that links are referenced a lot by name (a string) for collision checking etc. and string operations are quite expensive (consider all the OrderedLinkPair creating and comparing). Replacing this by a uuid (16 bytes, numerical) should give a measurable performance boost.

This PR just adds a uuid to the Link class as a first start.