### PR TITLE
Add hash to link class

### DIFF
--- a/tesseract_scene_graph/include/tesseract_scene_graph/cereal_serialization.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/cereal_serialization.h
@@ -74,6 +74,7 @@ void serialize(Archive& ar, Link& obj)
   ar(cereal::make_nvp("collision", obj.collision));
   ar(cereal::make_nvp("visible", obj.visible));
   ar(cereal::make_nvp("collision_enabled", obj.collision_enabled));
+  ar(cereal::make_nvp("hash", obj.hash_));
   ar(cereal::make_nvp("name", obj.name_));
 }
 

--- a/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -195,7 +195,7 @@ public:
 
   const std::string& getName() const;
 
-  const std::size_t& getHash() const;
+  std::size_t getHash() const;
 
   /// inertial element
   Inertial::Ptr inertial;

--- a/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -183,7 +183,7 @@ public:
   using Ptr = std::shared_ptr<Link>;
   using ConstPtr = std::shared_ptr<const Link>;
 
-  Link(std::string name);
+  Link(const std::string& name);
   Link() = default;
   ~Link() = default;
   // Links are non-copyable as their name must be unique
@@ -194,6 +194,8 @@ public:
   Link& operator=(Link&& other) = default;
 
   const std::string& getName() const;
+
+  const size_t& getHash() const;
 
   /// inertial element
   Inertial::Ptr inertial;
@@ -226,6 +228,9 @@ public:
 
 private:
   std::string name_;
+
+  /** @brief The hash of the link name */
+  size_t hash_{};
 
   template <class Archive>
   friend void ::tesseract_scene_graph::serialize(Archive& ar, Link& obj);

--- a/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -195,7 +195,7 @@ public:
 
   const std::string& getName() const;
 
-  const size_t& getHash() const;
+  const std::size_t& getHash() const;
 
   /// inertial element
   Inertial::Ptr inertial;
@@ -230,7 +230,7 @@ private:
   std::string name_;
 
   /** @brief The hash of the link name */
-  size_t hash_{};
+  std::size_t hash_{};
 
   template <class Archive>
   friend void ::tesseract_scene_graph::serialize(Archive& ar, Link& obj);

--- a/tesseract_scene_graph/src/link.cpp
+++ b/tesseract_scene_graph/src/link.cpp
@@ -140,7 +140,7 @@ Link::Link(const std::string& name) : name_(name), hash_(std::hash<std::string>{
 
 const std::string& Link::getName() const { return name_; }
 
-const std::size_t& Link::getHash() const { return hash_; }
+std::size_t Link::getHash() const { return hash_; }
 
 void Link::clear()
 {

--- a/tesseract_scene_graph/src/link.cpp
+++ b/tesseract_scene_graph/src/link.cpp
@@ -136,9 +136,11 @@ bool Collision::operator!=(const Collision& rhs) const { return !operator==(rhs)
 /*********************************************************/
 /******                     Link                     *****/
 /*********************************************************/
-Link::Link(std::string name) : name_(std::move(name)) { this->clear(); }
+Link::Link(const std::string& name) : name_(name), hash_(std::hash<std::string>{}(name)) { this->clear(); }
 
 const std::string& Link::getName() const { return name_; }
+
+const size_t& Link::getHash() const { return hash_; }
 
 void Link::clear()
 {
@@ -186,6 +188,7 @@ bool Link::operator==(const Link& rhs) const
       tesseract_common::pointersEqual<Collision>,
       [](const Collision::Ptr& v1, const Collision::Ptr& v2) { return v1->name < v2->name; });
   equal &= name_ == rhs.name_;
+  equal &= hash_ == rhs.hash_;
   equal &= visible == rhs.visible;
   equal &= collision_enabled == rhs.collision_enabled;
   return equal;

--- a/tesseract_scene_graph/src/link.cpp
+++ b/tesseract_scene_graph/src/link.cpp
@@ -140,7 +140,7 @@ Link::Link(const std::string& name) : name_(name), hash_(std::hash<std::string>{
 
 const std::string& Link::getName() const { return name_; }
 
-const size_t& Link::getHash() const { return hash_; }
+const std::size_t& Link::getHash() const { return hash_; }
 
 void Link::clear()
 {

--- a/tesseract_scene_graph/test/tesseract_scene_graph_link_unit.cpp
+++ b/tesseract_scene_graph/test/tesseract_scene_graph_link_unit.cpp
@@ -1,8 +1,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
-#include <iostream>
-#include <fstream>
 #include <tesseract_geometry/geometries.h>
 #include <tesseract_common/utils.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -136,7 +134,10 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkUnit)  // NOLINT
   l.collision.push_back(c);
 
   Link l_clone = l.clone();
+  // Names should be the same
   EXPECT_EQ(l_clone.getName(), "test_link");
+  // Hashes should be the same
+  EXPECT_EQ(l_clone.getHash(), l.getHash());
   EXPECT_TRUE(l_clone.inertial != l.inertial);
   EXPECT_TRUE(l_clone.inertial != nullptr);
   EXPECT_TRUE(l_clone.inertial->origin.isApprox(l.inertial->origin));
@@ -163,8 +164,22 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkUnit)  // NOLINT
   EXPECT_TRUE(l_clone.collision.front()->geometry == l.collision.front()->geometry);
   EXPECT_TRUE(l_clone.collision.front()->name == l.collision.front()->name);
 
+  Link l_renamed_clone = l.clone("test_link");
+  // We used the same name
+  EXPECT_EQ(l_clone.getName(), "test_link");
+  // So the hash should be the same
+  EXPECT_EQ(l_renamed_clone.getHash(), l.getHash());
+
+  Link l_renamed_clone2 = l.clone("renamed_link");
+  // We changed the name
+  EXPECT_EQ(l_renamed_clone2.getName(), "renamed_link");
+  // So the hash should be different
+  EXPECT_NE(l_renamed_clone2.getHash(), l.getHash());
+
+  auto hash_before_clear = l.getHash();
   l.clear();
   EXPECT_EQ(l.getName(), "test_link");
+  EXPECT_EQ(l.getHash(), hash_before_clear);
   EXPECT_TRUE(l.visual.empty());
   EXPECT_TRUE(l.collision.empty());
   EXPECT_TRUE(l.inertial == nullptr);


### PR DESCRIPTION
Last Tesseract dev meeting we talked about using hashes to reference links in all of Tesseract, instead of strings. Reason is that links are referenced a lot by name (a string) for collision checking etc. and string operations are quite expensive (consider all the OrderedLinkPair creating and comparing). Replacing this by a hash (size_t) should give a measurable performance boost.

This PR just adds a hash to the Link class as a first start.

(Replaces #1241)