### PR TITLE
Add aarch64 lib to search paths for tcmalloc_minimal library

### DIFF
--- a/tesseract_common/cmake/Findtcmalloc.cmake
+++ b/tesseract_common/cmake/Findtcmalloc.cmake
@@ -15,6 +15,7 @@ find_library(
   PATHS /lib
         /usr/lib
         /usr/lib/x86_64-linux-gnu
+        /usr/lib/aarch64-linux-gnu
         /usr/local/lib
         /opt/local/lib)
 

--- a/tesseract_common/cmake/Findtcmalloc_minimal.cmake
+++ b/tesseract_common/cmake/Findtcmalloc_minimal.cmake
@@ -16,6 +16,7 @@ find_library(
   PATHS /lib
         /usr/lib
         /usr/lib/x86_64-linux-gnu
+        /usr/lib/aarch64-linux-gnu
         /usr/local/lib
         /opt/local/lib)
 


### PR DESCRIPTION
Specific use case: Ubuntu docker container on Mac