### PR TITLE
Fix setCollisionObjectsTransform assuming an ordered map

### DIFF
--- a/collision/bullet/src/bullet_cast_bvh_manager.cpp
+++ b/collision/bullet/src/bullet_cast_bvh_manager.cpp
@@ -355,14 +355,11 @@ void BulletCastBVHManager::setCollisionObjectsTransform(const tesseract::common:
                                                         const tesseract::common::TransformMap& pose2)
 {
   assert(pose1.size() == pose2.size());
-  auto it1 = pose1.begin();
-  auto it2 = pose2.begin();
-  while (it1 != pose1.end())
+  for (const auto& [name, tf1] : pose1)
   {
-    assert(pose1.find(it1->first) != pose2.end());
-    setCollisionObjectsTransform(it1->first, it1->second, it2->second);
-    std::advance(it1, 1);
-    std::advance(it2, 1);
+    auto it2 = pose2.find(name);
+    assert(it2 != pose2.end());
+    setCollisionObjectsTransform(name, tf1, it2->second);
   }
 }
 

--- a/collision/bullet/src/bullet_cast_simple_manager.cpp
+++ b/collision/bullet/src/bullet_cast_simple_manager.cpp
@@ -290,14 +290,11 @@ void BulletCastSimpleManager::setCollisionObjectsTransform(const tesseract::comm
                                                            const tesseract::common::TransformMap& pose2)
 {
   assert(pose1.size() == pose2.size());
-  auto it1 = pose1.begin();
-  auto it2 = pose2.begin();
-  while (it1 != pose1.end())
+  for (const auto& [name, tf1] : pose1)
   {
-    assert(pose1.find(it1->first) != pose2.end());
-    setCollisionObjectsTransform(it1->first, it1->second, it2->second);
-    std::advance(it1, 1);
-    std::advance(it2, 1);
+    auto it2 = pose2.find(name);
+    assert(it2 != pose2.end());
+    setCollisionObjectsTransform(name, tf1, it2->second);
   }
 }
 


### PR DESCRIPTION
The two-pose TransformMap setCollisionObjectsTransform overloads assumed the ordering of both maps to be identical, which is not a given with unordered_map.