### PR TITLE
Fix sign conversion compiler error in common/utils.cpp

### DIFF
--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -76,7 +76,7 @@ std::string fileToString(const std::filesystem::path& filepath)
   std::string contents;
 
   ifs.seekg(0, std::ios::end);
-  contents.reserve(ifs.tellg());
+  contents.reserve(static_cast<std::size_t>(ifs.tellg()));
   ifs.seekg(0, std::ios::beg);
 
   contents.assign(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());


### PR DESCRIPTION
A sign conversion error was causing compiler errors in common/src/util.cpp. This PR adds a static_cast to silence the compiler error. The source value will always be positive.