### PR TITLE
Fix dangling references to yaml-cpp iterator proxy temporaries

### DIFF
--- a/common/src/property_tree.cpp
+++ b/common/src/property_tree.cpp
@@ -1215,7 +1215,7 @@ void validateCustomType(const PropertyTree& node, const std::string& path, std::
     for (auto it = map_node.begin(); it != map_node.end(); ++it)
     {
       auto key = it->first.as<std::string>();
-      const YAML::Node& value_node = it->second;
+      YAML::Node value_node = it->second;
 
       std::string actual_value_type = map_value_type;
       bool has_type_field = false;

--- a/kinematics/test/kinematics_factory_unit.cpp
+++ b/kinematics/test/kinematics_factory_unit.cpp
@@ -95,7 +95,7 @@ void runKinematicsFactoryTest(const std::filesystem::path& config_path)
     auto plugins = group_it->second["plugins"];
     for (auto solver_it = plugins.begin(); solver_it != plugins.end(); ++solver_it)
     {
-      const YAML::Node& plugin = solver_it->second;
+      YAML::Node plugin = solver_it->second;
       auto solver_name = solver_it->first.as<std::string>();
 
       tesseract::common::PluginInfo info;
@@ -121,7 +121,7 @@ void runKinematicsFactoryTest(const std::filesystem::path& config_path)
     auto plugins = group_it->second["plugins"];
     for (auto solver_it = plugins.begin(); solver_it != plugins.end(); ++solver_it)
     {
-      const YAML::Node& plugin = solver_it->second;
+      YAML::Node plugin = solver_it->second;
       auto solver_name = solver_it->first.as<std::string>();
 
       tesseract::common::PluginInfo info;


### PR DESCRIPTION
## Summary
- yaml-cpp's `iterator::operator->()` returns a proxy by value; the proxy holds the `iterator_value` (and its `first`/`second` Nodes) inline. Binding `const YAML::Node&` to `it->second` therefore points into a temporary that is destroyed at the end of the full expression — every later use reads stack memory that has gone out of scope.
- AddressSanitizer (`stack-use-after-scope`) caught this in `validateCustomType` (`common/src/property_tree.cpp:1218`) and the kinematics factory test (`kinematics/test/kinematics_factory_unit.cpp:98, 124`).
- Fix is to copy the Node by value. `YAML::Node` is a reference-counted handle to the underlying graph, so the copy is cheap and yields an independent handle whose memory holder remains valid after the proxy dies.
- Other yaml-cpp patterns in the tree (`node[key]`, `*it`, passing `it->second` directly as a function argument) are safe — only reference-binding to `it->first`/`it->second` is the dangerous case.

## Test plan
- [x] Build with `-fsanitize=address`
- [x] `AutoValidatorVerification.MapOfCustomTypesValidatorAutomaticallyAdded` passes under ASan
- [x] `TesseractKinematicsFactoryUnit.KDL_OPW_UR_ROP_REP_PluginTest` passes under ASan
- [x] Full `tesseract_common_property_tree_unit` and `tesseract_kinematics_factory_unit` test binaries clean under ASan

🤖 Generated with [Claude Code](https://claude.com/claude-code)